### PR TITLE
tests: fix e2e tests

### DIFF
--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -18,7 +18,9 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsUser: 65532
         runAsNonRoot: true
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       initContainers:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,7 +40,7 @@ var (
 	projectImage = "example.com/claw-operator:v0.0.1"
 
 	// proxyImage is the credential proxy sidecar image, built and loaded alongside the operator.
-	proxyImage = "openclaw-proxy:latest"
+	proxyImage = "example.com/openclaw-proxy:latest"
 )
 
 // TestMain runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,


### PR DESCRIPTION
rename proxy image (include org) and set user in claw containers (security)

I got the following error when running the e2e tests in kind:

```
Failed to pull image "openclaw-proxy:latest": failed to pull and unpack image "docker.io/library/openclaw-proxy:latest": failed to resolve reference "docker.io/library/openclaw-proxy:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```
it appears that renaming the image to something like `example.com/openclaw-proxy:latest` fixes the problem

Also, there was an error in the OpenClaw pod:
```
Warning  Failed            7s (x13 over 2m28s)  kubelet            Error: container has runAsNonRoot and image will run as root (pod: "openclaw-64bcfdbc59-4c8df_default(e30c7098-7210-4597-9ff9-04ba68d04ee8)", container: init-config)
```
Which is fixed after restoring the `runAsUser: 65532` (and probably the sibling `fsGroup: 65532`) removed in https://github.com/codeready-toolchain/claw-operator/pull/43


Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for deployment with improved user and filesystem group settings.
  * Updated test infrastructure proxy image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->