### PR TITLE
fix(deployment): add numeric user IDs for pod security validation

### DIFF
--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsUser: 65532
+        runAsNonRoot: true
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       initContainers:


### PR DESCRIPTION
Resolves "container has runAsNonRoot and image has non-numeric user" error
by specifying numeric UID (65532) at the pod security context level.

Kubernetes requires numeric user IDs when runAsNonRoot is enabled to verify
the user is actually non-root. The named user "node" from the container
image cannot be validated without a numeric UID.

Changes:
- Set runAsUser: 65532 for consistent non-root user enforcement
- Set fsGroup: 65532 to ensure PVC volume accessibility
- Move runAsNonRoot to pod level for clarity

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
