### PR TITLE
feat: filter reconciliation to only process OpenClawInstance named 'instance'

### DIFF
--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -64,6 +64,12 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// Only reconcile resources named "instance"
+	if instance.Name != "instance" {
+		logger.Info("Skipping reconciliation for OpenClawInstance with non-matching name", "name", instance.Name)
+		return ctrl.Result{}, nil
+	}
+
 	// Parse the embedded deployment manifest
 	decode := serializer.NewCodecFactory(r.Scheme).UniversalDeserializer().Decode
 	deployment := &appsv1.Deployment{}

--- a/internal/controller/openclawinstance_controller_suite_test.go
+++ b/internal/controller/openclawinstance_controller_suite_test.go
@@ -87,11 +87,11 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("OpenClawInstance Controller", func() {
 	const (
-		resourceName = "test-instance"
-		namespace    = "default"
+		namespace = "default"
 	)
 
-	Context("When reconciling an OpenClawInstance", func() {
+	Context("When reconciling an OpenClawInstance named 'instance'", func() {
+		const resourceName = "instance"
 		ctx := context.Background()
 
 		AfterEach(func() {
@@ -99,10 +99,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{}
 			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
 			_ = k8sClient.Delete(ctx, instance)
+
+			// Cleanup deployment
+			deployment := &appsv1.Deployment{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw", Namespace: namespace}, deployment)
+			_ = k8sClient.Delete(ctx, deployment)
 		})
 
 		It("should successfully create a Deployment when OpenClawInstance is created", func() {
-			By("Creating a new OpenClawInstance")
+			By("Creating a new OpenClawInstance named 'instance'")
 			instance := &openclawv1alpha1.OpenClawInstance{}
 			instance.Name = resourceName
 			instance.Namespace = namespace
@@ -150,7 +155,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 		})
 
 		It("should configure Deployment for garbage collection when OpenClawInstance is deleted", func() {
-			By("Creating a new OpenClawInstance")
+			By("Creating a new OpenClawInstance named 'instance'")
 			instance := &openclawv1alpha1.OpenClawInstance{}
 			instance.Name = resourceName
 			instance.Namespace = namespace
@@ -195,6 +200,127 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			// Note: envtest doesn't run garbage collection controller, so we can't test
 			// actual deletion. The test above verifies the owner reference is properly
 			// configured with Controller=true, which ensures GC will work in real clusters.
+		})
+	})
+
+	Context("When reconciling an OpenClawInstance with different name", func() {
+		const resourceName = "other-instance"
+		ctx := context.Background()
+
+		AfterEach(func() {
+			// Cleanup resources
+			instance := &openclawv1alpha1.OpenClawInstance{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
+			_ = k8sClient.Delete(ctx, instance)
+		})
+
+		It("should skip reconciliation for resource with non-matching name", func() {
+			By("Creating a new OpenClawInstance with name 'other-instance'")
+			instance := &openclawv1alpha1.OpenClawInstance{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawInstanceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Deployment was NOT created")
+			deployment := &appsv1.Deployment{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw",
+					Namespace: namespace,
+				}, deployment)
+				return err != nil
+			}, time.Second*2, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When multiple OpenClawInstance resources exist", func() {
+		ctx := context.Background()
+
+		AfterEach(func() {
+			// Cleanup all test resources
+			instanceNames := []string{"instance", "another-instance"}
+			for _, name := range instanceNames {
+				instance := &openclawv1alpha1.OpenClawInstance{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, instance)
+				_ = k8sClient.Delete(ctx, instance)
+			}
+
+			// Cleanup deployment
+			deployment := &appsv1.Deployment{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw", Namespace: namespace}, deployment)
+			_ = k8sClient.Delete(ctx, deployment)
+		})
+
+		It("should only reconcile the resource named 'instance'", func() {
+			// Setup reconciler
+			reconciler := &OpenClawInstanceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Creating OpenClawInstance named 'another-instance'")
+			otherInstance := &openclawv1alpha1.OpenClawInstance{}
+			otherInstance.Name = "another-instance"
+			otherInstance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, otherInstance)).Should(Succeed())
+
+			By("Reconciling 'another-instance'")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "another-instance",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no Deployment was created")
+			deployment := &appsv1.Deployment{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw",
+					Namespace: namespace,
+				}, deployment)
+				return err != nil
+			}, time.Second*1, interval).Should(BeTrue())
+
+			By("Creating OpenClawInstance named 'instance'")
+			instance := &openclawv1alpha1.OpenClawInstance{}
+			instance.Name = "instance"
+			instance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			By("Reconciling 'instance'")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "instance",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Deployment was created")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw",
+					Namespace: namespace,
+				}, deployment)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/design.md
+++ b/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The OpenClawInstance controller currently reconciles all resources of type OpenClawInstance regardless of their name. The requirement specifies that only resources named "instance" should be managed. This is a simple filtering requirement that needs to be enforced early in the reconciliation loop.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Filter reconciliation to only process OpenClawInstance resources named "instance"
+- Skip processing early to avoid unnecessary work for non-matching resources
+- Maintain existing reconciliation behavior for the resource named "instance"
+
+**Non-Goals:**
+- Making the filter name configurable (hardcoded to "instance")
+- Supporting multiple allowed names or patterns
+- Changing the watch configuration (still watch all resources, filter at reconcile time)
+- Deleting or rejecting non-matching resources
+
+## Decisions
+
+### Decision 1: Filter at reconcile time, not watch time
+
+**Choice:** Add name check in the Reconcile function after fetching the resource, rather than modifying the watch predicates.
+
+**Rationale:**
+- Simpler implementation - single line check
+- Easier to test and understand
+- Watch predicates are more complex and error-prone
+- Minimal performance impact (name check is trivial)
+- Controller still sees all events for monitoring/debugging
+
+**Alternative considered:** Use watch predicates to filter before reconciliation
+- Rejected: More complex, harder to test, less transparent about what's being filtered
+
+### Decision 2: Skip after successful Get, before any processing
+
+**Choice:** Check the name immediately after successfully fetching the OpenClawInstance, before parsing manifests or creating resources.
+
+**Rationale:**
+- Fail fast - avoid unnecessary work
+- Clear placement in code flow
+- Easy to add logging for visibility
+- Resource exists check still happens (useful for debugging)
+
+### Decision 3: Return success (not error) for non-matching names
+
+**Choice:** Return `ctrl.Result{}, nil` (success) when name doesn't match, similar to NotFound handling.
+
+**Rationale:**
+- Not an error condition - expected filtering behavior
+- Prevents reconciliation queue thrashing
+- Consistent with how NotFound is handled
+- Logs at info level for visibility without noise
+
+## Risks / Trade-offs
+
+**[Trade-off]** Resources named differently than "instance" will be ignored even if users expect them to work  
+→ **Accepted:** This is the intended behavior per requirements; can be documented
+
+**[Risk]** If name check is removed/modified accidentally, all resources will be reconciled again  
+→ **Mitigation:** Test coverage verifies filtering behavior; spec documents the requirement
+
+**[Trade-off]** Watch still triggers for all resources (small overhead)  
+→ **Accepted:** Minimal performance impact; filtering at reconcile time is simpler and sufficient

--- a/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/proposal.md
+++ b/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The controller currently reconciles all OpenClawInstance resources regardless of their name. However, the requirement is to only manage instances specifically named "instance", allowing other named resources to exist without triggering reconciliation.
+
+## What Changes
+
+- Controller reconciliation logic will check the resource name before proceeding
+- Resources not named "instance" will be skipped early in the reconcile loop
+- Early return for non-matching resources to avoid unnecessary processing
+
+## Capabilities
+
+### New Capabilities
+
+None - this change modifies existing controller filtering behavior.
+
+### Modified Capabilities
+
+- `openclawinstance-controller`: Controller will add name filtering to only reconcile OpenClawInstance resources named "instance"
+
+## Impact
+
+**Code:**
+- `internal/controller/openclawinstance_controller.go` - Add name check in Reconcile function
+- Controller tests - Update test cases to verify filtering behavior
+
+**Behavior:**
+- Only OpenClawInstance resources named "instance" will be reconciled
+- Other named OpenClawInstance resources will be ignored (no Deployment created)
+- Reduces unnecessary reconciliation overhead for resources outside scope

--- a/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/specs/openclawinstance-controller/spec.md
+++ b/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/specs/openclawinstance-controller/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Controller reconciles all OpenClawInstance resources
+The system SHALL configure the controller to watch all OpenClawInstance resources but only reconcile resources named "instance", skipping all other named resources.
+
+#### Scenario: Resource named 'instance' triggers reconciliation
+- **WHEN** an OpenClawInstance named 'instance' is created
+- **THEN** the controller's Reconcile function SHALL process the resource and create a Deployment
+
+#### Scenario: Resource with different name is skipped
+- **WHEN** an OpenClawInstance with a name other than 'instance' is created
+- **THEN** the controller's Reconcile function SHALL skip processing and return successfully without creating a Deployment
+
+#### Scenario: Multiple resources with different names
+- **WHEN** multiple OpenClawInstance resources exist with different names
+- **THEN** the controller SHALL only reconcile the resource named 'instance' and skip all others
+
+#### Scenario: Skipped resource is logged
+- **WHEN** an OpenClawInstance with a name other than 'instance' is reconciled
+- **THEN** the controller SHALL log that the resource is being skipped due to name mismatch
+
+## ADDED Requirements
+
+### Requirement: Controller filters by resource name
+The system SHALL check the OpenClawInstance resource name early in the reconciliation loop and skip processing if the name is not "instance".
+
+#### Scenario: Name check occurs after fetch
+- **WHEN** the Reconcile function fetches the OpenClawInstance resource
+- **THEN** it SHALL immediately check if the resource name equals "instance" before proceeding with any other logic
+
+#### Scenario: Name filtering returns success
+- **WHEN** a resource name does not match "instance"
+- **THEN** the Reconcile function SHALL return `ctrl.Result{}, nil` (success) without error
+
+#### Scenario: Name filtering does not affect NotFound handling
+- **WHEN** a resource is not found during fetch
+- **THEN** the controller SHALL still handle NotFound errors before checking the name

--- a/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/tasks.md
+++ b/openspec/changes/archive/2026-04-02-filter-reconcile-by-instance-name/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implement Name Filtering Logic
+
+- [x] 1.1 Add name check in Reconcile function after successful Get of OpenClawInstance
+- [x] 1.2 Compare resource name to literal string "instance"
+- [x] 1.3 Return `ctrl.Result{}, nil` if name does not match
+- [x] 1.4 Add info-level log message when skipping due to name mismatch
+
+## 2. Update Tests
+
+- [x] 2.1 Add test case: verify resource named "instance" is reconciled and creates Deployment
+- [x] 2.2 Add test case: verify resource with different name (e.g., "other") is skipped
+- [x] 2.3 Add test case: verify skipped resource does not create Deployment
+- [x] 2.4 Add test case: verify multiple resources, only "instance" is reconciled
+- [x] 2.5 Run `make test` to verify all tests pass

--- a/openspec/specs/openclawinstance-controller/spec.md
+++ b/openspec/specs/openclawinstance-controller/spec.md
@@ -27,15 +27,23 @@ The system SHALL configure the controller to watch for create, update, and delet
 - **THEN** the controller's Reconcile function SHALL be invoked
 
 ### Requirement: Controller reconciles all OpenClawInstance resources
-The system SHALL configure the controller to watch all OpenClawInstance resources in all namespaces, not just a specific named resource.
-
-#### Scenario: Multiple resources trigger reconciliation
-- **WHEN** multiple OpenClawInstance resources exist with different names
-- **THEN** the controller SHALL reconcile each resource independently
+The system SHALL configure the controller to watch all OpenClawInstance resources but only reconcile resources named "instance", skipping all other named resources.
 
 #### Scenario: Resource named 'instance' triggers reconciliation
 - **WHEN** an OpenClawInstance named 'instance' is created
-- **THEN** the controller's Reconcile function SHALL be invoked
+- **THEN** the controller's Reconcile function SHALL process the resource and create a Deployment
+
+#### Scenario: Resource with different name is skipped
+- **WHEN** an OpenClawInstance with a name other than 'instance' is created
+- **THEN** the controller's Reconcile function SHALL skip processing and return successfully without creating a Deployment
+
+#### Scenario: Multiple resources with different names
+- **WHEN** multiple OpenClawInstance resources exist with different names
+- **THEN** the controller SHALL only reconcile the resource named 'instance' and skip all others
+
+#### Scenario: Skipped resource is logged
+- **WHEN** an OpenClawInstance with a name other than 'instance' is reconciled
+- **THEN** the controller SHALL log that the resource is being skipped due to name mismatch
 
 ### Requirement: Reconcile function is a no-op skeleton
 The system SHALL implement the Reconcile function to fetch the OpenClawInstance resource and create a Deployment using the manifest from `internal/manifests/deployment.yaml`.
@@ -118,3 +126,18 @@ The system SHALL configure owner references such that Kubernetes garbage collect
 #### Scenario: Garbage collection deletes Deployment
 - **WHEN** an OpenClawInstance is deleted
 - **THEN** the Kubernetes API server SHALL automatically delete the associated Deployment due to the controller owner reference
+
+### Requirement: Controller filters by resource name
+The system SHALL check the OpenClawInstance resource name early in the reconciliation loop and skip processing if the name is not "instance".
+
+#### Scenario: Name check occurs after fetch
+- **WHEN** the Reconcile function fetches the OpenClawInstance resource
+- **THEN** it SHALL immediately check if the resource name equals "instance" before proceeding with any other logic
+
+#### Scenario: Name filtering returns success
+- **WHEN** a resource name does not match "instance"
+- **THEN** the Reconcile function SHALL return `ctrl.Result{}, nil` (success) without error
+
+#### Scenario: Name filtering does not affect NotFound handling
+- **WHEN** a resource is not found during fetch
+- **THEN** the controller SHALL still handle NotFound errors before checking the name


### PR DESCRIPTION
Add name-based filtering to the OpenClawInstance controller to only
reconcile resources specifically named "instance". Resources with
different names are skipped early in the reconciliation loop.

Changes:
- Add name check after fetching OpenClawInstance resource
- Skip reconciliation with info log for non-matching names
- Return success without error for filtered resources

Test updates:
- Updated existing tests to use resource name "instance"
- Added test case for non-matching name "other-instance"
- Added test case verifying no Deployment created for skipped resources
- Added test case for multiple resources where only "instance" reconciles
- All tests passing (54.5% coverage)

This reduces unnecessary processing overhead and ensures the controller
only manages the single designated OpenClaw instance per namespace.

Co-Authored-By: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
