### PR TITLE
feat: reverse resource creation order to ConfigMap before Deployment

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -1,0 +1,7 @@
+---
+name: commit-message
+description: Create a commit message based on the pending changes
+---
+
+Suggest a title and a description based on the pending changes
+Include the "Assisted-by:" trail with the name of the current model

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(make lint:*)",
       "Bash(make install:*)",
       "Bash(openspec list:*)",
-      "Bash(openspec:*)"
+      "Bash(openspec:*)",
+      "Bash(go build:*)",
+      "Bash(go test:*)"
     ]
   }
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,15 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/internal/assets/manifests.go
+++ b/internal/assets/manifests.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed manifests/deployment.yaml
 var DeploymentManifest []byte
+
+//go:embed manifests/configmap.yaml
+var ConfigMapManifest []byte

--- a/internal/assets/manifests/configmap.yaml
+++ b/internal/assets/manifests/configmap.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  labels:
+    app: openclaw
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "mode": "local",
+        "bind": "lan",
+        "port": 18789,
+        "auth": {
+          "mode": "token"
+        },
+        "controlUi": {
+          "enabled": true,
+          "allowedOrigins": ["https://OPENCLAW_ROUTE_HOST"]
+        },
+        "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12"]
+      },
+      "models": {
+        "providers": {
+          "google": {
+            "baseUrl": "http://openclaw-proxy:8080/gemini/v1beta",
+            "apiKey": "ah-ah-ah-you-didnt-say-the-magic-word",
+            "models": []
+          },
+          "anthropic": {
+            "baseUrl": "http://openclaw-proxy:8080/anthropic",
+            "apiKey": "ah-ah-ah-you-didnt-say-the-magic-word",
+            "models": []
+          },
+          "openai": {
+            "baseUrl": "http://openclaw-proxy:8080/openai",
+            "apiKey": "ah-ah-ah-you-didnt-say-the-magic-word",
+            "models": []
+          },
+          "openrouter": {
+            "baseUrl": "http://openclaw-proxy:8080/openrouter",
+            "apiKey": "ah-ah-ah-you-didnt-say-the-magic-word",
+            "models": []
+          }
+        }
+      },
+      "agents": {
+        "defaults": {
+          "model": { "primary": "google/gemini-3-flash-preview" },
+          "models": {
+            "google/gemini-3.1-pro-preview": { "alias": "Gemini Pro" },
+            "google/gemini-3-flash-preview": { "alias": "Gemini Flash" },
+            "anthropic/claude-sonnet-4-6": { "alias": "Claude Sonnet" },
+            "anthropic/claude-haiku-4-5": { "alias": "Claude Haiku" }
+          },
+          "workspace": "~/.openclaw/workspace"
+        },
+        "list": [
+          {
+            "id": "default",
+            "name": "OpenClaw Assistant",
+            "workspace": "~/.openclaw/workspace"
+          }
+        ]
+      },
+      "cron": { "enabled": false }
+    }
+  AGENTS.md: |
+    # OpenClaw Assistant
+
+    You are a helpful AI assistant running in OpenShift.

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -35,6 +35,10 @@ import (
 	"github.com/codeready-toolchain/openclaw-operator/internal/assets"
 )
 
+const (
+	OpenClawInstance = "OpenClawInstance"
+)
+
 // OpenClawInstanceReconciler reconciles a OpenClawInstance object
 type OpenClawInstanceReconciler struct {
 	client.Client

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -20,13 +20,16 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
 	"github.com/codeready-toolchain/openclaw-operator/internal/assets"
@@ -42,6 +45,7 @@ type OpenClawInstanceReconciler struct {
 // +kubebuilder:rbac:groups=openclaw.sandbox.redhat.com,resources=openclawinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=openclaw.sandbox.redhat.com,resources=openclawinstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -70,8 +74,52 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	// Parse the embedded deployment manifest
+	// Parse manifests
 	decode := serializer.NewCodecFactory(r.Scheme).UniversalDeserializer().Decode
+
+	// Parse the embedded ConfigMap manifest
+	configMap := &corev1.ConfigMap{}
+	_, _, err = decode(assets.ConfigMapManifest, nil, configMap)
+	if err != nil {
+		logger.Error(err, "Failed to decode ConfigMap manifest")
+		return ctrl.Result{}, err
+	}
+
+	// Set the ConfigMap namespace to match the OpenClawInstance namespace
+	configMap.Namespace = instance.Namespace
+
+	// Set the OpenClawInstance as the controller owner reference
+	if err := controllerutil.SetControllerReference(instance, configMap, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference on ConfigMap")
+		return ctrl.Result{}, err
+	}
+
+	// Create the ConfigMap
+	err = r.Create(ctx, configMap)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			logger.Info("ConfigMap already exists, skipping creation")
+		} else {
+			logger.Error(err, "Failed to create ConfigMap")
+			return ctrl.Result{}, err
+		}
+	} else {
+		logger.Info("Successfully created ConfigMap")
+	}
+
+	// Check if the openclaw-config ConfigMap exists before creating Deployment
+	existingConfigMap := &corev1.ConfigMap{}
+	err = r.Get(ctx, client.ObjectKey{Name: "openclaw-config", Namespace: instance.Namespace}, existingConfigMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("ConfigMap 'openclaw-config' not found yet, skipping Deployment creation")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get ConfigMap")
+		return ctrl.Result{}, err
+	}
+
+	// Parse the embedded deployment manifest
 	deployment := &appsv1.Deployment{}
 	_, _, err = decode(assets.DeploymentManifest, nil, deployment)
 	if err != nil {
@@ -105,8 +153,14 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenClawInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Predicate to filter ConfigMap events by name
+	configMapNamePredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == "openclaw-config"
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openclawv1alpha1.OpenClawInstance{}).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(configMapNamePredicate)).
 		Named("openclawinstance").
 		Complete(r)
 }

--- a/internal/controller/openclawinstance_controller_suite_test.go
+++ b/internal/controller/openclawinstance_controller_suite_test.go
@@ -154,7 +154,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 					return false
 				}
 				return len(configMap.OwnerReferences) > 0 &&
-					configMap.OwnerReferences[0].Kind == "OpenClawInstance" &&
+					configMap.OwnerReferences[0].Kind == OpenClawInstance &&
 					configMap.OwnerReferences[0].Name == resourceName
 			}, timeout, interval).Should(BeTrue())
 
@@ -187,7 +187,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 					return false
 				}
 				return len(deployment.OwnerReferences) > 0 &&
-					deployment.OwnerReferences[0].Kind == "OpenClawInstance" &&
+					deployment.OwnerReferences[0].Kind == OpenClawInstance &&
 					deployment.OwnerReferences[0].Name == resourceName
 			}, timeout, interval).Should(BeTrue())
 
@@ -229,7 +229,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 					return false
 				}
 				ownerRef := configMap.OwnerReferences[0]
-				return ownerRef.Kind == "OpenClawInstance" &&
+				return ownerRef.Kind == OpenClawInstance &&
 					ownerRef.Name == resourceName &&
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true
@@ -258,7 +258,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 					return false
 				}
 				ownerRef := deployment.OwnerReferences[0]
-				return ownerRef.Kind == "OpenClawInstance" &&
+				return ownerRef.Kind == OpenClawInstance &&
 					ownerRef.Name == resourceName &&
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true

--- a/internal/controller/openclawinstance_controller_suite_test.go
+++ b/internal/controller/openclawinstance_controller_suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -100,13 +101,18 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
 			_ = k8sClient.Delete(ctx, instance)
 
+			// Cleanup configmap
+			configMap := &corev1.ConfigMap{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw-config", Namespace: namespace}, configMap)
+			_ = k8sClient.Delete(ctx, configMap)
+
 			// Cleanup deployment
 			deployment := &appsv1.Deployment{}
 			_ = k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw", Namespace: namespace}, deployment)
 			_ = k8sClient.Delete(ctx, deployment)
 		})
 
-		It("should successfully create a Deployment when OpenClawInstance is created", func() {
+		It("should successfully create ConfigMap first, then Deployment when OpenClawInstance is created", func() {
 			By("Creating a new OpenClawInstance named 'instance'")
 			instance := &openclawv1alpha1.OpenClawInstance{}
 			instance.Name = resourceName
@@ -119,8 +125,41 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				Scheme: scheme.Scheme,
 			}
 
-			By("Reconciling the created resource")
+			By("Reconciling the created resource - should create ConfigMap")
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if ConfigMap was created in the same namespace as the OpenClawInstance")
+			configMap := &corev1.ConfigMap{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				return err == nil && configMap.Namespace == namespace
+			}, timeout, interval).Should(BeTrue())
+
+			By("Checking ConfigMap has correct owner reference")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				if err != nil {
+					return false
+				}
+				return len(configMap.OwnerReferences) > 0 &&
+					configMap.OwnerReferences[0].Kind == "OpenClawInstance" &&
+					configMap.OwnerReferences[0].Name == resourceName
+			}, timeout, interval).Should(BeTrue())
+
+			By("Reconciling again - should create Deployment")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      resourceName,
 					Namespace: namespace,
@@ -154,7 +193,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 
 		})
 
-		It("should configure Deployment for garbage collection when OpenClawInstance is deleted", func() {
+		It("should configure ConfigMap and Deployment for garbage collection when OpenClawInstance is deleted", func() {
 			By("Creating a new OpenClawInstance named 'instance'")
 			instance := &openclawv1alpha1.OpenClawInstance{}
 			instance.Name = resourceName
@@ -167,7 +206,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				Scheme: scheme.Scheme,
 			}
 
-			By("Reconciling the created resource")
+			By("Reconciling to create ConfigMap")
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      resourceName,
@@ -176,7 +215,36 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying Deployment has blockOwnerDeletion set to true")
+			By("Verifying ConfigMap has owner reference configured for garbage collection")
+			configMap := &corev1.ConfigMap{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				if err != nil {
+					return false
+				}
+				if len(configMap.OwnerReferences) == 0 {
+					return false
+				}
+				ownerRef := configMap.OwnerReferences[0]
+				return ownerRef.Kind == "OpenClawInstance" &&
+					ownerRef.Name == resourceName &&
+					ownerRef.Controller != nil &&
+					*ownerRef.Controller == true
+			}, timeout, interval).Should(BeTrue())
+
+			By("Reconciling again to create Deployment")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Deployment has owner reference configured for garbage collection")
 			deployment := &appsv1.Deployment{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{
@@ -186,7 +254,6 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				if err != nil {
 					return false
 				}
-				// Verify owner reference is configured for garbage collection
 				if len(deployment.OwnerReferences) == 0 {
 					return false
 				}
@@ -236,6 +303,16 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			By("Verifying ConfigMap was NOT created")
+			configMap := &corev1.ConfigMap{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				return err != nil
+			}, time.Second*2, interval).Should(BeTrue())
+
 			By("Verifying Deployment was NOT created")
 			deployment := &appsv1.Deployment{}
 			Consistently(func() bool {
@@ -259,6 +336,11 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				_ = k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, instance)
 				_ = k8sClient.Delete(ctx, instance)
 			}
+
+			// Cleanup configmap
+			configMap := &corev1.ConfigMap{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw-config", Namespace: namespace}, configMap)
+			_ = k8sClient.Delete(ctx, configMap)
 
 			// Cleanup deployment
 			deployment := &appsv1.Deployment{}
@@ -288,6 +370,16 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			By("Verifying no ConfigMap was created")
+			configMap := &corev1.ConfigMap{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				return err != nil
+			}, time.Second*1, interval).Should(BeTrue())
+
 			By("Verifying no Deployment was created")
 			deployment := &appsv1.Deployment{}
 			Consistently(func() bool {
@@ -304,7 +396,25 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			instance.Namespace = namespace
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
-			By("Reconciling 'instance'")
+			By("Reconciling 'instance' - should create ConfigMap")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "instance",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying ConfigMap was created")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "openclaw-config",
+					Namespace: namespace,
+				}, configMap)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Reconciling 'instance' again - should create Deployment")
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      "instance",

--- a/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/design.md
+++ b/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/design.md
@@ -1,0 +1,66 @@
+## Context
+
+Currently, the OpenClawInstance controller creates resources in this order:
+1. Deployment (from `internal/manifests/deployment.yaml`)
+2. ConfigMap (from `internal/manifests/configmap.yaml`) - only after Deployment exists
+
+This means the Deployment may start before its configuration is available. We need to reverse this order to ensure configuration exists before the application starts.
+
+The controller already:
+- Filters reconciliation to only process OpenClawInstance resources named "instance"
+- Embeds both manifest files at compile time
+- Uses owner references for garbage collection
+- Watches Deployments with name-based predicate filtering
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create ConfigMap immediately when reconciling an OpenClawInstance named 'instance'
+- Only create Deployment after confirming ConfigMap 'openclaw-config' exists
+- Maintain existing owner reference and garbage collection behavior
+- Preserve existing watches and filtering logic
+
+**Non-Goals:**
+- Changing which resources are created (still just ConfigMap and Deployment)
+- Modifying manifest contents
+- Changing name-based filtering for OpenClawInstance or Deployment resources
+- Adding new resource types
+
+## Decisions
+
+### Decision 1: Reverse creation order in single Reconcile function
+
+**Choice:** Modify the existing Reconcile function to:
+1. Check if ConfigMap exists; if not, create it and return
+2. On next reconcile (triggered by ConfigMap creation), check if Deployment exists; if not, create it
+
+**Rationale:** Maintains the existing two-step reconciliation pattern but reverses the order. Controller watches already trigger reconciliation when owned resources are created.
+
+**Alternative considered:** Create both in order within a single reconcile pass.
+- **Rejected because:** Less robust - if ConfigMap creation succeeds but Deployment creation fails, we'd need complex retry logic. The current watch-driven pattern is simpler.
+
+### Decision 2: Add ConfigMap watch
+
+**Choice:** Add a watch on ConfigMap resources (similar to the existing Deployment watch) filtered by name 'openclaw-config'.
+
+**Rationale:** Ensures reconciliation is triggered when the ConfigMap is created, allowing the controller to proceed to Deployment creation.
+
+**Alternative considered:** Requeue with a delay instead of watching.
+- **Rejected because:** Watch-based reconciliation is more responsive and aligned with the existing Deployment watch pattern.
+
+### Decision 3: Keep existing owner references
+
+**Choice:** Both ConfigMap and Deployment continue to have OpenClawInstance as their controller owner.
+
+**Rationale:** No change needed - garbage collection should work the same way regardless of creation order.
+
+## Risks / Trade-offs
+
+**Risk:** Deployment watch triggers reconciliation before ConfigMap exists
+→ **Mitigation:** The Deployment watch only triggers for Deployments named 'openclaw', and we only create the Deployment after ConfigMap exists, so this race is impossible.
+
+**Risk:** Test suite needs significant updates
+→ **Mitigation:** Existing tests verify creation order explicitly. Update them to expect ConfigMap first, then Deployment.
+
+**Trade-off:** Reconciliation now requires at least two passes to fully create all resources
+→ **Accepted:** This is the existing pattern; we're just reversing the order. Performance impact is negligible.

--- a/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/proposal.md
+++ b/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The current reconciliation creates the Deployment before the ConfigMap, which means the Deployment may start without configuration. By creating the ConfigMap first, we ensure configuration is available before the application starts.
+
+## What Changes
+
+- Reverse the order of resource creation: ConfigMap first, then Deployment
+- Controller creates ConfigMap from `internal/manifests/configmap.yaml` immediately when reconciling an OpenClawInstance named 'instance'
+- Controller only creates Deployment after detecting ConfigMap 'openclaw-config' exists
+- Deployment watch triggers reconciliation to create Deployment once ConfigMap is ready
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `openclawinstance-controller`: Change reconciliation order to create ConfigMap before Deployment, with Deployment creation conditional on ConfigMap existence
+
+## Impact
+
+- Reconciliation logic in `internal/controller/openclawinstance_controller.go`
+- Test suite in `internal/controller/openclawinstance_controller_suite_test.go` needs updates for new creation order
+- Existing behavior changes: ConfigMap created first instead of last

--- a/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/specs/openclawinstance-controller/spec.md
+++ b/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/specs/openclawinstance-controller/spec.md
@@ -1,30 +1,4 @@
-## ADDED Requirements
-
-### Requirement: OpenClawInstance controller exists
-The system SHALL provide a controller that reconciles OpenClawInstance custom resources.
-
-#### Scenario: Controller is registered with manager
-- **WHEN** the operator starts
-- **THEN** the OpenClawInstance controller SHALL be registered with the controller-runtime manager
-
-#### Scenario: Controller implements Reconciler interface
-- **WHEN** examining the controller code
-- **THEN** it SHALL implement the `Reconcile(context.Context, ctrl.Request) (ctrl.Result, error)` method
-
-### Requirement: Controller watches OpenClawInstance resources
-The system SHALL configure the controller to watch for create, update, and delete events on OpenClawInstance resources.
-
-#### Scenario: Controller triggers on create
-- **WHEN** an OpenClawInstance resource is created
-- **THEN** the controller's Reconcile function SHALL be invoked
-
-#### Scenario: Controller triggers on update
-- **WHEN** an OpenClawInstance resource is updated
-- **THEN** the controller's Reconcile function SHALL be invoked
-
-#### Scenario: Controller triggers on delete
-- **WHEN** an OpenClawInstance resource is deleted
-- **THEN** the controller's Reconcile function SHALL be invoked
+## MODIFIED Requirements
 
 ### Requirement: Controller reconciles all OpenClawInstance resources
 The system SHALL configure the controller to watch all OpenClawInstance resources but only reconcile resources named "instance", skipping all other named resources.
@@ -84,80 +58,6 @@ The system SHALL implement the Reconcile function to fetch the OpenClawInstance 
 - **WHEN** creating the Deployment
 - **THEN** the controller SHALL set the OpenClawInstance as the controller owner reference on the Deployment
 
-### Requirement: Controller has RBAC permissions
-The system SHALL generate RBAC markers and permissions for the controller to watch and reconcile OpenClawInstance resources.
-
-#### Scenario: Controller can list OpenClawInstance resources
-- **WHEN** the controller starts
-- **THEN** it SHALL have permissions to list OpenClawInstance resources
-
-#### Scenario: Controller can watch OpenClawInstance resources
-- **WHEN** the controller is running
-- **THEN** it SHALL have permissions to watch OpenClawInstance resources
-
-#### Scenario: Controller can update OpenClawInstance status
-- **WHEN** the controller needs to update status (in future implementations)
-- **THEN** it SHALL have permissions to update the status subresource
-
-### Requirement: Controller embeds deployment manifest
-The system SHALL embed the deployment manifest file `internal/manifests/deployment.yaml` into the controller binary at compile time using Go's embed directive.
-
-#### Scenario: Manifest is accessible at runtime
-- **WHEN** the controller starts
-- **THEN** the embedded manifest content SHALL be available without filesystem access
-
-#### Scenario: Manifest is parsed into Deployment object
-- **WHEN** the controller needs to create a Deployment
-- **THEN** it SHALL parse the embedded YAML manifest into an `appsv1.Deployment` struct using the controller-runtime serializer
-
-### Requirement: Controller has RBAC for Deployments
-The system SHALL define RBAC permissions for the controller to create, get, list, and watch Deployment resources.
-
-#### Scenario: Controller can create Deployments
-- **WHEN** the controller attempts to create a Deployment
-- **THEN** it SHALL have permissions to create Deployment resources in any namespace
-
-#### Scenario: Controller can get Deployments
-- **WHEN** the controller checks if a Deployment exists
-- **THEN** it SHALL have permissions to get Deployment resources
-
-#### Scenario: Controller can list Deployments
-- **WHEN** the controller needs to query existing Deployments
-- **THEN** it SHALL have permissions to list Deployment resources
-
-#### Scenario: Controller can watch Deployments
-- **WHEN** the controller sets up watches for owned resources
-- **THEN** it SHALL have permissions to watch Deployment resources
-
-### Requirement: Deployment is created in same namespace as OpenClawInstance
-The system SHALL create the Deployment resource in the same namespace as the owning OpenClawInstance resource.
-
-#### Scenario: Namespace matches owner
-- **WHEN** an OpenClawInstance is created in namespace "test-ns"
-- **THEN** the created Deployment SHALL also be in namespace "test-ns"
-
-### Requirement: Deployment is deleted when OpenClawInstance is deleted
-The system SHALL configure owner references such that Kubernetes garbage collection automatically deletes the Deployment when the owning OpenClawInstance is deleted.
-
-#### Scenario: Garbage collection deletes Deployment
-- **WHEN** an OpenClawInstance is deleted
-- **THEN** the Kubernetes API server SHALL automatically delete the associated Deployment due to the controller owner reference
-
-### Requirement: Controller filters by resource name
-The system SHALL check the OpenClawInstance resource name early in the reconciliation loop and skip processing if the name is not "instance".
-
-#### Scenario: Name check occurs after fetch
-- **WHEN** the Reconcile function fetches the OpenClawInstance resource
-- **THEN** it SHALL immediately check if the resource name equals "instance" before proceeding with any other logic
-
-#### Scenario: Name filtering returns success
-- **WHEN** a resource name does not match "instance"
-- **THEN** the Reconcile function SHALL return `ctrl.Result{}, nil` (success) without error
-
-#### Scenario: Name filtering does not affect NotFound handling
-- **WHEN** a resource is not found during fetch
-- **THEN** the controller SHALL still handle NotFound errors before checking the name
-
 ### Requirement: Controller creates Deployment after ConfigMap exists
 The system SHALL create a Deployment using the embedded manifest after detecting that the 'openclaw-config' ConfigMap exists.
 
@@ -172,6 +72,8 @@ The system SHALL create a Deployment using the embedded manifest after detecting
 #### Scenario: Deployment creation is idempotent
 - **WHEN** the Deployment already exists
 - **THEN** the controller SHALL skip creation and return successfully without error
+
+## ADDED Requirements
 
 ### Requirement: Controller watches ConfigMap resources
 The system SHALL configure the controller to watch ConfigMap resources that are owned by OpenClawInstance resources.

--- a/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/tasks.md
+++ b/openspec/changes/archive/2026-04-02-create-configmap-before-deployment/tasks.md
@@ -1,0 +1,28 @@
+## 1. Modify Reconcile Function
+
+- [x] 1.1 Move ConfigMap creation logic to execute first (before Deployment check)
+- [x] 1.2 Add check for ConfigMap 'openclaw-config' existence before creating Deployment
+- [x] 1.3 Skip Deployment creation if ConfigMap does not exist and return successfully
+- [x] 1.4 Ensure ConfigMap has OpenClawInstance owner reference set before creation
+- [x] 1.5 Ensure Deployment has OpenClawInstance owner reference set before creation
+
+## 2. Add ConfigMap Watch
+
+- [x] 2.1 Create predicate function to filter ConfigMap events by name 'openclaw-config'
+- [x] 2.2 Update SetupWithManager to include ConfigMap watch with Owns() and predicate filter
+- [x] 2.3 Verify ConfigMap watch triggers reconciliation when ConfigMap is created
+
+## 3. Update Test Suite
+
+- [x] 3.1 Update test "should successfully create a Deployment" to verify ConfigMap is created first
+- [x] 3.2 Update test to verify Deployment is only created after ConfigMap exists
+- [x] 3.3 Update test "should skip reconciliation for resource with non-matching name" to verify no ConfigMap or Deployment created
+- [x] 3.4 Update test for multiple OpenClawInstance resources to verify ConfigMap created for 'instance' only
+- [x] 3.5 Update or add test to verify ConfigMap watch triggers reconciliation
+- [x] 3.6 Update test names and assertions to reflect ConfigMap-first creation order
+
+## 4. Verify and Validate
+
+- [x] 4.1 Run test suite to verify all tests pass with new creation order
+- [x] 4.2 Verify RBAC markers generate correct permissions for ConfigMap resources
+- [x] 4.3 Verify garbage collection works correctly (both resources deleted when OpenClawInstance deleted)


### PR DESCRIPTION
Change the reconciliation logic to create ConfigMap first, then Deployment
only after the ConfigMap exists. This ensures configuration is available
before the application starts.

Changes:
- Reverse creation order: ConfigMap first, Deployment second
- Add ConfigMap watch with name-based predicate filtering ('openclaw-config')
- Check for ConfigMap existence before creating Deployment
- Update comprehensive test suite for new creation order
- Add RBAC permissions for ConfigMap resources
- Embed ConfigMap manifest using go:embed directive
- Update main spec to document reversed creation flow

The controller now:
1. Creates ConfigMap from internal/manifests/configmap.yaml
2. Waits for ConfigMap 'openclaw-config' to exist
3. Creates Deployment from internal/manifests/deployment.yaml

Both resources maintain OpenClawInstance owner references for proper
garbage collection.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
