### PR TITLE
build: update image name and target linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openclaw.devsandbox.openshift.com/openclaw-operator-bundle:$VERSION and openclaw.devsandbox.openshift.com/openclaw-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openclaw.devsandbox.openshift.com/openclaw-operator
+# openclaw-operator-bundle:$VERSION and openclaw-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= openclaw-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -50,7 +50,7 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.42.0
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= openclaw-operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -62,13 +62,15 @@ endif
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
+# tools. (i.e. docker)
 CONTAINER_TOOL ?= docker
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+PLATFORM ?= linux/amd64
 
 .PHONY: all
 all: build
@@ -168,7 +170,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build -t ${IMG} --platform $(PLATFORM) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -180,16 +182,16 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-.PHONY: docker-buildx
-docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name openclaw-operator-builder
-	$(CONTAINER_TOOL) buildx use openclaw-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm openclaw-operator-builder
-	rm Dockerfile.cross
+# PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+# .PHONY: docker-buildx
+# docker-buildx: ## Build and push docker image for the manager for cross-platform support
+# 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+# 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+# 	- $(CONTAINER_TOOL) buildx create --name openclaw-operator-builder
+# 	$(CONTAINER_TOOL) buildx use openclaw-operator-builder
+# 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+# 	- $(CONTAINER_TOOL) buildx rm openclaw-operator-builder
+# 	rm Dockerfile.cross
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# openclaw-operator
+# OpenClaw Operator
 
-An operator for managing OpenClaw instances in Red Hat's OpenShift.
+An operator for managing OpenClaw instances in Red Hat OpenShift.
 
 ## Description
 
@@ -33,7 +33,7 @@ The CRD is currently in its initial development phase with spec and status field
 
 ### Prerequisites
 - go version v1.24.0+
-- docker version 17.03+.
+- Pomand version 5.7.0+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: openclaw-operator-system
+namespace: openclaw-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/codeready-toolchain/openclaw-operator
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         ports: []
         securityContext:
@@ -95,4 +96,6 @@ spec:
         volumeMounts: []
       volumes: []
       serviceAccountName: controller-manager
+      # imagePullSecrets:
+      #   - name: openclaw-operator-quay-pull-secret
       terminationGracePeriodSeconds: 10

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "openclaw-operator-system"
+const namespace = "openclaw-operator"
 
 // serviceAccountName created for the project
 const serviceAccountName = "openclaw-operator-controller-manager"


### PR DESCRIPTION
even when the user builds controller image from a macOS machine

the image is now named `quay.io/codeready-toolchain/openclaw-operator:latest`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
