### PR TITLE
feat: add PersistentVolumeClaim controller for persistent storage

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "Bash(openspec:*)",
       "Bash(go build:*)",
       "Bash(go test:*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test -v ./internal/controller/... -ginkgo.focus=\"OpenClawPersistentVolumeClaim\")",
+      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test -v ./internal/controller/...)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,25 +36,26 @@ make docker-build IMG=<registry>/openclaw-operator:tag
 
 ## Architecture
 
-### Two-controller design
+### Split reconcilers design
 
 The operator uses **split reconcilers** (not one monolithic controller):
 
 - **OpenClawConfigMapReconciler** (`internal/controller/openclaw_configmap_controller.go`) — creates a ConfigMap (`openclaw-config`) from an embedded manifest
+- **OpenClawPersistentVolumeClaimReconciler** (`internal/controller/openclaw_pvc_controller.go`) — creates a PersistentVolumeClaim (`openclaw-home-pvc`) from an embedded manifest for persistent storage
 - **OpenClawDeploymentReconciler** (`internal/controller/openclaw_deployment_controller.go`) — creates a Deployment (`openclaw`), but only after the ConfigMap exists (explicit dependency check)
 
-Both controllers only reconcile `OpenClaw` resources named exactly `"instance"` — all other names are skipped.
+All three controllers only reconcile `OpenClaw` resources named exactly `"instance"` — all other names are skipped.
 
 ### Embedded manifests
 
-Kubernetes manifests are embedded via `//go:embed` in `internal/assets/manifests.go`. The actual YAML files live in `internal/assets/manifests/`. At runtime, manifests are decoded with the universal deserializer, then the namespace and owner reference are set dynamically.
+Kubernetes manifests are embedded via `//go:embed` in `internal/assets/manifests.go`. The actual YAML files live in `internal/assets/manifests/` (ConfigMap, PVC, Deployment). At runtime, manifests are decoded with the universal deserializer, then the namespace and owner reference are set dynamically.
 
 ### Key directories
 
 - `api/v1alpha1/` — CRD type definitions (OpenClawSpec, OpenClawStatus)
 - `internal/controller/` — Reconciler implementations and tests
-- `internal/assets/manifests/` — Embedded ConfigMap and Deployment YAML
-- `cmd/main.go` — Manager entrypoint, wires up both controllers
+- `internal/assets/manifests/` — Embedded ConfigMap, PVC, and Deployment YAML
+- `cmd/main.go` — Manager entrypoint, wires up all three controllers
 - `config/` — Kustomize overlays for CRDs, RBAC, manager deployment
 
 ### Code generation

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -217,6 +217,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenClawDeployment")
 		os.Exit(1)
 	}
+
+	if err = (&controller.OpenClawPersistentVolumeClaimReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "OpenClawPersistentVolumeClaim")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if metricsCertWatcher != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumeclaims
   verbs:
   - create
   - get

--- a/internal/assets/manifests.go
+++ b/internal/assets/manifests.go
@@ -7,3 +7,6 @@ var DeploymentManifest []byte
 
 //go:embed manifests/configmap.yaml
 var ConfigMapManifest []byte
+
+//go:embed manifests/pvc.yaml
+var PVCManifest []byte

--- a/internal/assets/manifests/pvc.yaml
+++ b/internal/assets/manifests/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-home-pvc
+  labels:
+    app: openclaw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/internal/controller/openclaw.go
+++ b/internal/controller/openclaw.go
@@ -1,0 +1,6 @@
+package controller
+
+const (
+	OpenClawResourceKind = "OpenClaw"
+	OpenClawInstanceName = "instance"
+)

--- a/internal/controller/openclaw_configmap_controller.go
+++ b/internal/controller/openclaw_configmap_controller.go
@@ -65,7 +65,7 @@ func (r *OpenClawConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Only reconcile resources named "instance"
-	if instance.Name != "instance" {
+	if instance.Name != OpenClawInstanceName {
 		logger.Info("Skipping reconciliation for OpenClaw with non-matching name", "name", instance.Name)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/openclaw_configmap_controller_test.go
+++ b/internal/controller/openclaw_configmap_controller_test.go
@@ -36,7 +36,7 @@ var _ = Describe("OpenClawConfigMap Controller", func() {
 	)
 
 	Context("When reconciling an OpenClaw named 'instance'", func() {
-		const resourceName = "instance"
+		const resourceName = OpenClawInstanceName
 		ctx := context.Background()
 
 		AfterEach(func() {
@@ -120,7 +120,7 @@ var _ = Describe("OpenClawConfigMap Controller", func() {
 					return false
 				}
 				ownerRef := configMap.OwnerReferences[0]
-				return ownerRef.Kind == "OpenClaw" &&
+				return ownerRef.Kind == OpenClawResourceKind &&
 					ownerRef.Name == resourceName &&
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true

--- a/internal/controller/openclaw_deployment_controller.go
+++ b/internal/controller/openclaw_deployment_controller.go
@@ -63,7 +63,7 @@ func (r *OpenClawDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Only reconcile resources named "instance"
-	if instance.Name != "instance" {
+	if instance.Name != OpenClawInstanceName {
 		logger.Info("Skipping reconciliation for OpenClaw with non-matching name", "name", instance.Name)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/openclaw_deployment_controller_test.go
+++ b/internal/controller/openclaw_deployment_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 	)
 
 	Context("When reconciling without ConfigMap", func() {
-		const resourceName = "instance"
+		const resourceName = OpenClawInstanceName
 		ctx := context.Background()
 
 		AfterEach(func() {
@@ -82,7 +82,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 	})
 
 	Context("When reconciling with ConfigMap", func() {
-		const resourceName = "instance"
+		const resourceName = OpenClawInstanceName
 		ctx := context.Background()
 
 		AfterEach(func() {
@@ -185,7 +185,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 					return false
 				}
 				ownerRef := deployment.OwnerReferences[0]
-				return ownerRef.Kind == "OpenClaw" &&
+				return ownerRef.Kind == OpenClawResourceKind &&
 					ownerRef.Name == resourceName &&
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true

--- a/internal/controller/openclaw_pvc_controller.go
+++ b/internal/controller/openclaw_pvc_controller.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
+	"github.com/codeready-toolchain/openclaw-operator/internal/assets"
+)
+
+const (
+	OpenClawPVCName = "openclaw-home-pvc"
+)
+
+// OpenClawPersistentVolumeClaimReconciler reconciles PersistentVolumeClaim resources for OpenClaw
+type OpenClawPersistentVolumeClaimReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=openclaw.sandbox.redhat.com,resources=openclaws,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create
+
+// Reconcile manages PersistentVolumeClaim lifecycle for OpenClaw resources
+func (r *OpenClawPersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling OpenClaw for PersistentVolumeClaim", "name", req.Name, "namespace", req.Namespace)
+
+	// Fetch the OpenClaw resource
+	instance := &openclawv1alpha1.OpenClaw{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("OpenClaw resource not found, ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get OpenClaw")
+		return ctrl.Result{}, err
+	}
+
+	// Only reconcile resources named "instance"
+	if instance.Name != "instance" {
+		logger.Info("Skipping reconciliation for OpenClaw with non-matching name", "name", instance.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Parse the embedded PVC manifest
+	decode := serializer.NewCodecFactory(r.Scheme).UniversalDeserializer().Decode
+	pvc := &corev1.PersistentVolumeClaim{}
+	_, _, err = decode(assets.PVCManifest, nil, pvc)
+	if err != nil {
+		logger.Error(err, "Failed to decode PVC manifest")
+		return ctrl.Result{}, err
+	}
+
+	// Set the PVC namespace to match the OpenClaw namespace
+	pvc.Namespace = instance.Namespace
+
+	// Set the OpenClaw as the controller owner reference
+	if err := controllerutil.SetControllerReference(instance, pvc, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference on PVC")
+		return ctrl.Result{}, err
+	}
+
+	// Create the PVC
+	err = r.Create(ctx, pvc)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			logger.Info("PVC already exists, skipping creation")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to create PVC")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Successfully created PVC")
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *OpenClawPersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Predicate to filter PVC events by name
+	pvcNamePredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == OpenClawPVCName
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&openclawv1alpha1.OpenClaw{}).
+		Owns(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(pvcNamePredicate)).
+		Named("openclawpersistentvolumeclaim").
+		Complete(r)
+}

--- a/internal/controller/openclaw_pvc_controller.go
+++ b/internal/controller/openclaw_pvc_controller.go
@@ -65,7 +65,7 @@ func (r *OpenClawPersistentVolumeClaimReconciler) Reconcile(ctx context.Context,
 	}
 
 	// Only reconcile resources named "instance"
-	if instance.Name != "instance" {
+	if instance.Name != OpenClawInstanceName {
 		logger.Info("Skipping reconciliation for OpenClaw with non-matching name", "name", instance.Name)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/openclaw_pvc_controller_test.go
+++ b/internal/controller/openclaw_pvc_controller_test.go
@@ -36,7 +36,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 	)
 
 	Context("When reconciling an OpenClaw named 'instance'", func() {
-		const resourceName = "instance"
+		const resourceName = OpenClawInstanceName
 		ctx := context.Background()
 
 		AfterEach(func() {
@@ -120,7 +120,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 					return false
 				}
 				ownerRef := pvc.OwnerReferences[0]
-				return ownerRef.Kind == "OpenClaw" &&
+				return ownerRef.Kind == OpenClawResourceKind &&
 					ownerRef.Name == resourceName &&
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true
@@ -135,7 +135,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 		BeforeEach(func() {
 			// Cleanup any instance named "instance" from previous tests
 			instance := &openclawv1alpha1.OpenClaw{}
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: "instance", Namespace: namespace}, instance)
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: OpenClawInstanceName, Namespace: namespace}, instance)
 			if err == nil {
 				_ = k8sClient.Delete(ctx, instance)
 			}

--- a/internal/controller/openclaw_pvc_controller_test.go
+++ b/internal/controller/openclaw_pvc_controller_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
+)
+
+var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
+	const (
+		namespace = "default"
+	)
+
+	Context("When reconciling an OpenClaw named 'instance'", func() {
+		const resourceName = "instance"
+		ctx := context.Background()
+
+		AfterEach(func() {
+			// Cleanup resources
+			instance := &openclawv1alpha1.OpenClaw{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
+			_ = k8sClient.Delete(ctx, instance)
+
+			// Cleanup PVC
+			pvc := &corev1.PersistentVolumeClaim{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: OpenClawPVCName, Namespace: namespace}, pvc)
+			_ = k8sClient.Delete(ctx, pvc)
+		})
+
+		It("should create PVC for OpenClaw named 'instance'", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawPersistentVolumeClaimReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if PVC was created")
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawPVCName,
+					Namespace: namespace,
+				}, pvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should set correct owner reference on PVC", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawPersistentVolumeClaimReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking PVC has correct owner reference")
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawPVCName,
+					Namespace: namespace,
+				}, pvc)
+				if err != nil {
+					return false
+				}
+				if len(pvc.OwnerReferences) == 0 {
+					return false
+				}
+				ownerRef := pvc.OwnerReferences[0]
+				return ownerRef.Kind == "OpenClaw" &&
+					ownerRef.Name == resourceName &&
+					ownerRef.Controller != nil &&
+					*ownerRef.Controller == true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When reconciling an OpenClaw with different name", func() {
+		const resourceName = "other-instance"
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			// Cleanup any instance named "instance" from previous tests
+			instance := &openclawv1alpha1.OpenClaw{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "instance", Namespace: namespace}, instance)
+			if err == nil {
+				_ = k8sClient.Delete(ctx, instance)
+			}
+
+			// Force delete PVC by removing finalizers
+			pvc := &corev1.PersistentVolumeClaim{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: OpenClawPVCName, Namespace: namespace}, pvc)
+			if err == nil {
+				pvc.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, pvc)
+				_ = k8sClient.Delete(ctx, pvc)
+
+				// Wait for PVC to be fully deleted
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: OpenClawPVCName, Namespace: namespace}, pvc)
+					return err != nil
+				}, timeout, interval).Should(BeTrue())
+			}
+		})
+
+		AfterEach(func() {
+			// Cleanup resources
+			instance := &openclawv1alpha1.OpenClaw{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
+			_ = k8sClient.Delete(ctx, instance)
+		})
+
+		It("should skip PVC creation for non-matching names", func() {
+			By("Creating a new OpenClaw with name 'other-instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawPersistentVolumeClaimReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying PVC was NOT created")
+			pvc := &corev1.PersistentVolumeClaim{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawPVCName,
+					Namespace: namespace,
+				}, pvc)
+				return err != nil
+			}, time.Second*2, interval).Should(BeTrue())
+		})
+	})
+})

--- a/openspec/changes/archive/2026-04-03-add-pvc-controller/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-03-add-pvc-controller/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-03

--- a/openspec/changes/archive/2026-04-03-add-pvc-controller/design.md
+++ b/openspec/changes/archive/2026-04-03-add-pvc-controller/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The openclaw-operator currently has dedicated controllers for ConfigMap and Deployment resources, each watching OpenClaw custom resources and creating their respective Kubernetes resources. The PVC manifest (`internal/manifests/pvc.yaml`) already exists but there is no controller to manage its lifecycle. This design follows the established pattern used by `OpenClawConfigMapReconciler` and `OpenClawDeploymentReconciler`.
+
+**Current State:**
+- PVC manifest template exists at `internal/manifests/pvc.yaml`
+- Existing controllers use embedded manifests from the `internal/assets` package
+- Controllers filter for OpenClaw resources named 'instance'
+- Controllers set owner references for garbage collection
+
+**Constraints:**
+- Must follow existing controller patterns for consistency
+- Must use the same reconciliation filtering (name == 'instance')
+- Must set controller owner references for automatic cleanup
+- Must handle idempotency (PVC already exists scenario)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create a dedicated PVC controller following the existing ConfigMap/Deployment controller pattern
+- Automatically provision PVC when an OpenClaw named 'instance' is created
+- Set proper owner references for garbage collection when OpenClaw is deleted
+- Handle idempotent operations (skip if PVC already exists)
+- Add necessary RBAC permissions for PVC operations
+
+**Non-Goals:**
+- Dynamic PVC sizing or configuration (uses static manifest template)
+- PVC updates or modifications after creation
+- Support for multiple PVCs per OpenClaw instance
+- Volume expansion or resizing logic
+
+## Decisions
+
+### Decision 1: Dedicated Controller vs Combined Controller
+**Choice:** Create a dedicated `OpenClawPersistentVolumeClaimReconciler` controller in a separate file
+
+**Rationale:**
+- Consistent with existing architecture (separate ConfigMap and Deployment controllers)
+- Maintains single responsibility principle
+- Easier to test and maintain independently
+- Allows for future PVC-specific logic without affecting other controllers
+
+**Alternatives Considered:**
+- Combine PVC creation into existing ConfigMap controller: Rejected because it violates single responsibility and reduces clarity
+
+### Decision 2: Controller Naming
+**Choice:** Name the controller `OpenClawPersistentVolumeClaimReconciler`
+
+**Rationale:**
+- Explicit and clear about what resource type it manages
+- Follows the pattern of being explicit about the Kubernetes resource type
+- Consistent with other reconciler naming conventions that specify the full resource type
+- Avoids ambiguity between volumes, persistent volumes, and persistent volume claims
+
+### Decision 3: Manifest Loading Approach
+**Choice:** Reuse the existing `internal/assets` package pattern with embedded manifests
+
+**Rationale:**
+- Consistent with ConfigMap and Deployment controllers
+- Single source of truth for manifest templates
+- Compile-time validation that manifests are included
+- No external file dependencies at runtime
+
+### Decision 4: Error Handling for AlreadyExists
+**Choice:** Treat `AlreadyExists` errors as success (skip creation, return nil error)
+
+**Rationale:**
+- Consistent with ConfigMap controller behavior
+- Idempotent reconciliation is required by controller-runtime pattern
+- PVCs are immutable after creation (no updates needed)
+- Owner reference ensures cleanup happens automatically
+
+## Risks / Trade-offs
+
+### Risk: PVC is not bound
+**Impact:** PVC created but no PersistentVolume available to bind
+**Mitigation:** This is expected Kubernetes behavior - PVC will remain Pending until a PV is available. Deployment controller will handle pod scheduling accordingly.
+
+### Risk: Owner reference deletion delay
+**Impact:** When OpenClaw is deleted, garbage collection may have a delay before removing PVC
+**Mitigation:** This is standard Kubernetes behavior. The finalizer chain will clean up properly.
+
+### Trade-off: Static PVC configuration
+**Trade-off:** Using a static manifest template means PVC size and access modes cannot be configured per-instance
+**Rationale:** Matches current architecture for ConfigMap and Deployment. Dynamic configuration can be added later if needed without breaking changes.
+
+### Risk: Namespace mismatch
+**Impact:** If PVC namespace isn't set correctly, creation could fail or create in wrong namespace
+**Mitigation:** Explicitly set `pvc.Namespace = instance.Namespace` before creation, following the ConfigMap controller pattern.

--- a/openspec/changes/archive/2026-04-03-add-pvc-controller/proposal.md
+++ b/openspec/changes/archive/2026-04-03-add-pvc-controller/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The OpenClaw application requires persistent storage for user data and home directories. Currently, there is no controller managing the lifecycle of PersistentVolumeClaim (PVC) resources when an OpenClaw instance is created. This change adds a dedicated controller to automatically provision the required PVC when an OpenClaw named 'instance' is created, following the same pattern as the existing ConfigMap and Deployment controllers.
+
+## What Changes
+
+- Add a new `OpenClawPersistentVolumeClaimReconciler` controller in `internal/controller/openclaw_pvc_controller.go`
+- Controller watches OpenClaw resources and creates PVCs based on the template in `internal/manifests/pvc.yaml`
+- Only reconciles OpenClaw resources named 'instance' (consistent with existing controllers)
+- PVC is created with the OpenClaw instance as the controller owner reference
+- RBAC permissions added for PersistentVolumeClaim resources (get, list, watch, create)
+
+## Capabilities
+
+### New Capabilities
+- `openclawpvc-controller`: Controller that manages PersistentVolumeClaim lifecycle for OpenClaw instances, creating a PVC from the embedded manifest template when an OpenClaw named 'instance' is created
+
+### Modified Capabilities
+<!-- No existing capabilities are being modified -->
+
+## Impact
+
+- New controller file: `internal/controller/openclaw_pvc_controller.go`
+- Existing PVC manifest: `internal/manifests/pvc.yaml` (already present)
+- Main controller setup will need to register the new controller
+- RBAC manifests will be updated with PVC permissions via kubebuilder annotations

--- a/openspec/changes/archive/2026-04-03-add-pvc-controller/specs/openclawpvc-controller/spec.md
+++ b/openspec/changes/archive/2026-04-03-add-pvc-controller/specs/openclawpvc-controller/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Controller watches OpenClaw resources
+The OpenClawPersistentVolumeClaimReconciler controller SHALL watch OpenClaw custom resources in all namespaces and trigger reconciliation when changes occur.
+
+#### Scenario: OpenClaw resource created triggers reconciliation
+- **WHEN** an OpenClaw custom resource is created
+- **THEN** the controller reconciliation loop is triggered with the resource name and namespace
+
+#### Scenario: OpenClaw resource updated triggers reconciliation
+- **WHEN** an OpenClaw custom resource is updated
+- **THEN** the controller reconciliation loop is triggered
+
+#### Scenario: OpenClaw resource deleted triggers reconciliation
+- **WHEN** an OpenClaw custom resource is deleted
+- **THEN** the controller reconciliation loop is triggered to handle cleanup
+
+### Requirement: Controller filters by instance name
+The controller SHALL only reconcile OpenClaw resources named 'instance' and skip all other names.
+
+#### Scenario: Reconcile OpenClaw named 'instance'
+- **WHEN** an OpenClaw resource named 'instance' is created or updated
+- **THEN** the controller proceeds with PVC creation logic
+
+#### Scenario: Skip OpenClaw with different name
+- **WHEN** an OpenClaw resource with a name other than 'instance' is created
+- **THEN** the controller logs a skip message and returns without creating a PVC
+
+### Requirement: Controller creates PVC from template
+The controller SHALL create a PersistentVolumeClaim based on the manifest template in `internal/manifests/pvc.yaml`.
+
+#### Scenario: PVC created from embedded manifest
+- **WHEN** reconciling an OpenClaw named 'instance'
+- **THEN** the controller decodes the embedded PVC manifest from the assets package
+- **THEN** the controller creates a PVC with the specification from the manifest
+
+#### Scenario: PVC namespace matches OpenClaw namespace
+- **WHEN** creating a PVC for an OpenClaw resource
+- **THEN** the PVC namespace SHALL be set to match the OpenClaw resource's namespace
+
+### Requirement: Controller sets owner reference
+The controller SHALL set the OpenClaw instance as the controller owner reference on the created PVC.
+
+#### Scenario: Owner reference set on PVC creation
+- **WHEN** creating a PVC for an OpenClaw resource
+- **THEN** the controller sets a controller owner reference pointing to the OpenClaw instance
+- **THEN** the PVC will be automatically garbage collected when the OpenClaw is deleted
+
+### Requirement: Controller handles idempotent creation
+The controller SHALL handle the case where the PVC already exists without returning an error.
+
+#### Scenario: PVC already exists
+- **WHEN** attempting to create a PVC that already exists
+- **THEN** the controller treats this as success and returns without error
+- **THEN** the controller logs that the PVC already exists
+
+### Requirement: Controller handles resource not found
+The controller SHALL handle the case where the OpenClaw resource is not found during reconciliation.
+
+#### Scenario: OpenClaw deleted before reconciliation
+- **WHEN** the OpenClaw resource is not found during reconciliation
+- **THEN** the controller logs that the resource was deleted
+- **THEN** the controller returns without error (no requeue)
+
+### Requirement: Controller logs reconciliation events
+The controller SHALL log key reconciliation events for observability.
+
+#### Scenario: Log reconciliation start
+- **WHEN** reconciliation begins
+- **THEN** the controller logs the OpenClaw name and namespace being reconciled
+
+#### Scenario: Log PVC creation success
+- **WHEN** a PVC is successfully created
+- **THEN** the controller logs a success message
+
+#### Scenario: Log PVC creation failure
+- **WHEN** PVC creation fails with an error other than AlreadyExists
+- **THEN** the controller logs the error
+- **THEN** the controller returns the error to trigger retry
+
+### Requirement: Controller registers with manager
+The controller SHALL register with the controller-runtime manager and configure appropriate predicates.
+
+#### Scenario: Controller registered with manager
+- **WHEN** the controller's SetupWithManager is called
+- **THEN** the controller registers to watch OpenClaw resources as the primary resource
+- **THEN** the controller registers to own PersistentVolumeClaim resources
+- **THEN** the controller is named "openclawpersistentvolumeclaim" for identification
+
+#### Scenario: PVC name predicate configured
+- **WHEN** setting up watches for owned PVCs
+- **THEN** the controller configures a predicate to filter PVC events by name "openclaw-home-pvc"
+
+### Requirement: Controller has RBAC permissions
+The controller SHALL have necessary RBAC permissions defined via kubebuilder annotations.
+
+#### Scenario: OpenClaw resource permissions
+- **WHEN** the controller is deployed
+- **THEN** RBAC rules grant get, list, and watch permissions for OpenClaw resources
+
+#### Scenario: PVC permissions
+- **WHEN** the controller is deployed
+- **THEN** RBAC rules grant get, list, watch, and create permissions for PersistentVolumeClaim resources

--- a/openspec/changes/archive/2026-04-03-add-pvc-controller/tasks.md
+++ b/openspec/changes/archive/2026-04-03-add-pvc-controller/tasks.md
@@ -1,0 +1,51 @@
+## 1. Setup Assets
+
+- [x] 1.1 Add PVC manifest embed to internal/assets/manifests.go
+- [x] 1.2 Copy internal/manifests/pvc.yaml to internal/assets/manifests/pvc.yaml
+
+## 2. Create Controller File
+
+- [x] 2.1 Create internal/controller/openclaw_pvc_controller.go with OpenClawPersistentVolumeClaimReconciler struct
+- [x] 2.2 Add package imports (context, corev1, apierrors, runtime, serializer, ctrl, builder, client, controllerutil, log, predicate, openclawv1alpha1, assets)
+- [x] 2.3 Add constant OpenClawPVCName = "openclaw-home-pvc"
+- [x] 2.4 Define OpenClawPersistentVolumeClaimReconciler struct with Client and Scheme fields
+
+## 3. Implement Reconcile Method
+
+- [x] 3.1 Add RBAC annotations for OpenClaw (get, list, watch) and PersistentVolumeClaim (get, list, watch, create) resources
+- [x] 3.2 Implement Reconcile method signature with context and request parameters
+- [x] 3.3 Add logging for reconciliation start with name and namespace
+- [x] 3.4 Fetch OpenClaw resource using r.Get() with error handling for NotFound case
+- [x] 3.5 Add name filtering to skip OpenClaw resources not named "instance"
+- [x] 3.6 Parse embedded PVC manifest using serializer.NewCodecFactory and decode into corev1.PersistentVolumeClaim
+- [x] 3.7 Set PVC namespace to match OpenClaw instance namespace
+- [x] 3.8 Set controller owner reference using controllerutil.SetControllerReference
+- [x] 3.9 Create PVC using r.Create() with AlreadyExists error handling
+- [x] 3.10 Add success logging after PVC creation
+
+## 4. Implement SetupWithManager Method
+
+- [x] 4.1 Create SetupWithManager method that accepts ctrl.Manager parameter
+- [x] 4.2 Create PVC name predicate using predicate.NewPredicateFuncs filtering for OpenClawPVCName
+- [x] 4.3 Build controller using ctrl.NewControllerManagedBy with For OpenClaw, Owns PVC with predicate, Named "openclawpersistentvolumeclaim"
+- [x] 4.4 Return Complete(r) to register the controller
+
+## 5. Register Controller with Manager
+
+- [x] 5.1 Add OpenClawPersistentVolumeClaimReconciler setup in cmd/main.go after OpenClawDeploymentReconciler registration
+- [x] 5.2 Include error handling and setup logging for the new controller
+
+## 6. Verification
+
+- [x] 6.1 Run make manifests to generate RBAC manifests from kubebuilder annotations
+- [x] 6.2 Verify the controller builds successfully (make build or go build)
+- [x] 6.3 Check that RBAC manifests in config/rbac/ include PVC permissions
+
+## 7. Unit Tests
+
+- [x] 7.1 Create internal/controller/openclaw_pvc_controller_test.go with test suite
+- [x] 7.2 Add test for creating PVC for OpenClaw named 'instance'
+- [x] 7.3 Add test for verifying correct owner reference on PVC
+- [x] 7.4 Add test for skipping PVC creation for non-matching names
+- [x] 7.5 Add BeforeEach cleanup to handle test isolation
+- [x] 7.6 Verify all controller tests pass (10/10 passing)

--- a/openspec/specs/openclawpvc-controller/spec.md
+++ b/openspec/specs/openclawpvc-controller/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Controller watches OpenClaw resources
+The OpenClawPersistentVolumeClaimReconciler controller SHALL watch OpenClaw custom resources in all namespaces and trigger reconciliation when changes occur.
+
+#### Scenario: OpenClaw resource created triggers reconciliation
+- **WHEN** an OpenClaw custom resource is created
+- **THEN** the controller reconciliation loop is triggered with the resource name and namespace
+
+#### Scenario: OpenClaw resource updated triggers reconciliation
+- **WHEN** an OpenClaw custom resource is updated
+- **THEN** the controller reconciliation loop is triggered
+
+#### Scenario: OpenClaw resource deleted triggers reconciliation
+- **WHEN** an OpenClaw custom resource is deleted
+- **THEN** the controller reconciliation loop is triggered to handle cleanup
+
+### Requirement: Controller filters by instance name
+The controller SHALL only reconcile OpenClaw resources named 'instance' and skip all other names.
+
+#### Scenario: Reconcile OpenClaw named 'instance'
+- **WHEN** an OpenClaw resource named 'instance' is created or updated
+- **THEN** the controller proceeds with PVC creation logic
+
+#### Scenario: Skip OpenClaw with different name
+- **WHEN** an OpenClaw resource with a name other than 'instance' is created
+- **THEN** the controller logs a skip message and returns without creating a PVC
+
+### Requirement: Controller creates PVC from template
+The controller SHALL create a PersistentVolumeClaim based on the manifest template in `internal/manifests/pvc.yaml`.
+
+#### Scenario: PVC created from embedded manifest
+- **WHEN** reconciling an OpenClaw named 'instance'
+- **THEN** the controller decodes the embedded PVC manifest from the assets package
+- **THEN** the controller creates a PVC with the specification from the manifest
+
+#### Scenario: PVC namespace matches OpenClaw namespace
+- **WHEN** creating a PVC for an OpenClaw resource
+- **THEN** the PVC namespace SHALL be set to match the OpenClaw resource's namespace
+
+### Requirement: Controller sets owner reference
+The controller SHALL set the OpenClaw instance as the controller owner reference on the created PVC.
+
+#### Scenario: Owner reference set on PVC creation
+- **WHEN** creating a PVC for an OpenClaw resource
+- **THEN** the controller sets a controller owner reference pointing to the OpenClaw instance
+- **THEN** the PVC will be automatically garbage collected when the OpenClaw is deleted
+
+### Requirement: Controller handles idempotent creation
+The controller SHALL handle the case where the PVC already exists without returning an error.
+
+#### Scenario: PVC already exists
+- **WHEN** attempting to create a PVC that already exists
+- **THEN** the controller treats this as success and returns without error
+- **THEN** the controller logs that the PVC already exists
+
+### Requirement: Controller handles resource not found
+The controller SHALL handle the case where the OpenClaw resource is not found during reconciliation.
+
+#### Scenario: OpenClaw deleted before reconciliation
+- **WHEN** the OpenClaw resource is not found during reconciliation
+- **THEN** the controller logs that the resource was deleted
+- **THEN** the controller returns without error (no requeue)
+
+### Requirement: Controller logs reconciliation events
+The controller SHALL log key reconciliation events for observability.
+
+#### Scenario: Log reconciliation start
+- **WHEN** reconciliation begins
+- **THEN** the controller logs the OpenClaw name and namespace being reconciled
+
+#### Scenario: Log PVC creation success
+- **WHEN** a PVC is successfully created
+- **THEN** the controller logs a success message
+
+#### Scenario: Log PVC creation failure
+- **WHEN** PVC creation fails with an error other than AlreadyExists
+- **THEN** the controller logs the error
+- **THEN** the controller returns the error to trigger retry
+
+### Requirement: Controller registers with manager
+The controller SHALL register with the controller-runtime manager and configure appropriate predicates.
+
+#### Scenario: Controller registered with manager
+- **WHEN** the controller's SetupWithManager is called
+- **THEN** the controller registers to watch OpenClaw resources as the primary resource
+- **THEN** the controller registers to own PersistentVolumeClaim resources
+- **THEN** the controller is named "openclawpersistentvolumeclaim" for identification
+
+#### Scenario: PVC name predicate configured
+- **WHEN** setting up watches for owned PVCs
+- **THEN** the controller configures a predicate to filter PVC events by name "openclaw-home-pvc"
+
+### Requirement: Controller has RBAC permissions
+The controller SHALL have necessary RBAC permissions defined via kubebuilder annotations.
+
+#### Scenario: OpenClaw resource permissions
+- **WHEN** the controller is deployed
+- **THEN** RBAC rules grant get, list, and watch permissions for OpenClaw resources
+
+#### Scenario: PVC permissions
+- **WHEN** the controller is deployed
+- **THEN** RBAC rules grant get, list, watch, and create permissions for PersistentVolumeClaim resources


### PR DESCRIPTION
Add `OpenClawPersistentVolumeClaimReconciler` to manage PVC lifecycle for
OpenClaw instances. The controller creates a PersistentVolumeClaim from
an embedded manifest template when an OpenClaw resource named `instance`
is created.

Implementation follows the existing pattern used by ConfigMap and
Deployment controllers:
- Embedded PVC manifest in `internal/assets/manifests/`
- Manifest decoded at runtime with namespace and owner reference set
- Only reconciles OpenClaw resources named `instance`
- Idempotent creation with `AlreadyExists` error handling

Changes:
- New controller in internal/controller/openclaw_pvc_controller.go
- Comprehensive unit tests with 100% pass rate (10/10 tests)
- RBAC permissions for PVC operations (get, list, watch, create)
- Controller registration in `cmd/main.go`
- Updated CLAUDE.md to document three-controller architecture

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
