### PR TITLE
docs: add security hardening sketch and questions

### DIFF
--- a/docs/proposals/security-hardening-questions.md
+++ b/docs/proposals/security-hardening-questions.md
@@ -1,0 +1,189 @@
+# Security Hardening — Open Questions
+
+**Status:** All decisions made
+**Related:** [Sketch document](security-hardening-sketch.md)
+
+---
+
+## Q1: How should the gateway token be managed?
+
+The OpenClaw gateway requires `OPENCLAW_GATEWAY_TOKEN` for authentication. The PoC generated this in a bash script. The operator needs an automated, secure approach. Without this, anyone who can reach the Route can interact with the assistant using the user's namespace permissions.
+
+### Option A: Operator generates a random token and stores it in a Secret
+
+The operator generates a cryptographically random token during reconciliation (if the Secret doesn't exist), stores it in `openclaw-secrets`, and the Deployment mounts it as `OPENCLAW_GATEWAY_TOKEN`. The token is never exposed in the CRD. The UI retrieves it via `kubectl get secret` using the user's kube token.
+
+- **Pro:** Fully automated — zero friction for the user, secure by default
+- **Pro:** Token never appears in CRD, audit logs of CR changes, or etcd as a non-Secret resource
+- **Con:** User can't easily set a custom token (would need to edit the Secret manually, and the operator would need to not overwrite it)
+
+**Decision:** Option A — automatic generation is the safest default with zero friction. The operator writes the Secret name back to the CR status (e.g., `status.gatewayTokenSecretRef`) so consumers (UI, CLI) can discover where the token lives, then fetch it using the user's kube token. The actual token value never appears in the CRD — only the reference.
+
+_Considered and rejected: Option B — user-provided token in CRD spec (same plaintext-in-CRD problem as apiKey, adds unnecessary friction), Option C — operator generates with manual override (fragile ownership-detection logic, premature flexibility)_
+
+---
+
+## Q2: How should users provide credentials to the operator?
+
+This question is about the **user-facing API** — how credentials get into the cluster and how the CRD references them. How those credentials are consumed by the proxy is a separate concern (see Q7).
+
+Today `OpenClaw.spec.apiKey` is a single plaintext string field on the CRD, managing only Gemini. In reality, the credential surface is much broader:
+
+| Category | Examples | Credential shape |
+|----------|----------|-----------------|
+| **LLM providers** | Gemini, Anthropic, OpenAI, OpenRouter | API key (header format varies) |
+| **Cloud AI** | Vertex AI, AWS Bedrock | Service account JSON / OAuth / SDK auth |
+| **Channel integrations** | Telegram bot token, Slack bot/app/signing tokens, Discord token | Varied per channel |
+| **Platform APIs** | GitHub token | Bearer token |
+| **Future integrations** | Calendar, CRM, internal tools, ... | Unknown |
+
+The design must handle this diversity without requiring CRD schema changes for every new integration. No secret data should ever appear in the CRD.
+
+### Option E: Typed credential CRDs
+
+Define a set of CRDs per credential *shape* (not per service). Each CRD combines a Secret reference with shape-specific configuration. The OpenClaw CR doesn't know about credentials at all — the controller discovers credential CRDs in the same namespace.
+
+**CRDs by credential shape:**
+
+```yaml
+# API key credentials (Gemini, Anthropic, OpenAI, OpenRouter, etc.)
+apiVersion: openclaw.sandbox.redhat.com/v1alpha1
+kind: APIKeyCredential
+metadata:
+  name: gemini
+  labels:
+    openclaw.sandbox.redhat.com/instance: instance
+spec:
+  secretRef:
+    name: my-llm-keys
+    key: GEMINI_API_KEY
+  domain: "generativelanguage.googleapis.com"
+  header: "x-goog-api-key"              # or "x-api-key" for Anthropic, etc.
+---
+# GCP / Vertex AI credentials (service account JSON → OAuth2)
+apiVersion: openclaw.sandbox.redhat.com/v1alpha1
+kind: GCPCredential
+metadata:
+  name: vertex-ai
+  labels:
+    openclaw.sandbox.redhat.com/instance: instance
+spec:
+  secretRef:
+    name: gcp-sa-secret
+    key: sa-key.json
+  project: my-project
+  location: us-central1
+  domain: "*.googleapis.com"
+---
+# Bearer token credentials (GitHub, etc.)
+apiVersion: openclaw.sandbox.redhat.com/v1alpha1
+kind: BearerTokenCredential
+metadata:
+  name: github
+  labels:
+    openclaw.sandbox.redhat.com/instance: instance
+spec:
+  secretRef:
+    name: platform-tokens
+    key: GITHUB_TOKEN
+  domain: "api.github.com"
+```
+
+The OpenClaw CR stays clean — no credential fields at all:
+```yaml
+apiVersion: openclaw.sandbox.redhat.com/v1alpha1
+kind: OpenClaw
+metadata:
+  name: instance
+spec: {}
+```
+
+The controller discovers all `APIKeyCredential`, `GCPCredential`, `BearerTokenCredential`, etc. in the namespace (by label) and configures the proxy accordingly.
+
+**Precedent:** Crossplane `ProviderConfig`, cert-manager `Issuer`, External Secrets Operator `SecretStore` — all use per-backend CRDs with Secret ref + typed config.
+
+**Decision:** Option E — typed credential CRDs using the `XYZCredential` naming pattern (singular Kind per Kubernetes convention). CRDs are organized by credential *shape* (e.g., `APIKeyCredential`, `GCPCredential`, `BearerTokenCredential`), not per service. Each CRD combines a Secret reference with shape-specific configuration (domain, header format, project/location, etc.). The OpenClaw CR carries no credential fields — the controller discovers credential CRDs in the namespace by label. Adding a new service with an existing auth shape is data (new CR instance); adding a new auth shape is a new CRD + controller logic.
+
+_Considered and rejected: Option A — single Secret ref (can't co-locate credential config; GCP is a special case), Option B — list of typed Secret refs (no config alongside the ref), Option C — per-category fields (rigid, new category = schema change), Option D — single Secret with conventions (fragile naming, mixes API keys with SA JSON)_
+
+---
+
+## Q3: How should network policies be tightened?
+
+**Already implemented (must keep):**
+- **OpenClaw pod egress** — restricted to proxy pod only (TCP 8080) + DNS. This is a key security measure: the OpenClaw process can never reach the internet or the Kubernetes API directly, only through the proxy.
+- **Proxy pod egress** — TCP 443 to anywhere + DNS. L7 blocking in the proxy (unknown paths return 403) is the primary control; L4 is intentionally broad because LLM API IPs are dynamic/CDN-hosted.
+
+**Gap:** No ingress restriction on the OpenClaw gateway pod — any in-cluster pod that can route to the Service can reach it.
+
+### Option A: Add ingress NetworkPolicy for the gateway pod
+
+Add an ingress policy allowing traffic to OpenClaw pods only from the OpenShift router (for user access via the Route). Proxy egress stays unchanged — the proxy itself handles L7 allowlisting.
+
+Additional NetworkPolicies managed outside the operator (e.g., by cluster admins or monitoring operators) can open access for other needs like Prometheus scraping, logging agents, etc. Since Kubernetes NetworkPolicies are additive (union of all matching rules), these compose cleanly with the operator's policies.
+
+- **Pro:** Addresses the highest-risk gap — blocks lateral movement from other in-cluster pods
+- **Pro:** Pragmatic — doesn't assume specific CNI capabilities
+- **Pro:** Composable — cluster-level monitoring/observability policies work alongside without conflict
+- **Con:** Ingress policy is OpenShift-specific (router label selectors vary by cluster)
+
+**Decision:** Option A — add ingress NetworkPolicy restricting gateway access to the OpenShift router. Proxy egress stays as-is with L7 blocking as defense-in-depth. Additional access (monitoring, etc.) is handled by separate NetworkPolicies outside the operator's scope.
+
+_Considered and rejected: Option B — restrict proxy egress by IP/CIDR (LLM APIs use dynamic CDN IPs, brittle and high maintenance), Option C — DNS-based egress via Cilium (requires specific CNI, not universally available)_
+
+---
+
+## Q4: Operator RBAC
+
+The operator currently has a `ClusterRole` with broad permissions. This will need a review to ensure least-privilege (only permissions the controller actually uses), but it's not a design question — it's a housekeeping task to do once the new credential CRDs and proxy architecture are implemented, since those changes will alter the required permission set.
+
+**Decision:** Deferred. Review and trim operator RBAC after Q2 (credential CRDs) and Q7 (proxy architecture) are implemented.
+
+---
+
+## Q5: Which container/supply-chain hardening items should we prioritize?
+
+Several minor gaps exist: init container security context, image digest pinning, Route TLS settings, and the `OPENCLAW_ROUTE_HOST` placeholder.
+
+**Decision:** Two quick wins:
+
+1. **Init container security context** — the busybox init container (`init-config`) has no explicit `securityContext`, relying on image defaults. The main container is fully hardened (non-root, read-only root FS, drop all caps, seccomp RuntimeDefault). The init container needs the same — required for Pod Security Admission restricted profile compliance.
+
+2. **Route host placeholder** — the ConfigMap has `"allowedOrigins": ["https://OPENCLAW_ROUTE_HOST"]` which is never substituted with the real hostname, breaking CORS protection. The operator creates the Route and knows the hostname — it should inject it into the ConfigMap during reconciliation.
+
+_Deferred: image digest pinning (good practice but needs CI automation first), Route TLS version/cipher config (OpenShift router enforces cluster-wide defaults)_
+
+---
+
+## Q6: Should the operator manage any application-layer security controls?
+
+OpenClaw as an AI agent can interact with Kubernetes on behalf of the user. Prompt injection could cause it to take unexpected actions. This is mostly an upstream concern, but the operator controls the deployment environment.
+
+**Decision:** Document the threat model and recommended mitigations. Investigate how OpenClaw accesses Kubernetes (ServiceAccount? user's token?) and whether RBAC scoping for the assistant is feasible — implement if it doesn't break core use cases.
+
+_Considered and rejected: Option A — fully out of scope (users expect a "secure deployment" to address this), Option B — restrict Kubernetes permissions now (unclear how OpenClaw accesses the API, needs investigation first)_
+
+---
+
+## Q7: What proxy architecture should inject credentials into LLM requests?
+
+This question is about the **credential injection mechanism** — how user-provided secrets (from Q2) are actually used when OpenClaw calls LLM APIs. This is separate from how users provide the secrets.
+
+Today the operator uses an **nginx reverse proxy** with static `location` blocks per provider. Each block rewrites one path prefix to one upstream, injecting credentials via `proxy_set_header` from environment variables. This works for simple API-key providers but has limitations:
+
+- **No Vertex AI / OAuth support**: Vertex AI requires short-lived OAuth2 access tokens obtained from a service account, with automatic refresh. Nginx cannot do this natively — it can only inject static values from env vars.
+- **Static configuration**: adding a new provider means editing the nginx config template. The set of upstream hosts and auth header formats is baked into the ConfigMap.
+- **No credential override guarantee**: nginx sets headers but doesn't strip client-supplied auth headers on the incoming side — a misconfigured or malicious OpenClaw process could potentially include its own credentials.
+
+**How reference projects solve this:**
+
+- **openshift-openclaw (PoC)**: same nginx pattern. Vertex AI partially sketched (SA JSON mounted, env vars set) but no actual Vertex route or OAuth token flow in nginx. Gemini only via static API key.
+- **paude-proxy**: Go-based MITM forward proxy. Declarative JSON config maps env vars → injector types (`bearer`, `api_key`, `gcloud`) → domain patterns. For Google/Vertex, loads ADC (SA JSON), obtains short-lived OAuth2 tokens via Go's `oauth2/google` library with automatic refresh, injects `Authorization: Bearer <real-token>` on `*.googleapis.com`. A token vendor intercepts `POST oauth2.googleapis.com/token` returning dummy responses so the client's Google auth library is satisfied without seeing real credentials. Explicitly overrides all client-supplied auth headers.
+- **onecli**: Rust gateway with DB-driven injection rules per host/path. Supports Anthropic (API key or OAuth), generic header injection, and vault-backed credentials.
+- **OpenShell**: Go inference router that strips incoming `authorization`/`x-api-key` headers and re-applies route-specific auth. Supports bearer and custom header injection. No Vertex/ADC.
+
+**Decision:** Option B — replace nginx with a purpose-built Go reverse proxy. Config-driven domain→injector routing, pluggable injectors (bearer, API key header, GCP ADC/OAuth2), explicit auth header stripping on all requests. Port paude-proxy's credential injection layer (~500 LOC, MIT-licensed, cleanly self-contained) as a starting point rather than building from scratch. Add health endpoint and strict header policy. Estimated ~800-1000 LOC total for a focused component that fits the operator's Go tech stack.
+
+The proxy derives its routing configuration from the credential CRDs (Q2) — the operator reads the CRDs and generates the proxy's config, so adding a new service is purely declarative (new CR instance), not a code or config template change.
+
+_Considered and rejected: Option A — nginx + sidecar for OAuth (band-aid, doesn't fix header stripping or static config), Option C — fork paude-proxy (its MITM/CONNECT/CA machinery is ~850 LOC we don't need; forking to delete half the codebase is worse than porting the valuable 500 LOC), Option D — keep nginx and defer (blocks Vertex AI, accumulates technical debt)_

--- a/docs/proposals/security-hardening-sketch.md
+++ b/docs/proposals/security-hardening-sketch.md
@@ -1,0 +1,129 @@
+# Security Hardening for OpenClaw Operator
+
+**Status:** Sketch complete — ready for detailed design
+
+## Problem
+
+The OpenClaw operator deploys a personal AI assistant with access to LLM APIs and the user's Kubernetes namespace. Today, credential isolation (nginx proxy) and egress NetworkPolicies are in place, but several security gaps remain: the gateway has no managed authentication, the CRD carries a plaintext API key, ingress is unrestricted, and the proxy can't handle OAuth-based providers like Vertex AI.
+
+On Dev Sandbox, each OpenClaw instance runs in a user's namespace with their permissions. A security failure here means either leaked LLM credentials (cost and privacy), unauthorized access to the assistant (abuse of the user's namespace permissions), or lateral movement from a compromised pod.
+
+## Current Security Posture (must keep)
+
+- **OpenClaw pod egress locked to proxy only** — the OpenClaw process can never reach the internet or the Kubernetes API directly, only through the proxy (TCP 8080) + DNS. This is a cornerstone security measure.
+- Credential isolation via reverse proxy (OpenClaw never sees raw API keys)
+- Proxy pod egress limited to TCP 443 + DNS; proxy L7 blocks unknown paths (returns 403)
+- Pod hardening: non-root (uid 65532), `readOnlyRootFilesystem`, `seccompProfile: RuntimeDefault`, all capabilities dropped, `automountServiceAccountToken: false`
+- Edge TLS on the Route with HTTP-to-HTTPS redirect
+- Server-side apply with field ownership tracking
+
+## Decisions
+
+All questions resolved — see [security-hardening-questions.md](security-hardening-questions.md) for full context, options considered, and rationale.
+
+### 1. Gateway Authentication (Q1)
+
+The operator auto-generates a cryptographically random gateway token during reconciliation, stores it in a Secret (`openclaw-secrets`), and injects it as `OPENCLAW_GATEWAY_TOKEN` into the gateway Deployment. The Secret name is written to the CR status (`status.gatewayTokenSecretRef`) so the UI can discover and retrieve it using the user's kube token.
+
+### 2. Credential Provisioning (Q2)
+
+Typed credential CRDs using the `XYZCredential` naming pattern, organized by credential *shape*:
+
+- **`APIKeyCredential`** — Gemini, Anthropic, OpenAI, OpenRouter, etc. Wraps a Secret ref + target domain + header name/format.
+- **`GCPCredential`** — Vertex AI, GCP APIs. Wraps a Secret ref (SA JSON) + project + location + domain.
+- **`BearerTokenCredential`** — GitHub, simple bearer services. Wraps a Secret ref + target domain.
+- Additional CRDs as needed (e.g., `OAuth2Credential`, `ChannelCredential`).
+
+The OpenClaw CR carries no credential fields. The controller discovers credential CRDs in the namespace by label (`openclaw.sandbox.redhat.com/instance: instance`). Adding a new service with an existing auth shape is purely declarative (new CR instance). Adding a new auth shape requires a new CRD + controller logic.
+
+### 3. Credential Injection — Go Proxy (Q7)
+
+Replace the nginx reverse proxy with a purpose-built Go reverse proxy:
+
+```
+OpenClaw ──HTTP──▶ Go Proxy ──HTTPS──▶ LLM APIs / External Services
+                      │
+                      ├─ Config derived from credential CRDs
+                      ├─ Domain → injector routing
+                      ├─ Pluggable injectors: bearer, API key header, GCP ADC/OAuth2
+                      ├─ Strips ALL client auth headers, then injects real credentials
+                      ├─ Health endpoint (/healthz)
+                      └─ Unknown domains → 403
+```
+
+Port paude-proxy's credential injection layer (~500 LOC, MIT-licensed) as a starting point. The proxy derives its routing configuration from the credential CRDs — the operator reads them and generates the proxy's config. Estimated ~800-1000 LOC for the full component.
+
+### 4. Network Isolation (Q3)
+
+Add an **ingress NetworkPolicy** restricting gateway access to the OpenShift router only. The existing egress policies (OpenClaw→proxy, proxy→443) remain unchanged. Additional access for monitoring, logging, etc. is handled by separate NetworkPolicies managed outside the operator — Kubernetes NetworkPolicies are additive (union of all matching rules), so they compose cleanly.
+
+### 5. Container Hardening (Q5)
+
+Two quick wins:
+- **Init container security context** — add explicit `securityContext` matching the main container (required for Pod Security Admission restricted profile)
+- **Route host placeholder** — operator injects the real Route hostname into the ConfigMap during reconciliation, fixing broken CORS `allowedOrigins`
+
+Deferred: image digest pinning (needs CI automation), Route TLS config (cluster-level concern on OpenShift).
+
+### 6. Operator RBAC (Q4)
+
+Deferred until credential CRDs and proxy changes are implemented, since those alter the required permission set. Review and trim to least-privilege at that point.
+
+### 7. Application-Layer Security (Q6)
+
+Document the threat model (prompt injection, excessive agency) and recommended mitigations. Investigate how OpenClaw accesses Kubernetes (ServiceAccount? user's token?) and whether RBAC scoping for the assistant is feasible.
+
+## Target Architecture
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │               User's Namespace              │
+                    │                                             │
+  User ──HTTPS──▶ Route ──▶ OpenClaw Gateway (port 18789)         │
+                    │           │                                 │
+                    │    ┌──────┴──────┐                          │
+                    │    │ Ingress NP: │                          │
+                    │    │ router only │                          │
+                    │    └──────┬──────┘                          │
+                    │           │                                 │
+                    │    ┌──────┴──────┐                          │
+                    │    │ Egress NP:  │                          │
+                    │    │ proxy only  │                          │
+                    │    └──────┬──────┘                          │
+                    │           ▼                                 │
+                    │    Go Credential Proxy                      │
+                    │    ┌──────────────────────────────┐         │
+                    │    │ Config from credential CRDs  │         │
+                    │    │ Strip client auth headers    │         │
+                    │    │ Inject real credentials      │         │
+                    │    │ Unknown domains → 403        │         │
+                    │    └──────┬───────────────────────┘         │
+                    │           │                                 │
+                    │    ┌──────┴──────┐                          │
+                    │    │ Egress NP:  │                          │
+                    │    │ TCP 443+DNS │                          │
+                    │    └──────┬──────┘                          │
+                    │           │                                 │
+                    └───────────┼─────────────────────────────────┘
+                                ▼
+                    LLM APIs, GitHub, Telegram, etc.
+
+
+  CRDs in namespace:
+
+  OpenClaw (instance)           ← no credential fields
+  APIKeyCredential (gemini)     ← secretRef + domain + header
+  APIKeyCredential (anthropic)  ← secretRef + domain + header
+  GCPCredential (vertex-ai)     ← secretRef + project + location
+  BearerTokenCredential (github)← secretRef + domain
+  Secret (openclaw-secrets)     ← auto-generated gateway token
+  Secret (llm-keys)             ← user-created, referenced by credential CRDs
+  Secret (gcp-sa)               ← user-created, referenced by GCPCredential
+```
+
+## Out of Scope
+
+- **Multi-tenancy within a single OpenClaw instance** — one instance per user per namespace
+- **End-to-end encryption (pod-to-pod TLS)** — typical OpenShift deployments trust the SDN
+- **Full agent sandboxing** (gVisor, Kata, custom seccomp) — disproportionate for a personal assistant
+- **LLM-layer defenses** (prompt injection filters, output sanitization) — upstream OpenClaw concern


### PR DESCRIPTION
- Sketch covers 7 security layers: gateway auth, credential provisioning, credential injection proxy, network isolation, container hardening, operator RBAC, and application-layer threats
- Key decisions: typed XYZCredential CRDs by auth shape, purpose-built Go proxy replacing nginx, auto-generated gateway token, ingress NetworkPolicy for the gateway pod
- Questions doc records all options considered, trade-offs, and rationale
