### PR TITLE
feat(operator): add version and build time logging at startup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,16 @@
       "Bash(go clean:*)",
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test ./internal/controller/...)",
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.33.0-darwin-arm64\" go test ./internal/controller/... -run \"Deployment\")",
-      "Bash(git mv:*)"
+      "Bash(git mv:*)",
+      "Bash(timeout 5 go run ./cmd/main.go)",
+      "Bash(timeout 3 ./bin/manager)",
+      "Bash(make docker-build:*)",
+      "Bash(timeout 5 podman run --rm openclaw-operator:test-version)",
+      "Bash(podman create:*)",
+      "Bash(podman cp:*)",
+      "Bash(podman rm:*)",
+      "Bash(chmod +x ./manager-test)",
+      "Bash(timeout 3 ./manager-test)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
 **CRD Spec Fields:**
 - `apiKey` (string, required): API key for LLM provider authentication (currently Gemini). Injected into `openclaw-proxy-secrets` Secret under `GEMINI_API_KEY` data entry.
 
+**Version Logging:**
+The operator logs version and build time at startup: `version` (short commit SHA) and `buildTime` (RFC3339). Injected via LDFLAGS during `docker-build`. Local builds show defaults (`dev`/`unknown`).
+
 ## Common Commands
 
 ```bash
@@ -146,7 +149,7 @@ The `internal/assets/manifests/` directory contains:
 - `api/v1alpha1/` — CRD type definitions (OpenClawSpec, OpenClawStatus)
 - `internal/controller/` — OpenClawReconciler implementation and tests (separate test files per resource type for readability)
 - `internal/assets/manifests/` — Embedded Kustomize directory with all manifests (10 total: kustomization.yaml, core resources, networking, and proxy components)
-- `cmd/main.go` — Manager entrypoint, wires up the unified OpenClawReconciler
+- `cmd/main.go` — Manager entrypoint, wires up the unified OpenClawReconciler. Contains package-level `version` and `buildTime` variables set via LDFLAGS during build, logged at startup
 - `config/` — Kustomize overlays for CRDs, RBAC, manager deployment
 
 ### Code generation

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG BUILD_TIME=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +23,9 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
+	-ldflags "-X main.version=${VERSION} -X main.buildTime=${BUILD_TIME}" \
+	-o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} --platform $(PLATFORM) .
+	$(CONTAINER_TOOL) build -t ${IMG} --platform $(PLATFORM) \
+		--build-arg VERSION=$$(git rev-parse --short HEAD) \
+		--build-arg BUILD_TIME=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ spec:
   apiKey: "AIzaSyD-your-actual-gemini-api-key-here"
 ```
 
+## Version Information
+
+The operator logs its version and build time during startup for troubleshooting and deployment tracking:
+
+```
+INFO	setup	Starting OpenClaw Operator	{"version": "fc7c72b0", "buildTime": "2026-04-07T13:17:26Z"}
+```
+
+**Version fields:**
+- `version`: Short commit SHA (7 characters) of the source code used to build the binary
+- `buildTime`: RFC3339 timestamp indicating when the binary was built
+
+**How it works:**
+- Version information is injected at build time via LDFLAGS in the `docker-build` Makefile target
+- Local development builds (e.g., `make run`) show default values: `version="dev"` and `buildTime="unknown"`
+- Production container builds automatically capture the git commit SHA and build timestamp
+
+This allows operators to quickly identify which version is running in any environment by checking the startup logs.
+
 ## Getting Started
 
 ### Prerequisites

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,10 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// version and buildTime are set via LDFLAGS during build
+	version   = "dev"
+	buildTime = "unknown"
 )
 
 func init() {
@@ -236,7 +240,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("Starting OpenClaw Operator", "version", version, "buildTime", buildTime)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/openspec/changes/archive/2026-04-07-log-commit-version/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-log-commit-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/openspec/changes/archive/2026-04-07-log-commit-version/design.md
+++ b/openspec/changes/archive/2026-04-07-log-commit-version/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The operator currently has no built-in version identification mechanism. During troubleshooting, it's difficult to determine which exact commit is running in production. This design adds version logging to show commit SHA and build time during startup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display commit SHA (short format) and build time in startup logs
+- Inject version info at build time via LDFLAGS (no runtime overhead)
+- Keep implementation simple and maintainable
+
+**Non-Goals:**
+- Version API endpoints or metrics (can be added later if needed)
+- Semantic versioning (git commit SHA is sufficient for operator deployment tracking)
+- Runtime version detection (build-time injection only)
+
+## Decisions
+
+### Use LDFLAGS for version injection
+
+**Decision:** Inject commit SHA and build time as string variables via `go build -ldflags` in the Makefile.
+
+**Rationale:** 
+- Standard Go practice for embedding build metadata
+- Zero runtime cost (values compiled into binary)
+- Already using `docker-build` target in Makefile, easy integration
+
+**Alternatives considered:**
+- Runtime git commands: rejected due to requiring git in production image
+- VERSION file: rejected due to needing manual updates and sync overhead
+
+### Variable placement in cmd/main.go
+
+**Decision:** Define package-level variables `version` and `buildTime` in `cmd/main.go`.
+
+**Rationale:**
+- `main` package is the entry point, natural place for startup logging
+- Package-level variables are easily set via LDFLAGS with `-X` flag
+- No need for separate version package for this simple use case
+
+### Log format
+
+**Decision:** Log version info as structured log entry before manager starts, format: `"Starting OpenClaw Operator" version=<sha> buildTime=<timestamp>`.
+
+**Rationale:**
+- Uses existing logger from controller-runtime
+- Parseable by log aggregation tools
+- Visible in both local dev and production logs
+
+### Commit SHA format
+
+**Decision:** Use short commit SHA (7 characters) via `git rev-parse --short HEAD`.
+
+**Rationale:**
+- Sufficient uniqueness for operator builds (low collision risk in single repo)
+- More readable in logs than full 40-char SHA
+- Standard format used by GitHub UI and git tooling
+
+### Build time format
+
+**Decision:** Use RFC3339 timestamp via `date -u +"%Y-%m-%dT%H:%M:%SZ"`.
+
+**Rationale:**
+- Unambiguous (includes timezone, UTC)
+- Human-readable
+- Machine-parseable
+
+## Risks / Trade-offs
+
+**[Risk: LDFLAGS not set in local builds]** → Document in CLAUDE.md that local `make run` won't show version. Acceptable trade-off since version is most critical in container deployments.
+
+**[Risk: Build time reflects build machine time, not git commit time]** → Accepted. Build time indicates when binary was created, which is useful for staleness detection.
+
+**[Trade-off: No semantic versioning]** → Commit SHA is sufficient for debugging. If semantic versions are needed later, can add alongside commit info.

--- a/openspec/changes/archive/2026-04-07-log-commit-version/proposal.md
+++ b/openspec/changes/archive/2026-04-07-log-commit-version/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+During troubleshooting and debugging, it's critical to know which exact version of the operator is running. Currently, there's no easy way to correlate a running operator instance with the source commit that built it.
+
+## What Changes
+
+- Add version logging during operator startup that displays commit SHA and build time
+- Inject version information via LDFLAGS in the Makefile's `docker-build` target
+- Log version information in `cmd/main.go` before starting the manager
+
+## Capabilities
+
+### New Capabilities
+- `version-logging`: Display commit SHA and build time during operator startup
+
+### Modified Capabilities
+<!-- No existing capabilities being modified -->
+
+## Impact
+
+- `cmd/main.go` — add version variables and log statement during startup
+- `Makefile` — modify `docker-build` target to inject version info via LDFLAGS
+- No breaking changes
+- No API changes
+- Improves operational visibility and debugging

--- a/openspec/changes/archive/2026-04-07-log-commit-version/specs/version-logging/spec.md
+++ b/openspec/changes/archive/2026-04-07-log-commit-version/specs/version-logging/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Version information variables
+The operator SHALL define variables for commit SHA and build time that can be populated via LDFLAGS during build.
+
+#### Scenario: Variables defined at package level
+- **WHEN** the operator binary is built
+- **THEN** commit SHA and build time variables exist and can be set via LDFLAGS
+
+### Requirement: Version information logging
+The operator SHALL log the commit SHA and build time during startup before starting the manager.
+
+#### Scenario: Startup logging with version info
+- **WHEN** the operator starts
+- **THEN** a log message displays the commit SHA and build time
+
+#### Scenario: Logging when version info not set
+- **WHEN** the operator starts without LDFLAGS set
+- **THEN** a log message indicates version information is not available or shows default values
+
+### Requirement: LDFLAGS injection in build
+The Makefile's docker-build target SHALL inject commit SHA and build time via LDFLAGS.
+
+#### Scenario: Docker build with version info
+- **WHEN** running make docker-build
+- **THEN** the build command includes LDFLAGS for commit SHA and build time
+
+#### Scenario: Commit SHA format
+- **WHEN** injecting commit SHA
+- **THEN** the value SHALL be the short commit SHA (7 characters) from git
+
+#### Scenario: Build time format
+- **WHEN** injecting build time
+- **THEN** the value SHALL be in RFC3339 format or similar human-readable timestamp

--- a/openspec/changes/archive/2026-04-07-log-commit-version/tasks.md
+++ b/openspec/changes/archive/2026-04-07-log-commit-version/tasks.md
@@ -1,0 +1,17 @@
+## 1. Add version variables to cmd/main.go
+
+- [x] 1.1 Define package-level `version` variable (string, default "dev")
+- [x] 1.2 Define package-level `buildTime` variable (string, default "unknown")
+- [x] 1.3 Add log statement in main() before manager start that outputs version and buildTime
+
+## 2. Update Makefile to inject version info
+
+- [x] 2.1 Modify docker-build target to capture commit SHA using `git rev-parse --short HEAD`
+- [x] 2.2 Modify docker-build target to capture build time using `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+- [x] 2.3 Add LDFLAGS to go build command with -X flags for version and buildTime variables
+
+## 3. Testing and verification
+
+- [x] 3.1 Test local build with `make docker-build` and verify version info in image
+- [x] 3.2 Verify log output shows commit SHA and build time when operator starts
+- [x] 3.3 Verify graceful handling when LDFLAGS not set (shows default values)

--- a/openspec/specs/version-logging/spec.md
+++ b/openspec/specs/version-logging/spec.md
@@ -1,0 +1,38 @@
+# version-logging Specification
+
+## Purpose
+TBD - created by archiving change log-commit-version. Update Purpose after archive.
+## Requirements
+### Requirement: Version information variables
+The operator SHALL define variables for commit SHA and build time that can be populated via LDFLAGS during build.
+
+#### Scenario: Variables defined at package level
+- **WHEN** the operator binary is built
+- **THEN** commit SHA and build time variables exist and can be set via LDFLAGS
+
+### Requirement: Version information logging
+The operator SHALL log the commit SHA and build time during startup before starting the manager.
+
+#### Scenario: Startup logging with version info
+- **WHEN** the operator starts
+- **THEN** a log message displays the commit SHA and build time
+
+#### Scenario: Logging when version info not set
+- **WHEN** the operator starts without LDFLAGS set
+- **THEN** a log message indicates version information is not available or shows default values
+
+### Requirement: LDFLAGS injection in build
+The Makefile's docker-build target SHALL inject commit SHA and build time via LDFLAGS.
+
+#### Scenario: Docker build with version info
+- **WHEN** running make docker-build
+- **THEN** the build command includes LDFLAGS for commit SHA and build time
+
+#### Scenario: Commit SHA format
+- **WHEN** injecting commit SHA
+- **THEN** the value SHALL be the short commit SHA (7 characters) from git
+
+#### Scenario: Build time format
+- **WHEN** injecting build time
+- **THEN** the value SHALL be in RFC3339 format or similar human-readable timestamp
+


### PR DESCRIPTION
Display commit SHA and build timestamp in operator startup logs to improve
troubleshooting and deployment tracking. Version information is injected at
build time via LDFLAGS.

Changes:
- Add version and buildTime package variables to cmd/main.go (defaults: "dev",
"unknown")
- Log version info at startup before manager starts
- Update Dockerfile to accept VERSION and BUILD_TIME build args
- Modify docker-build Makefile target to capture git commit SHA and build time
- Update CLAUDE.md and README.md with version logging documentation
- Add version-logging spec to openspec/specs/

The operator now logs:
```
2026-04-07T13:42:51Z    INFO    setup   Starting OpenClaw Operator      {"version": "fc7c72b0", "buildTime": "2026-04-07T13:38:57Z"}
````
Local builds show defaults; production builds embed actual git SHA and
timestamp.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
