### PR TITLE
refactor(controller): rename OpenClawReconciler to OpenClawResourceReconciler

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,8 @@
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test -v ./internal/controller/... -run \"ConfigMap\")",
       "Bash(go clean:*)",
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test ./internal/controller/...)",
-      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test ./internal/controller/... -run \"Deployment\")"
+      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test ./internal/controller/... -run \"Deployment\")",
+      "Bash(git mv:*)"
     ]
   }
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,7 +202,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.OpenClawReconciler{
+	if err = (&controller.OpenClawResourceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/openclaw_configmap_controller_test.go
+++ b/internal/controller/openclaw_configmap_controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("OpenClawConfigMap Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -92,7 +92,7 @@ var _ = Describe("OpenClawConfigMap Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -147,7 +147,7 @@ var _ = Describe("OpenClawConfigMap Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}

--- a/internal/controller/openclaw_deployment_controller_test.go
+++ b/internal/controller/openclaw_deployment_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -100,7 +100,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -169,7 +169,7 @@ var _ = Describe("OpenClawDeployment Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}

--- a/internal/controller/openclaw_pvc_controller_test.go
+++ b/internal/controller/openclaw_pvc_controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -92,7 +92,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
@@ -171,7 +171,7 @@ var _ = Describe("OpenClawPersistentVolumeClaim Controller", func() {
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 			// Setup reconciler
-			reconciler := &OpenClawReconciler{
+			reconciler := &OpenClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}

--- a/internal/controller/openclaw_resource_controller.go
+++ b/internal/controller/openclaw_resource_controller.go
@@ -45,8 +45,8 @@ const (
 	OpenClawDeploymentName = "openclaw"
 )
 
-// OpenClawReconciler reconciles all resources for OpenClaw
-type OpenClawReconciler struct {
+// OpenClawResourceReconciler reconciles all resources for OpenClaw
+type OpenClawResourceReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
@@ -57,7 +57,7 @@ type OpenClawReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 
 // Reconcile manages the complete lifecycle of resources for OpenClaw instances
-func (r *OpenClawReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *OpenClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling OpenClaw", "name", req.Name, "namespace", req.Namespace)
 
@@ -88,7 +88,7 @@ func (r *OpenClawReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 // applyKustomizedResources builds manifests using Kustomize and applies them via server-side apply
-func (r *OpenClawReconciler) applyKustomizedResources(ctx context.Context, instance *openclawv1alpha1.OpenClaw) error {
+func (r *OpenClawResourceReconciler) applyKustomizedResources(ctx context.Context, instance *openclawv1alpha1.OpenClaw) error {
 	logger := log.FromContext(ctx)
 
 	// Build manifests using Kustomize
@@ -202,7 +202,7 @@ func parseYAMLToObjects(yamlData []byte) ([]*unstructured.Unstructured, error) {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenClawReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpenClawResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openclawv1alpha1.OpenClaw{}).
 		Owns(&corev1.ConfigMap{}).

--- a/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-03

--- a/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/design.md
+++ b/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The OpenClaw operator uses a unified Kustomize-based controller that manages multiple Kubernetes resources (ConfigMap, PVC, Deployment) atomically using server-side apply. The current naming `OpenClawReconciler` doesn't clearly indicate that this is a resource-oriented reconciler managing a set of resources.
+
+The codebase follows kubebuilder/operator-sdk conventions where reconcilers are typically named after what they reconcile. Since this reconciler manages multiple Kubernetes resources as a coordinated set, `OpenClawResourceReconciler` better reflects its purpose.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename the reconciler struct and file to improve code clarity
+- Maintain all existing functionality without behavioral changes
+- Update all references in test files and main.go
+
+**Non-Goals:**
+- Change reconciliation logic or resource management behavior
+- Modify CRD definitions, RBAC, or external APIs
+- Refactor controller implementation beyond the rename
+
+## Decisions
+
+### Decision: Rename struct to OpenClawResourceReconciler
+**Rationale**: The "Resource" qualifier makes explicit that this reconciler manages Kubernetes resources (not just a single OpenClaw CR), aligning with the controller's actual behavior of managing ConfigMap, PVC, and Deployment as a unified set.
+
+**Alternative considered**: `OpenClawUnifiedReconciler` - Rejected because "unified" describes the implementation approach (Kustomize-based) rather than what it reconciles.
+
+### Decision: Rename file to openclaw_resource_controller.go
+**Rationale**: File naming should match the primary struct name for consistency. Kubebuilder convention is `<resource>_controller.go`.
+
+**Alternative considered**: Keep original filename - Rejected to maintain consistency between struct and file names, making the codebase easier to navigate.
+
+## Risks / Trade-offs
+
+**[Risk]** In-flight PRs or branches may have merge conflicts in affected files
+→ **Mitigation**: This is a straightforward rename with clear before/after state. Conflicts will be easy to resolve. Coordinate with team if active PRs exist.
+
+**[Trade-off]** Git history tracking may be disrupted if file rename not detected
+→ **Mitigation**: Ensure file rename is done atomically (delete old + create new in same commit) so git can track it. Use `git log --follow` to trace history across rename.

--- a/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/proposal.md
+++ b/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current `OpenClawReconciler` name doesn't clearly communicate that this controller manages multiple Kubernetes resources (ConfigMap, PVC, Deployment) as a unified set using Kustomize and server-side apply. Renaming to `OpenClawResourceReconciler` improves clarity and follows the pattern of naming reconcilers after what they reconcile.
+
+## What Changes
+
+- Rename `OpenClawReconciler` struct to `OpenClawResourceReconciler` in `internal/controller/openclaw_controller.go`
+- Rename file `internal/controller/openclaw_controller.go` to `internal/controller/openclaw_resource_controller.go`
+- Update all test files to reference the new struct name
+- Update `cmd/main.go` to instantiate `OpenClawResourceReconciler`
+
+## Capabilities
+
+### New Capabilities
+<!-- No new capabilities introduced by this refactor -->
+
+### Modified Capabilities
+<!-- No requirement changes - this is a naming refactor only -->
+
+## Impact
+
+- **Code**: Controller implementation file and all test files in `internal/controller/`
+- **Main entrypoint**: `cmd/main.go` controller setup
+- **No API changes**: CRD, RBAC, or external APIs remain unchanged
+- **No behavioral changes**: Reconciliation logic remains identical

--- a/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/specs/README.md
+++ b/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/specs/README.md
@@ -1,0 +1,3 @@
+# Specs
+
+No specification changes required - this is a naming refactor only with no behavioral changes.

--- a/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/tasks.md
+++ b/openspec/changes/archive/2026-04-03-rename-openclaw-reconciler/tasks.md
@@ -1,0 +1,21 @@
+## 1. Rename Controller File and Struct
+
+- [x] 1.1 Rename `internal/controller/openclaw_controller.go` to `internal/controller/openclaw_resource_controller.go`
+- [x] 1.2 Update struct name from `OpenClawReconciler` to `OpenClawResourceReconciler` in the renamed file
+- [x] 1.3 Update receiver variable references in all methods (if needed for consistency)
+
+## 2. Update Test Files
+
+- [x] 2.1 Update test files to reference `OpenClawResourceReconciler` instead of `OpenClawReconciler`
+- [x] 2.2 Verify test imports and suite setup still reference correct controller
+
+## 3. Update Main Entrypoint
+
+- [x] 3.1 Update `cmd/main.go` to instantiate `OpenClawResourceReconciler` instead of `OpenClawReconciler`
+- [x] 3.2 Update any controller setup or registration calls
+
+## 4. Verification
+
+- [x] 4.1 Run `make test` to verify all unit tests pass
+- [x] 4.2 Run `make lint` to verify no linting issues
+- [x] 4.3 Run `make build` to verify compilation succeeds


### PR DESCRIPTION
Description:
Rename the main reconciler struct and file to better reflect that it manages
multiple Kubernetes resources (ConfigMap, PVC, Deployment) as a unified set
using Kustomize and server-side apply.

Changes:
- Rename struct OpenClawReconciler → OpenClawResourceReconciler
- Rename file openclaw_controller.go → openclaw_resource_controller.go
- Update all test files to reference the new struct name
- Update cmd/main.go to instantiate OpenClawResourceReconciler

The "Resource" qualifier makes explicit that this reconciler manages multiple
Kubernetes resources, aligning with kubebuilder naming conventions and improving
code clarity. No behavioral changes to reconciliation logic.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
