### PR TITLE
fix(rbac): add finalizers permission to support owner references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - openclaw.sandbox.redhat.com
+  resources:
+  - openclaws/finalizers
+  verbs:
+  - update
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/internal/controller/openclaw_resource_controller.go
+++ b/internal/controller/openclaw_resource_controller.go
@@ -55,6 +55,7 @@ type OpenClawResourceReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=openclaw.sandbox.redhat.com,resources=openclaws,verbs=get;list;watch
+// +kubebuilder:rbac:groups=openclaw.sandbox.redhat.com,resources=openclaws/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
The controller was failing to create resources with the error "cannot set
blockOwnerDeletion if an ownerReference refers to a resource you can't set
finalizers on". This occurred because `controllerutil.SetControllerReference`
sets blockOwnerDeletion: true by default, which requires permission to update
finalizers on the owner resource (OpenClaw CR).

Added RBAC marker and regenerated manifests to grant update permission on
openclaws/finalizers subresource.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
