### PR TITLE
feat(crd): replace Age printcolumn with Ready and Reason columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
     - `Status=False, Reason=Provisioning`: Deployments are not yet ready
     - `Status=True, Reason=Ready`: Both `openclaw` and `openclaw-proxy` Deployments are available
 
+**CRD Printcolumns:**
+The CRD defines custom printcolumns for `kubectl get openclaw` output:
+- `Ready`: Shows Available condition status (True/False/Unknown) via JSONPath `.status.conditions[?(@.type=="Available")].status`
+- `Reason`: Shows Available condition reason (Provisioning/Ready) via JSONPath `.status.conditions[?(@.type=="Available")].reason`
+
 **Version Logging:**
 The operator logs version and build time at startup: `version` (short commit SHA) and `buildTime` (RFC3339). Injected via LDFLAGS during `docker-build`. Local builds show defaults (`dev`/`unknown`).
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,21 @@ The controller automatically populates status conditions to track the deployment
 **Checking instance status:**
 
 ```sh
+# View instance with status columns
+kubectl get openclaw
+# NAME       READY   REASON
+# instance   True    Ready
+
 # View full status
 kubectl get openclaw instance -o yaml
 
 # Check if instance is ready
 kubectl get openclaw instance -o jsonpath='{.status.conditions[?(@.type=="Available")].status}'
 ```
+
+The `kubectl get openclaw` output includes:
+- **Ready** column: Shows the Available condition status (True/False/Unknown)
+- **Reason** column: Shows why the instance is in its current state (Provisioning/Ready)
 
 **Important:** Only OpenClaw instances named `instance` will be reconciled by the controller.
 

--- a/api/v1alpha1/openclaw_types.go
+++ b/api/v1alpha1/openclaw_types.go
@@ -40,7 +40,8 @@ type OpenClawStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=openclaws,scope=Namespaced
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason"
 
 // OpenClaw is the Schema for the openclaws API
 type OpenClaw struct {

--- a/config/crd/bases/openclaw.sandbox.redhat.com_openclaws.yaml
+++ b/config/crd/bases/openclaw.sandbox.redhat.com_openclaws.yaml
@@ -15,9 +15,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Reason
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/openspec/changes/archive/2026-04-08-update-printcolumns/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-update-printcolumns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-update-printcolumns/design.md
+++ b/openspec/changes/archive/2026-04-08-update-printcolumns/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The OpenClaw CRD currently defines a single printcolumn showing the Age of the resource. With status conditions now implemented, operators need quick visibility into instance readiness when running `kubectl get openclaw`. Printcolumns control which fields appear in the table output.
+
+Kubebuilder generates CRD printcolumns from `+kubebuilder:printcolumn` markers on the Go type definition.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display Available condition status in kubectl table output
+- Display reason for current state (Provisioning vs Ready)
+- Remove Age column (not operationally useful for this resource)
+- Maintain consistency with Kubernetes conventions for status reporting
+
+**Non-Goals:**
+- Adding additional custom columns beyond Status and Reason
+- Changing status condition implementation (already exists)
+- Modifying kubectl output format beyond printcolumns
+
+## Decisions
+
+### Decision 1: Use JSONPath to extract condition fields
+Use JSONPath expressions in kubebuilder markers to extract `status` and `reason` from the Available condition.
+
+**Rationale:** Kubernetes supports JSONPath in printcolumn definitions. The status conditions array is searchable by type using the `?(@.type=="Available")` filter.
+
+**Alternatives considered:**
+- Adding dedicated status fields: Would duplicate information already in conditions
+- Custom printer columns via separate resource: Overly complex for this use case
+
+### Decision 2: Two columns - Status and Reason
+Display both the condition status (True/False/Unknown) and the reason (Provisioning/Ready).
+
+**Rationale:** Status alone doesn't explain why. Reason provides operational context without needing to inspect the full resource YAML.
+
+**Alternatives considered:**
+- Single "Ready" column showing yes/no: Less informative during troubleshooting
+- Three columns including message: Too verbose for table output
+
+### Decision 3: Remove Age column
+Remove the existing Age printcolumn.
+
+**Rationale:** Age is less useful than readiness for operational visibility. Users can still see creationTimestamp in YAML output or add Age via custom kubectl formatting if needed.
+
+**Alternatives considered:**
+- Keep Age and add Status/Reason: Three columns may be too wide for typical terminal output
+
+## Risks / Trade-offs
+
+**[Risk: JSONPath returns empty string if condition doesn't exist yet]**
+Mitigation: Controller sets Available condition immediately during first reconciliation, so the field will always be populated after initial reconcile. Empty cells during creation are acceptable.
+
+**[Trade-off: Losing Age visibility in default output]**
+Rationale: Users who need Age can view it via `kubectl get openclaw -o wide` or `kubectl describe`. Readiness is more valuable for at-a-glance operational status.
+
+**[Risk: JSONPath syntax errors in CRD generation]**
+Mitigation: JSONPath is validated during `make manifests`. Test with `kubectl get openclaw` after deployment to verify columns render correctly.

--- a/openspec/changes/archive/2026-04-08-update-printcolumns/proposal.md
+++ b/openspec/changes/archive/2026-04-08-update-printcolumns/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The current CRD printcolumns only show the Age column, which provides limited value for operators managing OpenClaw instances. With the newly added status conditions, we should surface the instance readiness directly in `kubectl get` output for better operational visibility.
+
+## What Changes
+
+- Replace the Age printcolumn with a Status column showing the Available condition status
+- Add a Reason column displaying why the instance is in its current state
+- Update kubebuilder markers in `api/v1alpha1/openclaw_types.go`
+- Regenerate CRD manifests to reflect the new printcolumns
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `openclawinstance-crd`: Update printcolumn definitions to display status condition readiness instead of Age
+
+## Impact
+
+- `api/v1alpha1/openclaw_types.go`: Update `+kubebuilder:printcolumn` markers
+- `config/crd/bases/openclaw.sandbox.redhat.com_openclaws.yaml`: Auto-regenerated CRD with new printcolumns
+- User experience: `kubectl get openclaw` will now show Status and Reason columns instead of Age

--- a/openspec/changes/archive/2026-04-08-update-printcolumns/specs/openclawinstance-crd/spec.md
+++ b/openspec/changes/archive/2026-04-08-update-printcolumns/specs/openclawinstance-crd/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: CRD defines printcolumns for status visibility
+The OpenClaw CRD SHALL define printcolumns to display the Available condition status and reason in kubectl table output.
+
+#### Scenario: Status column shows Available condition status
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the output SHALL include a "Status" column showing the status value from the Available condition (True, False, or Unknown)
+
+#### Scenario: Reason column shows Available condition reason
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the output SHALL include a "Reason" column showing the reason value from the Available condition (e.g., Provisioning, Ready)
+
+#### Scenario: Age column is not displayed
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the Age column SHALL NOT appear in the default table output
+
+#### Scenario: Printcolumns use JSONPath to extract condition fields
+- **WHEN** examining the CRD manifest
+- **THEN** printcolumn definitions SHALL use JSONPath expressions to extract status and reason from the Available condition (e.g., `.status.conditions[?(@.type=="Available")].status`)
+
+#### Scenario: Empty status cells when condition not yet set
+- **WHEN** an OpenClaw instance is newly created and the controller has not yet set status conditions
+- **THEN** the Status and Reason columns MAY be empty until the first reconciliation completes

--- a/openspec/changes/archive/2026-04-08-update-printcolumns/tasks.md
+++ b/openspec/changes/archive/2026-04-08-update-printcolumns/tasks.md
@@ -1,0 +1,26 @@
+## 1. Update CRD Printcolumn Markers
+
+- [x] 1.1 Remove existing Age printcolumn marker from api/v1alpha1/openclaw_types.go
+- [x] 1.2 Add Status printcolumn marker using JSONPath to extract Available condition status
+- [x] 1.3 Add Reason printcolumn marker using JSONPath to extract Available condition reason
+- [x] 1.4 Verify JSONPath syntax follows Kubernetes printcolumn conventions
+
+## 2. Regenerate CRD Manifests
+
+- [x] 2.1 Run `make manifests` to regenerate CRD YAML with updated printcolumns
+- [x] 2.2 Verify generated CRD includes Status and Reason printcolumns in config/crd/bases/
+- [x] 2.3 Verify Age printcolumn is removed from generated CRD
+
+## 3. Update Documentation
+
+- [x] 3.1 Update CLAUDE.md to mention new printcolumns if relevant
+- [x] 3.2 Update README.md to show example kubectl get output with new columns
+
+## 4. Testing and Verification
+
+- [x] 4.1 Run `make test` to ensure no regressions
+- [x] 4.2 Run `make lint` to verify code quality
+- [x] 4.3 Install updated CRD to test cluster with `make install`
+- [x] 4.4 Create test OpenClaw instance and verify `kubectl get openclaw` shows Status and Reason columns
+- [x] 4.5 Verify Status column shows True/False based on deployment readiness
+- [x] 4.6 Verify Reason column shows Provisioning/Ready appropriately

--- a/openspec/specs/openclawinstance-crd/spec.md
+++ b/openspec/specs/openclawinstance-crd/spec.md
@@ -54,3 +54,26 @@ The system SHALL generate a CRD manifest YAML file at `config/crd/bases/` contai
 #### Scenario: CRD includes status subresource
 - **WHEN** examining the generated CRD manifest
 - **THEN** it SHALL include `status: {}` in the subresources section
+
+### Requirement: CRD defines printcolumns for status visibility
+The OpenClaw CRD SHALL define printcolumns to display the Available condition status and reason in kubectl table output.
+
+#### Scenario: Ready column shows Available condition status
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the output SHALL include a "Ready" column showing the status value from the Available condition (True, False, or Unknown)
+
+#### Scenario: Reason column shows Available condition reason
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the output SHALL include a "Reason" column showing the reason value from the Available condition (e.g., Provisioning, Ready)
+
+#### Scenario: Age column is not displayed
+- **WHEN** user runs `kubectl get openclaw`
+- **THEN** the Age column SHALL NOT appear in the default table output
+
+#### Scenario: Printcolumns use JSONPath to extract condition fields
+- **WHEN** examining the CRD manifest
+- **THEN** printcolumn definitions SHALL use JSONPath expressions to extract status and reason from the Available condition (e.g., `.status.conditions[?(@.type=="Available")].status`)
+
+#### Scenario: Empty status cells when condition not yet set
+- **WHEN** an OpenClaw instance is newly created and the controller has not yet set status conditions
+- **THEN** the Ready and Reason columns MAY be empty until the first reconciliation completes


### PR DESCRIPTION
Replace the `Age` printcolumn with two new columns that surface the
Available condition status directly in kubectl get output for better
operational visibility.

Changes:
- Remove `Age` printcolumn from OpenClaw CRD
- Add `Ready` printcolumn showing `Available` condition status (`True/False/Unknown`)
- Add `Reason` printcolumn showing `Available` condition reason (`Provisioning/Ready`)
- Use JSONPath to extract condition fields from status.conditions array
- Update CLAUDE.md with printcolumn documentation
- Update README.md with example kubectl get output showing new columns
- Regenerate CRD manifests with updated additionalPrinterColumns

The new kubectl output provides at-a-glance readiness information:
```bash
NAME       READY   REASON
instance   True    Ready
```

This improves operational experience by showing deployment readiness
status without requiring users to inspect the full resource YAML.

Co-Authored-By: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
