### PR TITLE
feat: trigger proxy rollout on credential Secret data changes

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -40,6 +40,13 @@ const (
 	ConditionTypeProxyConfigured     = "ProxyConfigured"
 )
 
+// Annotation keys used on proxy pod templates.
+const (
+	AnnotationKeyProxyConfigHash  = "claw.sandbox.redhat.com/proxy-config-hash"
+	AnnotationPrefixSecretVersion = "claw.sandbox.redhat.com/"
+	AnnotationSuffixSecretVersion = "-secret-version"
+)
+
 // Condition reasons for Claw status.
 const (
 	ConditionReasonReady            = "Ready"

--- a/internal/controller/claw_credentials_test.go
+++ b/internal/controller/claw_credentials_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -309,7 +310,7 @@ func TestOpenClawCredentialSecretReference(t *testing.T) {
 				if annotations == nil {
 					return false
 				}
-				_, exists := annotations["claw.sandbox.redhat.com/proxy-config-hash"]
+				_, exists := annotations[clawv1alpha1.AnnotationKeyProxyConfigHash]
 				return exists
 			}, "pod template should have proxy-config-hash annotation")
 		})
@@ -442,6 +443,99 @@ func TestConfigureProxyForCredentials(t *testing.T) {
 		}
 		assert.True(t, envNames["CRED_GEMINI"], "should have CRED_GEMINI")
 		assert.True(t, envNames["CRED_OPENAI"], "should have CRED_OPENAI")
+	})
+}
+
+func TestStampSecretVersionAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should stamp Secret ResourceVersion on proxy pod template", func(t *testing.T) {
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		createClawInstance(t, ctx, ClawInstanceName, namespace)
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      ClawProxyDeploymentName,
+			Namespace: namespace,
+		}, deployment))
+
+		annotations := deployment.Spec.Template.Annotations
+		require.NotNil(t, annotations, "pod template annotations should exist")
+		geminiSecretVersionKey := clawv1alpha1.AnnotationPrefixSecretVersion + "gemini" + clawv1alpha1.AnnotationSuffixSecretVersion
+		rv, ok := annotations[geminiSecretVersionKey]
+		assert.True(t, ok, "gemini-secret-version annotation should exist")
+		assert.NotEmpty(t, rv, "ResourceVersion should not be empty")
+	})
+
+	t.Run("should update annotation when Secret data changes", func(t *testing.T) {
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		createClawInstance(t, ctx, ClawInstanceName, namespace)
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      ClawProxyDeploymentName,
+			Namespace: namespace,
+		}, deployment))
+		geminiSecretVersionKey := clawv1alpha1.AnnotationPrefixSecretVersion + "gemini" + clawv1alpha1.AnnotationSuffixSecretVersion
+		originalRV := deployment.Spec.Template.Annotations[geminiSecretVersionKey]
+		require.NotEmpty(t, originalRV)
+
+		// Update the Secret data
+		secret := &corev1.Secret{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      aiModelSecret,
+			Namespace: namespace,
+		}, secret))
+		secret.Data[aiModelSecretKey] = []byte("rotated-api-key")
+		require.NoError(t, k8sClient.Update(ctx, secret))
+
+		// Reconcile again
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      ClawProxyDeploymentName,
+			Namespace: namespace,
+		}, deployment))
+		newRV := deployment.Spec.Template.Annotations[geminiSecretVersionKey]
+		assert.NotEqual(t, originalRV, newRV,
+			"annotation should change after Secret data update (old=%s, new=%s)", originalRV, newRV)
+	})
+
+	t.Run("should skip credentials without secretRef", func(t *testing.T) {
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:   "passthrough",
+				Type:   clawv1alpha1.CredentialTypeNone,
+				Domain: "example.com",
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      ClawProxyDeploymentName,
+			Namespace: namespace,
+		}, deployment))
+
+		annotations := deployment.Spec.Template.Annotations
+		for key := range annotations {
+			assert.False(t, strings.HasSuffix(key, clawv1alpha1.AnnotationSuffixSecretVersion),
+				"should not have secret-version annotations for none-type credentials, found %s", key)
+		}
 	})
 }
 

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -193,6 +193,11 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to stamp proxy config hash: %w", err)
 	}
 
+	// Stamp Secret ResourceVersions to trigger rollout when Secret data changes
+	if err := r.stampSecretVersionAnnotation(ctx, objects, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to stamp secret version annotations: %w", err)
+	}
+
 	// Apply Route and wait for ingress host to be populated
 	var routeHost string
 	var routeApplied int
@@ -881,7 +886,7 @@ func stampProxyConfigHash(objects []*unstructured.Unstructured, hash string) err
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		annotations["claw.sandbox.redhat.com/proxy-config-hash"] = hash
+		annotations[clawv1alpha1.AnnotationKeyProxyConfigHash] = hash
 
 		if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
 			return fmt.Errorf("failed to set pod template annotations: %w", err)
@@ -889,6 +894,54 @@ func stampProxyConfigHash(objects []*unstructured.Unstructured, hash string) err
 		return nil
 	}
 	return fmt.Errorf("openclaw-proxy deployment not found for config hash stamping")
+}
+
+// stampSecretVersionAnnotation fetches each credential's referenced Secret and stamps
+// its ResourceVersion as a pod template annotation. This ensures that when Secret data
+// changes (without any Claw CR spec change), the pod template differs and Kubernetes
+// triggers a rolling update.
+func (r *ClawResourceReconciler) stampSecretVersionAnnotation(
+	ctx context.Context,
+	objects []*unstructured.Unstructured,
+	instance *clawv1alpha1.Claw,
+) error {
+	versions := make(map[string]string)
+	for _, cred := range instance.Spec.Credentials {
+		if cred.SecretRef == nil {
+			continue
+		}
+		secret := &corev1.Secret{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: instance.Namespace,
+			Name:      cred.SecretRef.Name,
+		}, secret); err != nil {
+			return fmt.Errorf("failed to get Secret %q for credential %q: %w", cred.SecretRef.Name, cred.Name, err)
+		}
+		versions[cred.Name] = secret.ResourceVersion
+	}
+
+	if len(versions) == 0 {
+		return nil
+	}
+
+	for _, obj := range objects {
+		if obj.GetKind() != DeploymentKind || obj.GetName() != ClawProxyDeploymentName {
+			continue
+		}
+
+		annotations, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		for credName, rv := range versions {
+			annotations[clawv1alpha1.AnnotationPrefixSecretVersion+credName+clawv1alpha1.AnnotationSuffixSecretVersion] = rv
+		}
+		if err := unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations"); err != nil {
+			return fmt.Errorf("failed to set secret version annotations: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("openclaw-proxy deployment not found for secret version stamping")
 }
 
 // readEmbeddedFile reads a file from the embedded filesystem


### PR DESCRIPTION
Add stampSecretVersionAnnotation to stamp each referenced Secret's ResourceVersion on the proxy pod template, ensuring data-only Secret changes trigger a rolling update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy pods now automatically track credential secret versions and trigger redeployment when credentials are updated, ensuring deployments remain synchronized with the latest credential changes without manual intervention.

* **Tests**
  * Added comprehensive test coverage for secret version annotation tracking and automatic proxy pod synchronization with credential updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->