### PR TITLE
test: reduce code duplication in controller unit tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,7 +52,10 @@
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.34.1-darwin-arm64\" go test -p 1 ./internal/controller -v)",
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.34.1-darwin-arm64\" go test ./internal/controller -run TestOpenClaw)",
       "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.34.1-darwin-arm64\" go test ./internal/controller -v)",
-      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.34.1-darwin-arm64\" go test ./internal/controller -run TestOpenClawPersistentVolumeClaim -v)"
+      "Bash(KUBEBUILDER_ASSETS=\"/Users/xcoulon/code/go/src/github.com/codeready-toolchain/openclaw-operator/bin/k8s/1.34.1-darwin-arm64\" go test ./internal/controller -run TestOpenClawPersistentVolumeClaim -v)",
+      "Bash(cat)",
+      "Read(//tmp/**)",
+      "Bash(wc -l internal/controller/*_test.go)"
     ]
   }
 }

--- a/internal/controller/openclaw_configmap_controller_test.go
+++ b/internal/controller/openclaw_configmap_controller_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
@@ -41,34 +39,9 @@ func TestOpenClawConfigMapController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check if ConfigMap was created
 			configMap := &corev1.ConfigMap{}
@@ -86,34 +59,9 @@ func TestOpenClawConfigMapController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check ConfigMap has correct owner reference
 			configMap := &corev1.ConfigMap{}
@@ -149,41 +97,16 @@ func TestOpenClawConfigMapController(t *testing.T) {
 				}
 			})
 
-			// Create a new OpenClaw with name 'other-instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify ConfigMap was NOT created
 			// Sleep to give reconciler time to (incorrectly) create resources
 			time.Sleep(2 * time.Second)
 
 			configMap := &corev1.ConfigMap{}
-			err = k8sClient.Get(ctx, client.ObjectKey{
+			err := k8sClient.Get(ctx, client.ObjectKey{
 				Name:      ClawConfigMapName,
 				Namespace: namespace,
 			}, configMap)

--- a/internal/controller/openclaw_deployment_controller_test.go
+++ b/internal/controller/openclaw_deployment_controller_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	netv1 "k8s.io/api/networking/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
@@ -45,34 +43,9 @@ func TestOpenClawDeploymentController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check if Deployment was created
 			deployment := &appsv1.Deployment{}
@@ -90,34 +63,9 @@ func TestOpenClawDeploymentController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check if Deployment was created
 			deployment := &appsv1.Deployment{}
@@ -154,30 +102,9 @@ func TestOpenClawDeploymentController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw")
-
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			np := &netv1.NetworkPolicy{}
 			waitFor(t, timeout, interval, func() bool {
@@ -210,41 +137,16 @@ func TestOpenClawDeploymentController(t *testing.T) {
 				}
 			})
 
-			// Create a new OpenClaw with name 'other-instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify Deployment was NOT created
 			// Sleep to give reconciler time to (incorrectly) create resources
 			time.Sleep(2 * time.Second)
 
 			deployment := &appsv1.Deployment{}
-			err = k8sClient.Get(ctx, client.ObjectKey{
+			err := k8sClient.Get(ctx, client.ObjectKey{
 				Name:      ClawDeploymentName,
 				Namespace: namespace,
 			}, deployment)

--- a/internal/controller/openclaw_gatewaysecret_controller_test.go
+++ b/internal/controller/openclaw_gatewaysecret_controller_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
@@ -42,34 +40,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance' with APIKey
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check if gateway Secret was created
 			secret := &corev1.Secret{}
@@ -90,34 +63,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile to create Secret
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify token format and length
 			secret := &corev1.Secret{}
@@ -144,34 +92,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile to create Secret with initial token
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Get the initial token value
 			secret := &corev1.Secret{}
@@ -185,13 +108,7 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 			initialToken := string(secret.Data[GatewayTokenKeyName])
 
 			// Reconcile again
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify token was not regenerated
 			secret = &corev1.Secret{}
@@ -213,34 +130,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile to create Secret with first token
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Get the first token value
 			secret := &corev1.Secret{}
@@ -257,13 +149,7 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 			require.NoError(t, k8sClient.Delete(ctx, secret), "failed to delete Secret")
 
 			// Reconcile again to generate a new token
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify a new unique token was generated
 			newSecret := &corev1.Secret{}
@@ -286,33 +172,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check gateway Secret has correct owner reference
 			secret := &corev1.Secret{}
@@ -340,36 +202,27 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
 			// Create required API key Secret
 			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
 			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
+
+			// Create OpenClaw instance manually (not using helper)
+			instance := &openclawv1alpha1.Claw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
 			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
 				Name: aiModelSecret,
 				Key:  aiModelSecretKey,
 			}
 			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
+
 			// Create gateway secret
 			gatewaySecret := createTestGatewaySecret(t, ClawGatewaySecretName, namespace)
 			require.NoError(t, k8sClient.Create(ctx, gatewaySecret), "failed to create gateway Secret")
 			assert.Empty(t, gatewaySecret.OwnerReferences, "gateway Secret should not have owner references initially")
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
 
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check gateway Secret has correct owner reference
 			secret := &corev1.Secret{}
@@ -397,34 +250,9 @@ func TestOpenClawGatewaySecretController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create required API key Secret
-			apiSecret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, apiSecret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile to create gateway Secret
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify gateway Secret has owner reference for garbage collection
 			secret := &corev1.Secret{}

--- a/internal/controller/openclaw_pvc_controller_test.go
+++ b/internal/controller/openclaw_pvc_controller_test.go
@@ -20,11 +20,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openclawv1alpha1 "github.com/codeready-toolchain/openclaw-operator/api/v1alpha1"
@@ -41,34 +38,9 @@ func TestOpenClawPersistentVolumeClaimController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check if PVC was created
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -86,34 +58,9 @@ func TestOpenClawPersistentVolumeClaimController(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// Create a new OpenClaw named 'instance'
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Check PVC has correct owner reference
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -171,34 +118,9 @@ func TestOpenClawPersistentVolumeClaimController(t *testing.T) {
 				}
 			})
 
-			// Create a new OpenClaw with name 'other-instance'
-			instance = &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			// Create API key Secret
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create Secret")
-
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create OpenClaw")
-
-			// Setup reconciler
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: scheme.Scheme,
-			}
-
-			// Reconcile the created resource
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			// Verify PVC was NOT created
 			pvc = &corev1.PersistentVolumeClaim{}

--- a/internal/controller/openclaw_secretref_controller_test.go
+++ b/internal/controller/openclaw_secretref_controller_test.go
@@ -40,32 +40,9 @@ func TestOpenClawSecretReference(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			t.Log("Creating the referenced Secret")
-			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
-			require.NoError(t, k8sClient.Create(ctx, secret), "Failed to create Secret")
-
-			t.Log("Creating OpenClaw instance")
-			instance := &openclawv1alpha1.Claw{}
-			instance.Name = resourceName
-			instance.Namespace = namespace
-			instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
-				Name: aiModelSecret,
-				Key:  aiModelSecretKey,
-			}
-			require.NoError(t, k8sClient.Create(ctx, instance), "Failed to create OpenClaw instance")
-
-			t.Log("Reconciling the OpenClaw instance")
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "Reconcile failed")
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			t.Log("Verifying proxy deployment references the user's Secret")
 			deployment := &appsv1.Deployment{}
@@ -112,17 +89,8 @@ func TestOpenClawSecretReference(t *testing.T) {
 			require.NoError(t, k8sClient.Create(ctx, instance), "Failed to create OpenClaw instance")
 
 			t.Log("Reconciling the OpenClaw instance")
-			reconciler := &ClawResourceReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "Reconcile failed")
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			t.Log("Verifying pod template has Secret version annotation")
 			deployment := &appsv1.Deployment{}
@@ -153,13 +121,7 @@ func TestOpenClawSecretReference(t *testing.T) {
 			assert.NotEqual(t, originalVersion, secret.ResourceVersion, "Secret ResourceVersion should change")
 
 			t.Log("Reconciling again after Secret update")
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      resourceName,
-					Namespace: namespace,
-				},
-			})
-			require.NoError(t, err, "Reconcile failed after Secret update")
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
 			t.Log("Verifying pod template annotation updated with new Secret version")
 			waitFor(t, timeout, interval, func() bool {
@@ -197,10 +159,7 @@ func TestOpenClawSecretReference(t *testing.T) {
 		require.NoError(t, k8sClient.Create(ctx, instance), "Failed to create OpenClaw instance")
 
 		t.Log("Reconciling the OpenClaw instance")
-		reconciler := &ClawResourceReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-		}
+		reconciler := createClawReconciler()
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Name:      ClawInstanceName,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -225,4 +226,45 @@ func createTestGatewaySecret(t *testing.T, name, namespace string) *corev1.Secre
 			GatewayTokenKeyName: []byte(token),
 		},
 	}
+}
+
+// createClawInstance creates a Claw instance with the required API key Secret.
+// Returns the created Claw instance.
+func createClawInstance(t *testing.T, ctx context.Context, name, namespace string) {
+	t.Helper()
+
+	// Create API key Secret
+	secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+	require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+	// Create Claw instance
+	instance := &openclawv1alpha1.Claw{}
+	instance.Name = name
+	instance.Namespace = namespace
+	instance.Spec.GeminiAPIKey = &openclawv1alpha1.SecretRef{
+		Name: aiModelSecret,
+		Key:  aiModelSecretKey,
+	}
+	require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+}
+
+// createClawReconciler creates a ClawResourceReconciler for testing.
+func createClawReconciler() *ClawResourceReconciler {
+	return &ClawResourceReconciler{
+		Client: k8sClient,
+		Scheme: scheme.Scheme,
+	}
+}
+
+// reconcileClaw performs a reconciliation for the given Claw resource.
+func reconcileClaw(t *testing.T, ctx context.Context, reconciler *ClawResourceReconciler, name, namespace string) {
+	t.Helper()
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      name,
+			Namespace: namespace,
+		},
+	})
+	require.NoError(t, err, "reconcile failed")
 }


### PR DESCRIPTION
Add reusable helper functions in `suite_test.go` to eliminate repetitive
test setup code across controller test files:

- `createClawInstance()`: creates Claw instance with API key Secret
- `createClawReconciler()`: instantiates test reconciler
- `reconcileClaw()`: performs reconciliation with error handling

This reduces ~20 lines to 3 lines per test case, removing ~273 net
lines while improving readability and maintainability. Changes to
instance creation logic now only need to be made in one place.

Also removes unused imports (ctrl, scheme) from refactored test files.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved test suite consistency by extracting common setup patterns into reusable helper functions across multiple test suites, reducing code duplication and enhancing maintainability.
  * Enhanced development configuration with additional command permissions for improved testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->