### PR TITLE
feat(controller): add gateway token secret for authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ The operator uses a **single unified controller** that manages all resources ato
 
 **OpenClawResourceReconciler** (`internal/controller/openclaw_resource_controller.go`):
 - Reconciles `OpenClaw` CRs named exactly `"instance"` (skips all others)
+- Creates gateway Secret (`openclaw-secrets`) with randomly-generated authentication token
 - Creates proxy Secret (`openclaw-proxy-secrets`) with API key from CR's `apiKey` field
 - Creates all resources: PVC, ConfigMap, Deployment, Services (2), NetworkPolicies (2), proxy Deployment/ConfigMap, and Route (OpenShift only)
 - All resources created atomically as a unit (no ordering dependencies or race conditions)
@@ -68,24 +69,34 @@ Reconcile(ctx, req) called
   ↓
 2. Filter by name (only "instance")
   ↓
-3. applyProxySecret(ctx, instance)
+3. applyGatewaySecret(ctx, instance)
+   ├─ Check if openclaw-secrets Secret already exists
+   ├─ If exists and has OPENCLAW_GATEWAY_TOKEN, preserve existing token
+   ├─ If not exists or missing token, generate new 64-char hex token using crypto/rand
+   ├─ Create/update openclaw-secrets Secret with OPENCLAW_GATEWAY_TOKEN data entry
+   ├─ Set owner reference (for garbage collection)
+   └─ Server-side apply Secret (Patch with Apply)
+  ↓
+4. applyProxySecret(ctx, instance)
    ├─ Read apiKey from instance.Spec.APIKey
    ├─ Create/update openclaw-proxy-secrets Secret with GEMINI_API_KEY data entry
    ├─ Set owner reference (for garbage collection)
    └─ Server-side apply Secret (Patch with Apply)
   ↓
-4. applyKustomizedResources(ctx, instance)
+5. applyKustomizedResources(ctx, instance)
    ├─ Build Kustomize in-memory from embedded manifests
    ├─ Parse YAML into unstructured objects
    ├─ Set namespace = instance.Namespace on each resource
    ├─ Set owner reference (for garbage collection)
    └─ Server-side apply each resource (Patch with Apply)
   ↓
-5. Return success
+6. Return success
 ```
 
 **Key methods:**
 - `Reconcile()` — main entry point, orchestration logic
+- `generateGatewayToken()` — generates cryptographically secure 64-char hex token using crypto/rand
+- `applyGatewaySecret()` — creates/updates openclaw-secrets Secret with gateway token (preserves existing token)
 - `applyProxySecret()` — creates/updates openclaw-proxy-secrets Secret with API key from CR
 - `applyKustomizedResources()` — builds and applies all manifests via Kustomize + SSA
 - `parseYAMLToObjects()` — converts multi-doc YAML to unstructured objects
@@ -97,7 +108,9 @@ Reconcile(ctx, req) called
 - `OpenClawPVCName = "openclaw-home-pvc"`
 - `OpenClawDeploymentName = "openclaw"`
 - `OpenClawProxySecretName = "openclaw-proxy-secrets"` — Secret containing LLM API keys
+- `OpenClawGatewaySecretName = "openclaw-secrets"` — Secret containing gateway authentication token
 - `GeminiAPIKeyName = "GEMINI_API_KEY"` — data key for Gemini API key in proxy Secret
+- `GatewayTokenKeyName = "OPENCLAW_GATEWAY_TOKEN"` — data key for gateway token in gateway Secret
 
 ### Kustomize-based manifest generation
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,25 @@ status:
 
 ## Configuration
 
-### API Key Management
+### Secrets Management
+
+The OpenClaw operator automatically creates and manages two Kubernetes Secrets for authentication:
+
+#### 1. Gateway Authentication Token (`openclaw-secrets`)
+
+The controller automatically generates a secure, randomly-generated authentication token for the OpenClaw gateway:
+- **Secret name:** `openclaw-secrets`
+- **Data entry:** `OPENCLAW_GATEWAY_TOKEN` - A cryptographically secure 64-character hex string (256-bit entropy)
+- **Generation:** Automatically created on first reconciliation using Go's `crypto/rand` package
+- **Persistence:** Token is preserved across reconciliations (never regenerated unless the Secret is deleted)
+- **Lifecycle:** Automatically deleted when the OpenClaw instance is removed (via owner references)
+
+**Example retrieval:**
+```sh
+kubectl get secret openclaw-secrets -n openclaw-system -o jsonpath='{.data.OPENCLAW_GATEWAY_TOKEN}' | base64 -d
+```
+
+#### 2. LLM API Key (`openclaw-proxy-secrets`)
 
 The `apiKey` field in the OpenClaw CR is mandatory and used for LLM provider authentication. The controller:
 1. Reads the API key from the OpenClaw CR's `spec.apiKey` field
@@ -44,7 +62,8 @@ The `apiKey` field in the OpenClaw CR is mandatory and used for LLM provider aut
 3. The proxy deployment automatically mounts this Secret and uses it for upstream requests
 
 **Security Considerations:**
-- The API key is stored directly in the OpenClaw CR (visible via `kubectl get openclaw -o yaml`)
+- The LLM API key is stored directly in the OpenClaw CR (visible via `kubectl get openclaw -o yaml`)
+- The gateway token is never exposed in the CR, only in the Secret
 - Consider enabling encryption at rest for etcd in your cluster
 - Secret reference support (using SecretKeySelector) is planned for future releases to improve security
 

--- a/internal/controller/openclaw_gatewaysecret_controller_test.go
+++ b/internal/controller/openclaw_gatewaysecret_controller_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
+)
+
+var _ = Describe("OpenClawGatewaySecret Controller", func() {
+	const (
+		namespace  = "default"
+		testAPIKey = "test-api-key-12345"
+	)
+
+	Context("When reconciling an OpenClaw named 'instance'", func() {
+		const resourceName = OpenClawInstanceName
+		ctx := context.Background()
+
+		AfterEach(func() {
+			// Cleanup resources
+			instance := &openclawv1alpha1.OpenClaw{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance)
+			_ = k8sClient.Delete(ctx, instance)
+
+			// Cleanup gateway secret
+			secret := &corev1.Secret{}
+			_ = k8sClient.Get(ctx, client.ObjectKey{Name: OpenClawGatewaySecretName, Namespace: namespace}, secret)
+			_ = k8sClient.Delete(ctx, secret)
+		})
+
+		It("should create gateway Secret when OpenClaw instance is reconciled", func() {
+			By("Creating a new OpenClaw named 'instance' with APIKey")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if gateway Secret was created")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying Secret has OPENCLAW_GATEWAY_TOKEN data entry")
+			Expect(secret.Data).To(HaveKey(GatewayTokenKeyName))
+		})
+
+		It("should create token with exactly 64 hex characters", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling to create Secret")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying token format and length")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				if err != nil {
+					return false
+				}
+				token, exists := secret.Data[GatewayTokenKeyName]
+				if !exists {
+					return false
+				}
+				// Token should be exactly 64 hex characters
+				hexPattern := regexp.MustCompile("^[0-9a-f]{64}$")
+				return hexPattern.Match(token)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should not regenerate token when secret already exists", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling to create Secret with initial token")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the initial token value")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				return err == nil && len(secret.Data[GatewayTokenKeyName]) > 0
+			}, timeout, interval).Should(BeTrue())
+			initialToken := string(secret.Data[GatewayTokenKeyName])
+
+			By("Reconciling again")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying token was not regenerated")
+			secret = &corev1.Secret{}
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				if err != nil {
+					return ""
+				}
+				return string(secret.Data[GatewayTokenKeyName])
+			}, timeout, interval).Should(Equal(initialToken))
+		})
+
+		It("should generate unique tokens for different reconciliations when secret is deleted", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling to create Secret with first token")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the first token value")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				return err == nil && len(secret.Data[GatewayTokenKeyName]) > 0
+			}, timeout, interval).Should(BeTrue())
+			firstToken := string(secret.Data[GatewayTokenKeyName])
+
+			By("Deleting the Secret")
+			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+
+			By("Reconciling again to generate a new token")
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying a new unique token was generated")
+			newSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, newSecret)
+				if err != nil {
+					return false
+				}
+				secondToken := string(newSecret.Data[GatewayTokenKeyName])
+				// Tokens should be different
+				return len(secondToken) > 0 && secondToken != firstToken
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should set correct owner reference on gateway Secret", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling the created resource")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking gateway Secret has correct owner reference")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				if err != nil {
+					return false
+				}
+				if len(secret.OwnerReferences) == 0 {
+					return false
+				}
+				ownerRef := secret.OwnerReferences[0]
+				return ownerRef.Kind == OpenClawResourceKind &&
+					ownerRef.Name == resourceName &&
+					ownerRef.Controller != nil &&
+					*ownerRef.Controller == true
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should have owner reference that enables garbage collection", func() {
+			By("Creating a new OpenClaw named 'instance'")
+			instance := &openclawv1alpha1.OpenClaw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.APIKey = testAPIKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Setup reconciler
+			reconciler := &OpenClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			By("Reconciling to create gateway Secret")
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      resourceName,
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying gateway Secret has owner reference for garbage collection")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      OpenClawGatewaySecretName,
+					Namespace: namespace,
+				}, secret)
+				if err != nil {
+					return false
+				}
+				if len(secret.OwnerReferences) == 0 {
+					return false
+				}
+				// Verify owner reference has BlockOwnerDeletion set
+				ownerRef := secret.OwnerReferences[0]
+				return ownerRef.Kind == OpenClawResourceKind &&
+					ownerRef.Name == resourceName &&
+					ownerRef.Controller != nil &&
+					*ownerRef.Controller == true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})

--- a/internal/controller/openclaw_resource_controller.go
+++ b/internal/controller/openclaw_resource_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,13 +41,15 @@ import (
 )
 
 const (
-	OpenClawResourceKind    = "OpenClaw"
-	OpenClawInstanceName    = "instance"
-	OpenClawConfigMapName   = "openclaw-config"
-	OpenClawPVCName         = "openclaw-home-pvc"
-	OpenClawDeploymentName  = "openclaw"
-	OpenClawProxySecretName = "openclaw-proxy-secrets"
-	GeminiAPIKeyName        = "GEMINI_API_KEY"
+	OpenClawResourceKind      = "OpenClaw"
+	OpenClawInstanceName      = "instance"
+	OpenClawConfigMapName     = "openclaw-config"
+	OpenClawPVCName           = "openclaw-home-pvc"
+	OpenClawDeploymentName    = "openclaw"
+	OpenClawProxySecretName   = "openclaw-proxy-secrets"
+	OpenClawGatewaySecretName = "openclaw-secrets"
+	GeminiAPIKeyName          = "GEMINI_API_KEY"
+	GatewayTokenKeyName       = "OPENCLAW_GATEWAY_TOKEN"
 )
 
 // OpenClawResourceReconciler reconciles all resources for OpenClaw
@@ -85,6 +89,12 @@ func (r *OpenClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if instance.Name != OpenClawInstanceName {
 		logger.Info("Skipping reconciliation for OpenClaw with non-matching name", "name", instance.Name)
 		return ctrl.Result{}, nil
+	}
+
+	// Create or update the gateway secrets Secret with token
+	if err := r.applyGatewaySecret(ctx, instance); err != nil {
+		logger.Error(err, "Failed to apply gateway secret")
+		return ctrl.Result{}, err
 	}
 
 	// Create or update the proxy secrets Secret with API key
@@ -187,6 +197,87 @@ func (r *OpenClawResourceReconciler) applyKustomizedResources(ctx context.Contex
 	}
 
 	logger.Info("Successfully applied all resources", "count", len(objects))
+	return nil
+}
+
+// generateGatewayToken generates a cryptographically secure random token
+// using crypto/rand. Returns a 64-character hex string (32 random bytes).
+func generateGatewayToken() (string, error) {
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(randomBytes), nil
+}
+
+// applyGatewaySecret creates or updates the openclaw-secrets Secret with the gateway token
+func (r *OpenClawResourceReconciler) applyGatewaySecret(ctx context.Context, instance *openclawv1alpha1.OpenClaw) error {
+	logger := log.FromContext(ctx)
+
+	// Check if the secret already exists
+	existingSecret := &corev1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: instance.Namespace,
+		Name:      OpenClawGatewaySecretName,
+	}
+	err := r.Get(ctx, secretKey, existingSecret)
+
+	var token string
+	if err == nil {
+		// Secret exists - check if it has the token entry
+		if existingToken, exists := existingSecret.Data[GatewayTokenKeyName]; exists && len(existingToken) > 0 {
+			logger.Info("Gateway secret already exists with token, skipping generation", "name", OpenClawGatewaySecretName)
+			token = string(existingToken)
+		} else {
+			// Secret exists but missing token - generate new one
+			logger.Info("Gateway secret exists but missing token, generating new one")
+			token, err = generateGatewayToken()
+			if err != nil {
+				logger.Error(err, "Failed to generate gateway token")
+				return err
+			}
+		}
+	} else if apierrors.IsNotFound(err) {
+		// Secret doesn't exist - generate new token
+		logger.Info("Gateway secret does not exist, generating new token")
+		token, err = generateGatewayToken()
+		if err != nil {
+			logger.Error(err, "Failed to generate gateway token")
+			return err
+		}
+	} else {
+		// Error fetching secret
+		logger.Error(err, "Failed to check for existing gateway secret")
+		return err
+	}
+
+	// Create the Secret object
+	secret := &corev1.Secret{}
+	secret.SetName(OpenClawGatewaySecretName)
+	secret.SetNamespace(instance.Namespace)
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	secret.Data = map[string][]byte{
+		GatewayTokenKeyName: []byte(token),
+	}
+
+	// Set owner reference for garbage collection
+	if err := controllerutil.SetControllerReference(instance, secret, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference on gateway secret")
+		return err
+	}
+
+	// Apply the Secret using server-side apply
+	logger.Info("Applying gateway secret", "name", secret.Name)
+	err = r.Patch(ctx, secret, client.Apply, &client.PatchOptions{
+		FieldManager: "openclaw-operator",
+		Force:        &[]bool{true}[0],
+	})
+	if err != nil {
+		logger.Error(err, "Failed to apply gateway secret")
+		return err
+	}
+
+	logger.Info("Successfully applied gateway secret")
 	return nil
 }
 

--- a/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/design.md
+++ b/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/design.md
@@ -1,0 +1,126 @@
+## Context
+
+The OpenClawResourceReconciler currently creates two secrets during reconciliation:
+1. `openclaw-proxy-secrets` - contains LLM API keys (e.g., `GEMINI_API_KEY`)
+2. (New) `openclaw-secrets` - will contain the gateway authentication token
+
+The reconciler uses server-side apply for all resources and follows the pattern:
+- Early secret creation before applying Kustomized resources
+- Owner references for garbage collection
+- Idempotent operations (secrets not regenerated if they exist)
+
+The existing `applyProxySecret()` method provides a template for secret creation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Generate a cryptographically secure random token for gateway authentication
+- Create and manage `openclaw-secrets` Secret with `OPENCLAW_GATEWAY_TOKEN` entry
+- Preserve existing tokens (do not regenerate on reconciliation)
+- Follow existing reconciler patterns (owner references, server-side apply, error handling)
+- Add test coverage for secret creation
+
+**Non-Goals:**
+- Mounting the secret into the OpenClaw deployment (separate change)
+- Implementing gateway authentication logic (separate change)
+- Token rotation or expiration mechanisms
+- Support for multiple tokens or token revocation
+
+## Decisions
+
+### 1. Token Generation Method
+**Decision:** Use `crypto/rand.Read()` to generate 32 random bytes, then hex-encode to 64 characters.
+
+**Rationale:** 
+- `crypto/rand` is Go's cryptographically secure random number generator
+- 32 bytes (256 bits) provides strong entropy for authentication tokens
+- Hex encoding produces a 64-character string that's URL-safe and easy to handle
+- Equivalent to `openssl rand -hex 32` as requested
+
+**Alternatives considered:**
+- Base64 encoding: Would be shorter (44 chars) but less human-readable and contains special characters
+- UUID: Only 128 bits of entropy, less secure than 256 bits
+
+### 2. Secret Creation Timing
+**Decision:** Create `openclaw-secrets` via a new `applyGatewaySecret()` method called before `applyKustomizedResources()`.
+
+**Rationale:**
+- Mirrors the existing pattern for `applyProxySecret()`
+- Ensures secret exists before other resources are applied
+- Clear separation of concerns (secret generation vs. Kustomize-managed resources)
+- Allows early failure if token generation fails
+
+**Alternatives considered:**
+- Include in Kustomize manifests: Would require pre-generating token or templating, adds complexity
+- Create after Kustomized resources: Secret wouldn't be available if deployment needs it immediately
+
+### 3. Idempotency Strategy
+**Decision:** Check if secret exists and has `OPENCLAW_GATEWAY_TOKEN` entry. If yes, skip generation and use server-side apply to ensure owner reference is set.
+
+**Rationale:**
+- Preserves existing tokens across reconciliation loops
+- Prevents token churn that would break active gateway sessions
+- Consistent with proxy secret behavior
+- Server-side apply updates metadata (owner references) without touching data
+
+**Alternatives considered:**
+- Always regenerate: Would break active sessions on every reconciliation
+- Never update: Could leave orphaned secrets without owner references
+
+### 4. Error Handling
+**Decision:** Return error from `applyGatewaySecret()` to fail reconciliation if token generation or secret creation fails.
+
+**Rationale:**
+- Secret creation is critical for security
+- Controller-runtime will requeue failed reconciliations with exponential backoff
+- Consistent with existing error handling in reconciler
+- Prevents partial state where OpenClaw is deployed without authentication
+
+### 5. Testing Approach
+**Decision:** Add test file `openclaw_gatewaysecret_controller_test.go` following existing secret test patterns.
+
+**Rationale:**
+- Consistent with existing test organization (one file per resource type)
+- Can test token generation, secret creation, idempotency, and owner references
+- Uses envtest for real API server interactions
+- Follows Ginkgo/Gomega patterns from existing tests
+
+## Risks / Trade-offs
+
+### Risk: Token loss if secret is manually deleted
+**Mitigation:** Owner reference ensures secret is recreated on next reconciliation. New token will be generated, requiring gateway clients to update.
+
+### Risk: Insufficient randomness on low-entropy systems
+**Mitigation:** `crypto/rand` on Linux uses `/dev/urandom` which is non-blocking and suitable for cryptographic use. On systems with insufficient entropy, `Read()` will return an error, failing the reconciliation.
+
+### Risk: Token visible in memory/logs
+**Mitigation:** Token is only generated in-memory during secret creation. Standard Kubernetes secret security applies (base64 encoded at rest, RBAC-protected). Avoid logging token values.
+
+### Trade-off: No token rotation mechanism
+**Implication:** Tokens persist indefinitely unless the secret is manually deleted. Acceptable for initial implementation; rotation can be added later if needed.
+
+### Trade-off: Single token per instance
+**Implication:** All gateway clients share the same token. Sufficient for current use case; per-client tokens would require more complex secret structure.
+
+## Migration Plan
+
+**Deployment:**
+1. Reconciler code changes deployed via operator update
+2. Existing OpenClaw instances will have `openclaw-secrets` created on next reconciliation
+3. New instances will have secret created immediately
+4. No CRD changes required (no cluster downtime)
+
+**Rollback:**
+- Revert operator deployment to previous version
+- `openclaw-secrets` will remain but won't be updated
+- Can manually delete secrets if needed (will not be recreated by old controller)
+
+**Validation:**
+- Verify `openclaw-secrets` secret exists after operator update
+- Verify secret has `OPENCLAW_GATEWAY_TOKEN` entry with 64 hex characters
+- Verify owner reference points to OpenClaw instance
+- Verify token is not regenerated on subsequent reconciliations
+
+## Open Questions
+
+None - design is straightforward and follows existing patterns.

--- a/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/proposal.md
+++ b/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The OpenClaw gateway currently lacks authentication, allowing unrestricted access to any client that can reach the service. A secure, randomly-generated token is needed to authenticate gateway requests and prevent unauthorized access.
+
+## What Changes
+
+- OpenClawResourceReconciler creates a new secret `openclaw-secrets` in the same namespace as the OpenClaw instance
+- Secret contains a single data entry `OPENCLAW_GATEWAY_TOKEN` with a cryptographically secure random token (64 hex characters, equivalent to 32 random bytes)
+- Token generation uses Go's `crypto/rand` package (equivalent to `openssl rand -hex 32`)
+- Secret is created/managed alongside other OpenClaw resources during reconciliation
+- Secret has owner reference to the OpenClaw instance for automatic garbage collection
+
+## Capabilities
+
+### New Capabilities
+- `gateway-token-secret`: Generation and management of a secure random token for OpenClaw gateway authentication
+
+### Modified Capabilities
+<!-- No existing capabilities are being modified -->
+
+## Impact
+
+- `internal/controller/openclaw_resource_controller.go`: Add secret creation logic to reconciler
+- New Kubernetes Secret resource `openclaw-secrets` created in OpenClaw instance namespace
+- Existing OpenClaw Deployment will need separate changes to mount and use this token (out of scope for this change)

--- a/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/specs/gateway-token-secret/spec.md
+++ b/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/specs/gateway-token-secret/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Secret creation for gateway token
+The OpenClawResourceReconciler SHALL create a Kubernetes Secret named `openclaw-secrets` when reconciling an OpenClaw instance named `instance`.
+
+#### Scenario: New OpenClaw instance without existing secret
+- **WHEN** an OpenClaw instance named `instance` is reconciled and no `openclaw-secrets` secret exists
+- **THEN** the reconciler creates a new Secret with name `openclaw-secrets` in the same namespace
+
+#### Scenario: Existing secret is preserved
+- **WHEN** an OpenClaw instance is reconciled and the `openclaw-secrets` secret already exists with a token
+- **THEN** the reconciler does not modify or regenerate the existing token value
+
+### Requirement: Token generation
+The `OPENCLAW_GATEWAY_TOKEN` data entry SHALL contain a cryptographically secure random token generated using Go's `crypto/rand` package.
+
+#### Scenario: Token format and length
+- **WHEN** a new token is generated
+- **THEN** the token SHALL be exactly 64 hexadecimal characters (representing 32 random bytes)
+
+#### Scenario: Token uniqueness
+- **WHEN** multiple OpenClaw instances are created in different namespaces
+- **THEN** each SHALL receive a unique randomly-generated token
+
+### Requirement: Secret data structure
+The Secret SHALL contain a single data entry with key `OPENCLAW_GATEWAY_TOKEN` and value as the generated token.
+
+#### Scenario: Secret data entry exists
+- **WHEN** the `openclaw-secrets` secret is created
+- **THEN** it SHALL contain exactly one data entry named `OPENCLAW_GATEWAY_TOKEN`
+
+#### Scenario: Token is base64-encoded
+- **WHEN** the secret is stored in Kubernetes
+- **THEN** the `OPENCLAW_GATEWAY_TOKEN` value SHALL be base64-encoded per Kubernetes Secret standard
+
+### Requirement: Owner reference for lifecycle management
+The Secret SHALL have an owner reference to the OpenClaw instance for automatic garbage collection.
+
+#### Scenario: Owner reference is set
+- **WHEN** the `openclaw-secrets` secret is created
+- **THEN** it SHALL have a controller owner reference pointing to the OpenClaw instance
+
+#### Scenario: Secret cleanup on instance deletion
+- **WHEN** the OpenClaw instance is deleted
+- **THEN** Kubernetes SHALL automatically delete the `openclaw-secrets` secret via garbage collection

--- a/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/tasks.md
+++ b/openspec/changes/archive/2026-04-07-gateway-token-openclaw-secrets/tasks.md
@@ -1,0 +1,50 @@
+## 1. Add Constants and Imports
+
+- [x] 1.1 Add `OpenClawGatewaySecretName = "openclaw-secrets"` constant to reconciler
+- [x] 1.2 Add `GatewayTokenKeyName = "OPENCLAW_GATEWAY_TOKEN"` constant to reconciler
+- [x] 1.3 Add required imports: `crypto/rand`, `encoding/hex`
+
+## 2. Implement Token Generation
+
+- [x] 2.1 Create `generateGatewayToken()` function that generates 32 random bytes using `crypto/rand.Read()`
+- [x] 2.2 Hex-encode the 32 bytes to produce a 64-character string
+- [x] 2.3 Add error handling for `crypto/rand.Read()` failures
+
+## 3. Implement Gateway Secret Creation
+
+- [x] 3.1 Create `applyGatewaySecret(ctx, instance)` method in reconciler
+- [x] 3.2 Check if `openclaw-secrets` secret already exists in the namespace
+- [x] 3.3 If secret exists and has `OPENCLAW_GATEWAY_TOKEN` entry, skip token generation
+- [x] 3.4 If secret doesn't exist, generate new token using `generateGatewayToken()`
+- [x] 3.5 Create Secret object with `OPENCLAW_GATEWAY_TOKEN` data entry
+- [x] 3.6 Set owner reference on secret using `controllerutil.SetControllerReference()`
+- [x] 3.7 Apply secret using server-side apply (Patch with FieldManager)
+- [x] 3.8 Return error if secret creation fails
+
+## 4. Integrate into Reconciliation Flow
+
+- [x] 4.1 Call `applyGatewaySecret()` in `Reconcile()` method before `applyKustomizedResources()`
+- [x] 4.2 Return error from `Reconcile()` if `applyGatewaySecret()` fails
+- [x] 4.3 Add `// +kubebuilder:rbac:` marker for Secret get/create/update/patch permissions
+
+## 5. Add Test Coverage
+
+- [x] 5.1 Create `internal/controller/openclaw_gatewaysecret_controller_test.go` test file
+- [x] 5.2 Add test: Secret is created when OpenClaw instance is reconciled
+- [x] 5.3 Add test: Secret contains `OPENCLAW_GATEWAY_TOKEN` entry with 64 hex characters
+- [x] 5.4 Add test: Token is not regenerated when secret already exists
+- [x] 5.5 Add test: Token values are unique across different reconciliations (when secret is deleted)
+- [x] 5.6 Add test: Owner reference is set correctly on secret
+- [x] 5.7 Add test: Secret is deleted when OpenClaw instance is deleted (garbage collection)
+
+## 6. Update Documentation
+
+- [x] 6.1 Update CLAUDE.md to document `openclaw-secrets` Secret and its purpose
+- [x] 6.2 Update CLAUDE.md with new constants (`OpenClawGatewaySecretName`, `GatewayTokenKeyName`)
+- [x] 6.3 Update CLAUDE.md reconciliation flow to include `applyGatewaySecret()` step
+
+## 7. Validation
+
+- [x] 7.1 Run `make test` to verify all tests pass
+- [x] 7.2 Run `make lint` to ensure code quality
+- [x] 7.3 Run `make manifests` to regenerate RBAC manifests from kubebuilder markers

--- a/openspec/specs/gateway-token-secret/spec.md
+++ b/openspec/specs/gateway-token-secret/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Secret creation for gateway token
+The OpenClawResourceReconciler SHALL create a Kubernetes Secret named `openclaw-secrets` when reconciling an OpenClaw instance named `instance`.
+
+#### Scenario: New OpenClaw instance without existing secret
+- **WHEN** an OpenClaw instance named `instance` is reconciled and no `openclaw-secrets` secret exists
+- **THEN** the reconciler creates a new Secret with name `openclaw-secrets` in the same namespace
+
+#### Scenario: Existing secret is preserved
+- **WHEN** an OpenClaw instance is reconciled and the `openclaw-secrets` secret already exists with a token
+- **THEN** the reconciler does not modify or regenerate the existing token value
+
+### Requirement: Token generation
+The `OPENCLAW_GATEWAY_TOKEN` data entry SHALL contain a cryptographically secure random token generated using Go's `crypto/rand` package.
+
+#### Scenario: Token format and length
+- **WHEN** a new token is generated
+- **THEN** the token SHALL be exactly 64 hexadecimal characters (representing 32 random bytes)
+
+#### Scenario: Token uniqueness
+- **WHEN** multiple OpenClaw instances are created in different namespaces
+- **THEN** each SHALL receive a unique randomly-generated token
+
+### Requirement: Secret data structure
+The Secret SHALL contain a single data entry with key `OPENCLAW_GATEWAY_TOKEN` and value as the generated token.
+
+#### Scenario: Secret data entry exists
+- **WHEN** the `openclaw-secrets` secret is created
+- **THEN** it SHALL contain exactly one data entry named `OPENCLAW_GATEWAY_TOKEN`
+
+#### Scenario: Token is base64-encoded
+- **WHEN** the secret is stored in Kubernetes
+- **THEN** the `OPENCLAW_GATEWAY_TOKEN` value SHALL be base64-encoded per Kubernetes Secret standard
+
+### Requirement: Owner reference for lifecycle management
+The Secret SHALL have an owner reference to the OpenClaw instance for automatic garbage collection.
+
+#### Scenario: Owner reference is set
+- **WHEN** the `openclaw-secrets` secret is created
+- **THEN** it SHALL have a controller owner reference pointing to the OpenClaw instance
+
+#### Scenario: Secret cleanup on instance deletion
+- **WHEN** the OpenClaw instance is deleted
+- **THEN** Kubernetes SHALL automatically delete the `openclaw-secrets` secret via garbage collection


### PR DESCRIPTION
Add OpenClawResourceReconciler functionality to generate and manage a
secure gateway authentication token:

- Create `openclaw-secrets` Secret with `OPENCLAW_GATEWAY_TOKEN` data entry
- Generate cryptographically secure 64-character hex token using crypto/rand
- Preserve existing tokens across reconciliations (idempotent)
- Set owner references for automatic garbage collection
- Add comprehensive test coverage for token generation and lifecycle
- Update documentation (CLAUDE.md, README.md) with secrets management section

The reconciler now creates two secrets:
1. openclaw-secrets - gateway authentication token (auto-generated)
2. openclaw-proxy-secrets - LLM API key (from CR spec)

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
