### PR TITLE
refactor: rename openclaw-* resource names to claw-*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,12 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
   - `oauth2` (OAuth2Config, optional): Required when type is `oauth2`. Fields: `clientID` (minLength=1), `tokenURL` (minLength=1), `scopes` ([]string, optional)
 
 **Status Fields:**
-- `gatewayTokenSecretRef` (string, optional): Name of the Secret containing the gateway authentication token (`openclaw-gateway-token`)
+- `gatewayTokenSecretRef` (string, optional): Name of the Secret containing the gateway authentication token (`claw-gateway-token`)
 - `url` (string, optional): HTTPS URL for accessing the Claw instance
 - `conditions` ([]metav1.Condition, optional): Standard Kubernetes condition array tracking instance state. Condition types:
   - `Ready`: Indicates whether the Claw instance is ready for use
     - `Status=False, Reason=Provisioning`: Deployments are not yet ready
-    - `Status=True, Reason=Ready`: Both `openclaw` and `openclaw-proxy` Deployments are available
+    - `Status=True, Reason=Ready`: Both `claw` and `claw-proxy` Deployments are available
   - `CredentialsResolved`: Tracks credential validation status
     - `Status=True, Reason=Resolved`: All credentials validated successfully
     - `Status=False, Reason=ValidationFailed`: Credential validation failed
@@ -112,12 +112,12 @@ The operator uses a **single unified controller** that manages all resources usi
 
 **ClawResourceReconciler** (`internal/controller/claw_resource_controller.go`):
 - Reconciles `Claw` CRs named exactly `"instance"` (skips all others)
-- Creates gateway Secret (`openclaw-gateway-token`) with randomly-generated authentication token
+- Creates gateway Secret (`claw-gateway-token`) with randomly-generated authentication token
 - Validates user-provided credentials (array of CredentialSpec in CR's `credentials` field) and referenced Secrets
-- Creates all resources: PVC, ConfigMap, Deployment, Services (2), NetworkPolicies (3: egress for openclaw, egress for proxy, ingress for gateway), proxy Deployment/ConfigMap, and Route (OpenShift only)
+- Creates all resources: PVC, ConfigMap, Deployment, Services (2), NetworkPolicies (3: egress for claw, egress for proxy, ingress for gateway), proxy Deployment/ConfigMap, and Route (OpenShift only)
 - Uses **three-phase reconciliation** to dynamically inject Route host into ConfigMap for CORS configuration
 - Uses server-side apply for idempotent, conflict-free resource management
-- Automatically labels all resources with `app.kubernetes.io/name: openclaw`
+- Automatically labels all resources with `app.kubernetes.io/name: claw`
 - Gracefully skips resources whose CRDs aren't registered (e.g., Route on vanilla Kubernetes)
 - Updates status conditions (Ready, CredentialsResolved, ProxyConfigured) based on Deployment readiness and credential validation
 - Supports proxy image override via `ProxyImage` field (set from `PROXY_IMAGE` env var on the manager)
@@ -127,7 +127,7 @@ The operator uses a **single unified controller** that manages all resources usi
 - Simplified codebase: 1 controller managing all resources
 - Dynamic CORS configuration: Route host automatically injected into ConfigMap at deployment time
 - Field ownership: server-side apply tracks which controller owns which fields
-- Consistent labeling: queryable with `kubectl get all -l app.kubernetes.io/name=openclaw`
+- Consistent labeling: queryable with `kubectl get all -l app.kubernetes.io/name=claw`
 - Graceful fallback: localhost CORS origin on vanilla Kubernetes (no Route CRD)
 - Future-proof: adding new resources only requires updating kustomization.yaml
 
@@ -144,10 +144,10 @@ Reconcile(ctx, req) called
   ↓
 PHASE 1: Gateway Secret
 3. applyGatewaySecret(ctx, instance)
-   ├─ Check if openclaw-gateway-token Secret already exists
+   ├─ Check if claw-gateway-token Secret already exists
    ├─ If exists and has token, preserve existing token
    ├─ If not exists or missing token, generate new 64-char hex token using crypto/rand
-   ├─ Create/update openclaw-gateway-token Secret with token data entry
+   ├─ Create/update claw-gateway-token Secret with token data entry
    ├─ Set owner reference (for garbage collection)
    └─ Server-side apply Secret (Patch with Apply)
   ↓
@@ -170,20 +170,20 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    ├─ Build Kustomize in-memory from embedded manifests
    ├─ Parse YAML into unstructured objects
    ├─ configureProxyDeployment(objects, instance)
-   │  ├─ Find openclaw-proxy Deployment in parsed objects
-   │  ├─ Navigate to spec.template.spec.containers[].env[]
-   │  ├─ Configure credential-specific environment variables based on instance.Spec.Credentials
-   │  ├─ Update valueFrom.secretKeyRef to point to user's Secrets (name and key from each CredentialSpec.SecretRef)
-   │  └─ Modify in-place BEFORE applying (so pod template changes trigger automatic pod restarts on Secret ref changes)
-   ├─ stampSecretVersionAnnotation(ctx, objects, instance)
-   │  ├─ Fetch user's Secrets to get their ResourceVersions
-   │  ├─ Find openclaw-proxy Deployment in parsed objects
+ │  ├─ Find claw-proxy Deployment in parsed objects
+ │  ├─ Navigate to spec.template.spec.containers[].env[]
+ │  ├─ Configure credential-specific environment variables based on instance.Spec.Credentials
+ │  ├─ Update valueFrom.secretKeyRef to point to user's Secrets (name and key from each CredentialSpec.SecretRef)
+ │  └─ Modify in-place BEFORE applying (so pod template changes trigger automatic pod restarts on Secret ref changes)
+ ├─ stampSecretVersionAnnotation(ctx, objects, instance)
+ │  ├─ Fetch user's Secrets to get their ResourceVersions
+ │  ├─ Find claw-proxy Deployment in parsed objects
    │  ├─ Add annotations to pod template: claw.sandbox.redhat.com/<credential-name>-secret-version=<ResourceVersion>
    │  └─ This triggers pod restarts when Secret data changes (ResourceVersion updates), not just Secret reference changes
    └─ Return parsed objects
   ↓
 7. injectRouteHostIntoConfigMap(objects, routeHost)
-   ├─ Find openclaw-config ConfigMap in objects
+   ├─ Find claw-config ConfigMap in objects
    ├─ Extract data["openclaw.json"] string
    ├─ Replace "OPENCLAW_ROUTE_HOST" placeholder with routeHost (https://...)
    ├─ If routeHost is empty (vanilla Kubernetes): use "http://localhost:18789" fallback
@@ -197,8 +197,8 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    └─ Server-side apply each resource (ConfigMap, Deployments, Services, NetworkPolicies)
   ↓
 11. updateStatus(ctx, instance)
-   ├─ Fetch openclaw Deployment and check Available condition
-   ├─ Fetch openclaw-proxy Deployment and check Available condition
+   ├─ Fetch claw Deployment and check Available condition
+   ├─ Fetch claw-proxy Deployment and check Available condition
    ├─ Set Claw Ready condition based on both deployment statuses
    ├─ Set GatewayTokenSecretRef to gateway Secret name
    ├─ Populate instance.Status.URL with Route URL (if available)
@@ -211,28 +211,28 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 **Route Status Polling:**
 - If Route is applied but `.status.ingress[0].host` is not yet populated, reconciliation requeues with 5-second backoff
 - OpenShift router typically populates Route status within 5-10 seconds
-- Indefinite requeue: cluster-level Route issues should be diagnosed via `kubectl describe route openclaw`
+- Indefinite requeue: cluster-level Route issues should be diagnosed via `kubectl describe route claw`
 
 **Vanilla Kubernetes Fallback:**
 - On clusters without Route CRD (vanilla Kubernetes), Route application fails with `meta.IsNoMatchError`
 - Controller logs "Route CRD not registered, using localhost fallback for CORS"
 - ConfigMap receives `http://localhost:18789` as `allowedOrigins` value
-- Control UI accessible via port-forward: `kubectl port-forward svc/openclaw 18789:18789`
+- Control UI accessible via port-forward: `kubectl port-forward svc/claw 18789:18789`
 
 **Key methods:**
 - `Reconcile()` — main entry point, orchestrates three-phase reconciliation (gateway Secret → Route → ConfigMap injection + remaining resources)
 - `generateGatewayToken()` — generates cryptographically secure 64-char hex token using crypto/rand
-- `applyGatewaySecret()` — creates/updates openclaw-gateway-token Secret with gateway token (preserves existing token)
+- `applyGatewaySecret()` — creates/updates claw-gateway-token Secret with gateway token (preserves existing token)
 - `applyRouteOnly()` — applies only Route resource from Kustomize manifests (Phase 2)
 - `getRouteURL()` — fetches Route and extracts `.status.ingress[0].host`, returns empty string if status not populated
 - `buildKustomizedObjects()` — builds Kustomize manifests, configures proxy deployment, stamps Secret version, returns parsed objects
 - `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in ConfigMap with Route host (or localhost fallback)
 - `applyResources()` — applies list of unstructured objects using server-side apply
 - `configureProxyImage()` — overrides proxy Deployment container image if `ProxyImage` is set (from `PROXY_IMAGE` env var); no-op when empty (preserves embedded default for `make run`)
-- `configureProxyDeployment()` — modifies openclaw-proxy deployment manifest in-place to reference user's Secret BEFORE applying (ensures pod template changes trigger restarts when Secret reference changes)
+- `configureProxyDeployment()` — modifies claw-proxy deployment manifest in-place to reference user's Secret BEFORE applying (ensures pod template changes trigger restarts when Secret reference changes)
 - `stampSecretVersionAnnotation()` — adds Secret ResourceVersion annotation to pod template BEFORE applying (ensures pod template changes trigger restarts when Secret data changes, not just reference)
 - `getDeploymentAvailableStatus()` — fetches Deployment and checks its Available condition
-- `checkDeploymentsReady()` — checks if both openclaw and openclaw-proxy Deployments are ready
+- `checkDeploymentsReady()` — checks if both claw and claw-proxy Deployments are ready
 - `setReadyCondition()` — sets Ready condition on Claw based on deployment states
 - `updateStatus()` — updates Claw status conditions, GatewayTokenSecretRef, and URL field via status subresource
 - `parseYAMLToObjects()` — converts multi-doc YAML to unstructured objects
@@ -241,11 +241,11 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 
 **Shared constants** (`internal/controller/claw_resource_controller.go`):
 - `ClawInstanceName = "instance"` — only this name is reconciled
-- `ClawConfigMapName = "openclaw-config"`
-- `ClawPVCName = "openclaw-home-pvc"`
-- `ClawDeploymentName = "openclaw"`
-- `ClawGatewaySecretName = "openclaw-gateway-token"` — Secret containing gateway authentication token
-- `ClawIngressNetworkPolicyName = "openclaw-ingress"` — ingress NetworkPolicy restricting gateway access to OpenShift router
+- `ClawConfigMapName = "claw-config"`
+- `ClawPVCName = "claw-home-pvc"`
+- `ClawDeploymentName = "claw"`
+- `ClawGatewaySecretName = "claw-gateway-token"` — Secret containing gateway authentication token
+- `ClawIngressNetworkPolicyName = "claw-ingress"` — ingress NetworkPolicy restricting gateway access to OpenShift router
 - `GatewayTokenKeyName = "token"` — data key for gateway token in gateway Secret
 
 **NodePairingRequestApprovalReconciler** (`internal/controller/nodepairingrequestapproval_controller.go`):

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openclaw.devsandbox.openshift.com/claw-operator-bundle:$VERSION and openclaw.devsandbox.openshift.com/claw-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openclaw.devsandbox.openshift.com/claw-operator
+# claw.sandbox.redhat.com/claw-operator-bundle:$VERSION and claw.sandbox.redhat.com/claw-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= claw.sandbox.redhat.com/claw-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.42.0
 # Image URL to use all building/pushing image targets
 IMG ?= claw-operator:latest
-PROXY_IMG ?= openclaw-proxy:latest
+PROXY_IMG ?= claw-proxy:latest
 PLATFORM ?= linux/amd64
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -274,7 +274,7 @@ ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-build REGISTRY=quay.io/myuser)
 endif
 	$(MAKE) docker-build IMG=$(REGISTRY)/claw-operator:$(TAG)
-	$(MAKE) docker-build-proxy PROXY_IMG=$(REGISTRY)/openclaw-proxy:$(TAG)
+	$(MAKE) docker-build-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-push
 dev-push: ## Push operator and proxy images for dev.
@@ -282,7 +282,7 @@ ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-push REGISTRY=quay.io/myuser)
 endif
 	$(MAKE) docker-push IMG=$(REGISTRY)/claw-operator:$(TAG)
-	$(MAKE) docker-push-proxy PROXY_IMG=$(REGISTRY)/openclaw-proxy:$(TAG)
+	$(MAKE) docker-push-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-deploy
 dev-deploy: ## Install CRDs and deploy controller for dev.
@@ -290,7 +290,7 @@ ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-deploy REGISTRY=quay.io/myuser)
 endif
 	$(MAKE) install
-	$(MAKE) deploy IMG=$(REGISTRY)/claw-operator:$(TAG) PROXY_IMG=$(REGISTRY)/openclaw-proxy:$(TAG)
+	$(MAKE) deploy IMG=$(REGISTRY)/claw-operator:$(TAG) PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-setup
 dev-setup: ## Full dev setup: build, push, and deploy.

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: openclaw.devsandbox.openshift.com
+domain: claw.sandbox.redhat.com
 layout:
 - go.kubebuilder.io/v4
 plugins:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The controller automatically populates status conditions to track the deployment
 - `conditions` (array): Standard Kubernetes conditions following the [metav1.Condition](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/condition/) format. Currently includes:
   - **Ready**: Indicates whether the Claw instance is ready for use
     - `status: "False"`, `reason: Provisioning` — Deployments are being created or are not yet ready
-    - `status: "True"`, `reason: Ready` — Both `openclaw` and `openclaw-proxy` Deployments are available
+    - `status: "True"`, `reason: Ready` — Both `claw` and `claw-proxy` Deployments are available
   - **CredentialsResolved**: Indicates whether all credential Secrets have been validated
     - `status: "False"`, `reason: ValidationFailed` — One or more credential Secrets are missing or invalid
     - `status: "True"`, `reason: Resolved` — All credential Secrets are valid
@@ -99,10 +99,10 @@ The `oc get claw` output includes:
 
 The operator manages two categories of Secrets:
 
-#### 1. Gateway Authentication Token (`openclaw-gateway-token`)
+#### 1. Gateway Authentication Token (`claw-gateway-token`)
 
 The controller automatically generates and manages a secure authentication token for the OpenClaw gateway:
-- **Secret name:** `openclaw-gateway-token`
+- **Secret name:** `claw-gateway-token`
 - **Data entry:** `token` — A cryptographically secure 64-character hex string (256-bit entropy)
 - **Generation:** Automatically created on first reconciliation using Go's `crypto/rand` package
 - **Persistence:** Token is preserved across reconciliations (never regenerated unless the Secret is deleted)
@@ -110,7 +110,7 @@ The controller automatically generates and manages a secure authentication token
 
 **Example retrieval:**
 ```sh
-oc get secret openclaw-gateway-token -o jsonpath='{.data.token}' | base64 -d
+oc get secret claw-gateway-token -o jsonpath='{.data.token}' | base64 -d
 ```
 
 #### 2. Credential Secrets (User-Managed)
@@ -118,7 +118,7 @@ oc get secret openclaw-gateway-token -o jsonpath='{.data.token}' | base64 -d
 Each entry in `spec.credentials` references a user-managed Secret. The controller:
 1. Validates that each referenced Secret exists in the same namespace
 2. Verifies the Secret contains the specified key
-3. Configures the `openclaw-proxy` deployment to reference Secrets directly (via env vars or volume mounts depending on credential type)
+3. Configures the `claw-proxy` deployment to reference Secrets directly (via env vars or volume mounts depending on credential type)
 4. Generates a proxy config JSON with credential routing rules and applies it as a ConfigMap
 
 **How credentials are injected into the proxy:**
@@ -211,7 +211,7 @@ make install
 **Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
-make deploy IMG=<some-registry>/claw-operator:tag PROXY_IMG=<some-registry>/openclaw-proxy:tag
+make deploy IMG=<some-registry>/claw-operator:tag PROXY_IMG=<some-registry>/claw-proxy:tag
 ```
 
 > **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
@@ -285,7 +285,7 @@ oc get claw instance -n claw-operator -o jsonpath='{.status.url}'
 On **vanilla Kubernetes** (no Route CRD), use port-forwarding:
 
 ```sh
-oc port-forward svc/openclaw 18789:18789 -n claw-operator
+oc port-forward svc/claw 18789:18789 -n claw-operator
 ```
 
 Then open http://localhost:18789 in your browser.
@@ -295,7 +295,7 @@ Then open http://localhost:18789 in your browser.
 The operator generates a gateway authentication token stored in a Secret. Retrieve it with:
 
 ```sh
-oc get secret openclaw-gateway-token -n claw-operator -o jsonpath='{.data.token}' | base64 -d
+oc get secret claw-gateway-token -n claw-operator -o jsonpath='{.data.token}' | base64 -d
 ```
 
 ### To Uninstall

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -188,7 +188,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "33f671a1.openclaw.devsandbox.openshift.com",
+		LeaderElectionID:       "33f671a1.claw.sandbox.redhat.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
         name: manager
         env:
           - name: PROXY_IMAGE
-            value: openclaw-proxy:latest
+            value: claw-proxy:latest
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/assets/manifests/configmap.yaml
+++ b/internal/assets/manifests/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: openclaw-config
+  name: claw-config
   labels:
-    app: openclaw
+    app: claw
 data:
   openclaw.json: |
     {

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: openclaw
+  name: claw
   labels:
-    app: openclaw
+    app: claw
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openclaw
+      app: claw
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: openclaw
+        app: claw
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -51,7 +51,7 @@ spec:
               memory: 64Mi
               cpu: 100m
           volumeMounts:
-            - name: openclaw-home
+            - name: claw-home
               mountPath: /home/node/.openclaw
             - name: config
               mountPath: /config
@@ -78,12 +78,12 @@ spec:
             - name: OPENCLAW_GATEWAY_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: openclaw-gateway-token
+                  name: claw-gateway-token
                   key: token
             - name: HTTP_PROXY
-              value: http://openclaw-proxy:8080
+              value: http://claw-proxy:8080
             - name: HTTPS_PROXY
-              value: http://openclaw-proxy:8080
+              value: http://claw-proxy:8080
             - name: NODE_EXTRA_CA_CERTS
               value: /etc/proxy-ca/ca.crt
           resources:
@@ -112,7 +112,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           volumeMounts:
-            - name: openclaw-home
+            - name: claw-home
               mountPath: /home/node/.openclaw
             - name: tmp-volume
               mountPath: /tmp
@@ -127,17 +127,17 @@ spec:
               drop:
                 - ALL
       volumes:
-        - name: openclaw-home
+        - name: claw-home
           persistentVolumeClaim:
-            claimName: openclaw-home-pvc
+            claimName: claw-home-pvc
         - name: config
           configMap:
-            name: openclaw-config
+            name: claw-config
         - name: tmp-volume
           emptyDir: {}
         - name: proxy-ca
           secret:
-            secretName: openclaw-proxy-ca
+            secretName: claw-proxy-ca
             items:
               - key: ca.crt
                 path: ca.crt

--- a/internal/assets/manifests/ingress-networkpolicy.yaml
+++ b/internal/assets/manifests/ingress-networkpolicy.yaml
@@ -1,13 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: openclaw-ingress
+  name: claw-ingress
   labels:
-    app: openclaw
+    app: claw
 spec:
   podSelector:
     matchLabels:
-      app: openclaw
+      app: claw
   policyTypes:
     - Ingress
   ingress:

--- a/internal/assets/manifests/kustomization.yaml
+++ b/internal/assets/manifests/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 labels:
   - pairs:
-      app.kubernetes.io/name: openclaw
+      app.kubernetes.io/name: claw
 
 resources:
   - pvc.yaml

--- a/internal/assets/manifests/networkpolicy.yaml
+++ b/internal/assets/manifests/networkpolicy.yaml
@@ -3,13 +3,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: openclaw-egress
+  name: claw-egress
   labels:
-    app: openclaw
+    app: claw
 spec:
   podSelector:
     matchLabels:
-      app: openclaw
+      app: claw
   policyTypes:
     - Egress
   egress:
@@ -17,7 +17,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              app: openclaw-proxy
+              app: claw-proxy
       ports:
         - port: 8080
           protocol: TCP
@@ -43,13 +43,13 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: openclaw-proxy-egress
+  name: claw-proxy-egress
   labels:
-    app: openclaw-proxy
+    app: claw-proxy
 spec:
   podSelector:
     matchLabels:
-      app: openclaw-proxy
+      app: claw-proxy
   policyTypes:
     - Egress
   egress:

--- a/internal/assets/manifests/proxy-configmap.yaml
+++ b/internal/assets/manifests/proxy-configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: openclaw-proxy-config
+  name: claw-proxy-config
   labels:
-    app: openclaw-proxy
+    app: claw-proxy
 data:
   proxy-config.json: '{"routes":[]}'

--- a/internal/assets/manifests/proxy-deployment.yaml
+++ b/internal/assets/manifests/proxy-deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: openclaw-proxy
+  name: claw-proxy
   labels:
-    app: openclaw-proxy
+    app: claw-proxy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openclaw-proxy
+      app: claw-proxy
   template:
     metadata:
       labels:
-        app: openclaw-proxy
+        app: claw-proxy
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: proxy
-          image: openclaw-proxy:latest
+          image: claw-proxy:latest
           imagePullPolicy: IfNotPresent
           args:
             - --config=/etc/proxy/proxy-config.json
@@ -68,7 +68,7 @@ spec:
       volumes:
         - name: proxy-config
           configMap:
-            name: openclaw-proxy-config
+            name: claw-proxy-config
         - name: proxy-ca
           secret:
-            secretName: openclaw-proxy-ca
+            secretName: claw-proxy-ca

--- a/internal/assets/manifests/proxy-service.yaml
+++ b/internal/assets/manifests/proxy-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: openclaw-proxy
+  name: claw-proxy
   labels:
-    app: openclaw-proxy
+    app: claw-proxy
 spec:
   type: ClusterIP
   selector:
-    app: openclaw-proxy
+    app: claw-proxy
   ports:
     - name: http
       port: 8080

--- a/internal/assets/manifests/pvc.yaml
+++ b/internal/assets/manifests/pvc.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: openclaw-home-pvc
+  name: claw-home-pvc
   labels:
-    app: openclaw
+    app: claw
 spec:
   accessModes:
     - ReadWriteOnce

--- a/internal/assets/manifests/route.yaml
+++ b/internal/assets/manifests/route.yaml
@@ -1,15 +1,15 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: openclaw
+  name: claw
   labels:
-    app: openclaw
+    app: claw
   annotations:
     haproxy.router.openshift.io/timeout: 3600s
 spec:
   to:
     kind: Service
-    name: openclaw
+    name: claw
     weight: 100
   port:
     targetPort: 18789

--- a/internal/assets/manifests/service.yaml
+++ b/internal/assets/manifests/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: openclaw
+  name: claw
   labels:
-    app: openclaw
+    app: claw
 spec:
   type: ClusterIP
   selector:
-    app: openclaw
+    app: claw
   ports:
     - name: gateway
       port: 18789

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -401,16 +401,16 @@ func TestConfigureProxyImage(t *testing.T) {
 
 	t.Run("should override proxy image when set", func(t *testing.T) {
 		objects := buildObjects(t)
-		require.NoError(t, configureProxyImage(objects, "quay.io/myuser/openclaw-proxy:v1"))
+		require.NoError(t, configureProxyImage(objects, "quay.io/myuser/claw-proxy:v1"))
 
-		assert.Equal(t, "quay.io/myuser/openclaw-proxy:v1", getProxyImage(t, objects))
+		assert.Equal(t, "quay.io/myuser/claw-proxy:v1", getProxyImage(t, objects))
 	})
 
 	t.Run("should preserve default image when empty", func(t *testing.T) {
 		objects := buildObjects(t)
 		require.NoError(t, configureProxyImage(objects, ""))
 
-		assert.Equal(t, "openclaw-proxy:latest", getProxyImage(t, objects))
+		assert.Equal(t, "claw-proxy:latest", getProxyImage(t, objects))
 	})
 }
 

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -66,19 +66,19 @@ const (
 	ClawInstanceName = "instance"
 
 	// Core resources
-	ClawConfigMapName            = "openclaw-config"
-	ClawPVCName                  = "openclaw-home-pvc"
-	ClawNetworkPolicyName        = "openclaw-egress"
-	ClawIngressNetworkPolicyName = "openclaw-ingress"
-	ClawRouteName                = "openclaw"
-	ClawServiceName              = "openclaw"
-	ClawDeploymentName           = "openclaw"
-	ClawGatewaySecretName        = "openclaw-gateway-token"
+	ClawConfigMapName            = "claw-config"
+	ClawPVCName                  = "claw-home-pvc"
+	ClawNetworkPolicyName        = "claw-egress"
+	ClawIngressNetworkPolicyName = "claw-ingress"
+	ClawRouteName                = "claw"
+	ClawServiceName              = "claw"
+	ClawDeploymentName           = "claw"
+	ClawGatewaySecretName        = "claw-gateway-token"
 	GatewayTokenKeyName          = "token"
-	ClawProxyServiceName         = "openclaw-proxy"
-	ClawProxyConfigMapName       = "openclaw-proxy-config"
-	ClawProxyDeploymentName      = "openclaw-proxy"
-	ClawProxyCACertSecretName    = "openclaw-proxy-ca"
+	ClawProxyServiceName         = "claw-proxy"
+	ClawProxyConfigMapName       = "claw-proxy-config"
+	ClawProxyDeploymentName      = "claw-proxy"
+	ClawProxyCACertSecretName    = "claw-proxy-ca"
 	ClawProxyContainerName       = "proxy"
 	// Kubernetes resource kinds
 	RouteKind      = "Route"
@@ -404,7 +404,7 @@ func generateGatewayToken() (string, error) {
 	return hex.EncodeToString(randomBytes), nil
 }
 
-// applyGatewaySecret creates or updates the openclaw-gateway-token Secret with the gateway token
+// applyGatewaySecret creates or updates the claw-gateway-token Secret with the gateway token
 func (r *ClawResourceReconciler) applyGatewaySecret(ctx context.Context, instance *clawv1alpha1.Claw) error {
 	logger := log.FromContext(ctx)
 
@@ -771,11 +771,11 @@ func configureProxyImage(objects []*unstructured.Unstructured, image string) err
 		}
 		return fmt.Errorf("container %q not found in proxy deployment", ClawProxyContainerName)
 	}
-	return fmt.Errorf("openclaw-proxy deployment not found in manifests")
+	return fmt.Errorf("claw-proxy deployment not found in manifests")
 }
 
 // configureProxyForCredentials adds credential env vars and volume mounts to the
-// openclaw-proxy Deployment based on spec.credentials[]. This modifies the parsed
+// claw-proxy Deployment based on spec.credentials[]. This modifies the parsed
 // kustomize objects in-place before they are applied via SSA.
 func configureProxyForCredentials(objects []*unstructured.Unstructured, credentials []clawv1alpha1.CredentialSpec) error {
 	for _, obj := range objects {
@@ -871,7 +871,7 @@ func configureProxyForCredentials(objects []*unstructured.Unstructured, credenti
 
 		return nil
 	}
-	return fmt.Errorf("openclaw-proxy deployment not found in manifests")
+	return fmt.Errorf("claw-proxy deployment not found in manifests")
 }
 
 // stampProxyConfigHash adds a hash annotation to the proxy pod template to trigger
@@ -893,7 +893,7 @@ func stampProxyConfigHash(objects []*unstructured.Unstructured, hash string) err
 		}
 		return nil
 	}
-	return fmt.Errorf("openclaw-proxy deployment not found for config hash stamping")
+	return fmt.Errorf("claw-proxy deployment not found for config hash stamping")
 }
 
 // stampSecretVersionAnnotation fetches each credential's referenced Secret and stamps
@@ -941,7 +941,7 @@ func (r *ClawResourceReconciler) stampSecretVersionAnnotation(
 		}
 		return nil
 	}
-	return fmt.Errorf("openclaw-proxy deployment not found for secret version stamping")
+	return fmt.Errorf("claw-proxy deployment not found for secret version stamping")
 }
 
 // readEmbeddedFile reads a file from the embedded filesystem
@@ -1002,9 +1002,9 @@ func (r *ClawResourceReconciler) getDeploymentAvailableStatus(ctx context.Contex
 	return false, nil
 }
 
-// checkDeploymentsReady checks if both openclaw and openclaw-proxy Deployments are ready
+// checkDeploymentsReady checks if both claw and claw-proxy Deployments are ready
 func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, namespace string) (bool, []string, error) {
-	openclawReady, err := r.getDeploymentAvailableStatus(ctx, namespace, ClawDeploymentName)
+	clawReady, err := r.getDeploymentAvailableStatus(ctx, namespace, ClawDeploymentName)
 	if err != nil {
 		return false, nil, err
 	}
@@ -1015,7 +1015,7 @@ func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, name
 	}
 
 	var pending []string
-	if !openclawReady {
+	if !clawReady {
 		pending = append(pending, ClawDeploymentName)
 	}
 	if !proxyReady {
@@ -1039,11 +1039,11 @@ func (r *ClawResourceReconciler) getRouteURL(ctx context.Context, instance *claw
 
 	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: instance.Namespace,
-		Name:      "openclaw",
+		Name:      ClawRouteName,
 	}, route); err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			// Route not found (or CRD not registered on non-OpenShift clusters)
-			logger.Info("Route not found or CRD not registered", "name", "openclaw")
+			logger.Info("Route not found or CRD not registered", "name", ClawRouteName)
 			return "", nil
 		}
 		return "", fmt.Errorf("failed to get Route: %w", err)
@@ -1116,7 +1116,7 @@ func setReadyCondition(instance *clawv1alpha1.Claw, ready bool, pendingDeploymen
 	})
 }
 
-// getGatewayToken fetches the gateway token from the openclaw-gateway-token Secret and Base64-decodes it.
+// getGatewayToken fetches the gateway token from the claw-gateway-token Secret and Base64-decodes it.
 // Returns the token string, or empty string if the Secret cannot be read.
 func (r *ClawResourceReconciler) getGatewayToken(ctx context.Context, namespace string) string {
 	logger := log.FromContext(ctx)
@@ -1219,7 +1219,7 @@ func (r *ClawResourceReconciler) findClawsReferencingSecret(ctx context.Context,
 		return nil
 	}
 
-	// Skip operator-managed secrets (openclaw-gateway-token for gateway token)
+	// Skip operator-managed secrets (claw-gateway-token for gateway token)
 	if secret.Name == ClawGatewaySecretName {
 		return nil
 	}

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -243,7 +243,7 @@ func TestOpenClawDeploymentController(t *testing.T) {
 			deployment := &appsv1.Deployment{}
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{
-					Name:      "openclaw",
+					Name:      ClawDeploymentName,
 					Namespace: namespace,
 				}, deployment)
 				return err == nil
@@ -592,7 +592,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
-			routeHost := "https://example-openclaw.apps.cluster.com"
+			routeHost := "https://example-claw.apps.cluster.com"
 
 			reconciler := &ClawResourceReconciler{
 				Client: k8sClient,

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -115,7 +115,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			}, "Ready condition should be False with Provisioning reason")
 		})
 
-		t.Run("should keep Ready condition False when only openclaw Deployment is ready", func(t *testing.T) {
+		t.Run("should keep Ready condition False when only claw Deployment is ready", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
 			})
@@ -146,7 +146,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 				return err == nil
-			}, "openclaw Deployment should be created")
+			}, "claw Deployment should be created")
 
 			deployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -172,7 +172,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			assert.Equal(t, clawv1alpha1.ConditionReasonProvisioning, condition.Reason, "Ready condition reason")
 		})
 
-		t.Run("should keep Ready condition False when only openclaw-proxy Deployment is ready", func(t *testing.T) {
+		t.Run("should keep Ready condition False when only claw-proxy Deployment is ready", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
 			})
@@ -203,7 +203,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 				return err == nil
-			}, "openclaw-proxy Deployment should be created")
+			}, "claw-proxy Deployment should be created")
 
 			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -260,7 +260,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 				return err == nil
-			}, "openclaw Deployment should be created")
+			}, "claw Deployment should be created")
 
 			deployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -274,7 +274,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 				return err == nil
-			}, "openclaw-proxy Deployment should be created")
+			}, "claw-proxy Deployment should be created")
 
 			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -346,7 +346,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 				return err == nil
-			}, "openclaw Deployment should be created")
+			}, "claw Deployment should be created")
 
 			deployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -360,7 +360,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 				return err == nil
-			}, "openclaw-proxy Deployment should be created")
+			}, "claw-proxy Deployment should be created")
 
 			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -566,7 +566,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
 			})
 
-			t.Run("should keep status.url empty when only openclaw deployment is ready", func(t *testing.T) {
+			t.Run("should keep status.url empty when only claw deployment is ready", func(t *testing.T) {
 				t.Cleanup(func() {
 					deleteAndWaitAllResources(t, namespace)
 				})
@@ -597,7 +597,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 					return err == nil
-				}, "openclaw Deployment should be created")
+				}, "claw Deployment should be created")
 
 				deployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -651,7 +651,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 					return err == nil
-				}, "openclaw-proxy Deployment should be created")
+				}, "claw-proxy Deployment should be created")
 
 				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -705,7 +705,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 					return err == nil
-				}, "openclaw Deployment should be created")
+				}, "claw Deployment should be created")
 
 				deployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -719,7 +719,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 					return err == nil
-				}, "openclaw-proxy Deployment should be created")
+				}, "claw-proxy Deployment should be created")
 
 				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -750,7 +750,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 					}
 					err = k8sClient.Status().Update(ctx, deployment)
 					return err == nil
-				}, "openclaw Deployment should be updated to Available=False")
+				}, "claw Deployment should be updated to Available=False")
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -796,7 +796,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 					return err == nil
-				}, "openclaw Deployment should be created")
+				}, "claw Deployment should be created")
 
 				deployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -810,7 +810,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 					return err == nil
-				}, "openclaw-proxy Deployment should be created")
+				}, "claw-proxy Deployment should be created")
 
 				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -927,15 +927,15 @@ func TestOpenClawStatusConditions(t *testing.T) {
 					Version: "v1",
 					Kind:    "Route",
 				})
-				route.SetName("openclaw")
+				route.SetName(ClawRouteName)
 				route.SetNamespace(namespace)
 
-				routeHost := "openclaw-default.apps.example.com"
+				routeHost := "claw-default.apps.example.com"
 
 				require.NoError(t, k8sClient.Create(ctx, route), "failed to create Route")
 
 				waitFor(t, timeout, interval, func() bool {
-					return k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw", Namespace: namespace}, route) == nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: ClawRouteName, Namespace: namespace}, route) == nil
 				}, "Route should be created")
 
 				route.Object["status"] = map[string]interface{}{
@@ -955,7 +955,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 						Version: "v1",
 						Kind:    "Route",
 					})
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: "openclaw", Namespace: namespace}, createdRoute)
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawRouteName, Namespace: namespace}, createdRoute)
 					if err != nil {
 						return false
 					}
@@ -975,7 +975,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 					return err == nil
-				}, "openclaw Deployment should be created")
+				}, "claw Deployment should be created")
 
 				deployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -989,7 +989,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 					return err == nil
-				}, "openclaw-proxy Deployment should be created")
+				}, "claw-proxy Deployment should be created")
 
 				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 					{
@@ -1126,7 +1126,7 @@ func TestOpenClawURLStatusField(t *testing.T) {
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawDeploymentName, Namespace: namespace}, deployment)
 				return err == nil
-			}, "openclaw deployment to be created")
+			}, "claw deployment to be created")
 
 			deployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -1134,13 +1134,13 @@ func TestOpenClawURLStatusField(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				},
 			}
-			require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update openclaw deployment status")
+			require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update claw deployment status")
 
 			proxyDeployment := &appsv1.Deployment{}
 			waitFor(t, timeout, interval, func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: ClawProxyDeploymentName, Namespace: namespace}, proxyDeployment)
 				return err == nil
-			}, "openclaw-proxy deployment to be created")
+			}, "claw-proxy deployment to be created")
 
 			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 				{
@@ -1148,7 +1148,7 @@ func TestOpenClawURLStatusField(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				},
 			}
-			require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update openclaw-proxy deployment status")
+			require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update claw-proxy deployment status")
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
@@ -1185,7 +1185,7 @@ func TestGatewayTokenRetrieval(t *testing.T) {
 		}
 	}
 
-	t.Run("should retrieve and decode gateway token from openclaw-gateway-token", func(t *testing.T) {
+	t.Run("should retrieve and decode gateway token from claw-gateway-token", func(t *testing.T) {
 		setupGatewaySecretTest(t)
 		t.Cleanup(func() {
 			deleteAndWaitAllResources(t, namespace)
@@ -1281,15 +1281,15 @@ func TestURLConstructionWithTokenFragment(t *testing.T) {
 		}{
 			{
 				name:     "should append token fragment when both route and token are provided",
-				routeURL: "https://openclaw-route.apps.example.com",
+				routeURL: "https://claw-route.apps.example.com",
 				token:    "abc123def456",
-				expected: "https://openclaw-route.apps.example.com#token=abc123def456",
+				expected: "https://claw-route.apps.example.com#token=abc123def456",
 			},
 			{
 				name:     "should return route URL without fragment when token is empty",
-				routeURL: "https://openclaw-route.apps.example.com",
+				routeURL: "https://claw-route.apps.example.com",
 				token:    "",
-				expected: "https://openclaw-route.apps.example.com",
+				expected: "https://claw-route.apps.example.com",
 			},
 			{
 				name:     "should return empty string when route URL is empty",
@@ -1305,9 +1305,9 @@ func TestURLConstructionWithTokenFragment(t *testing.T) {
 			},
 			{
 				name:     "should percent-encode special characters in token",
-				routeURL: "https://openclaw-route.apps.example.com",
+				routeURL: "https://claw-route.apps.example.com",
 				token:    "token+with=special&chars#fragment",
-				expected: "https://openclaw-route.apps.example.com#token=token%2Bwith%3Dspecial%26chars%23fragment",
+				expected: "https://claw-route.apps.example.com#token=token%2Bwith%3Dspecial%26chars%23fragment",
 			},
 		}
 		for _, tt := range tests {
@@ -1319,12 +1319,12 @@ func TestURLConstructionWithTokenFragment(t *testing.T) {
 	})
 
 	t.Run("should follow format https://<route-host>#token=<gateway-token>", func(t *testing.T) {
-		routeURL := "https://openclaw-default.apps.cluster.example.com"
+		routeURL := "https://claw-default.apps.cluster.example.com"
 		token := "64chartoken1234567890abcdef64chartoken1234567890abcdef123456"
 
 		result := buildClawURL(routeURL, token)
 
-		expected := "https://openclaw-default.apps.cluster.example.com#token=64chartoken1234567890abcdef64chartoken1234567890abcdef123456"
+		expected := "https://claw-default.apps.cluster.example.com#token=64chartoken1234567890abcdef64chartoken1234567890abcdef123456"
 		assert.Equal(t, expected, result, "URL construction result")
 		assert.True(t, strings.HasPrefix(result, "https://"), "expected result to start with https://")
 		assert.Contains(t, result, "#token=")

--- a/internal/proxy/injector_gcp.go
+++ b/internal/proxy/injector_gcp.go
@@ -120,7 +120,7 @@ func hostnameOnly(hostPort string) string {
 // TokenVendingResponse returns a dummy access token for Google SDK client satisfaction.
 func TokenVendingResponse() []byte {
 	resp := map[string]any{
-		"access_token": "openclaw-proxy-vended-token",
+		"access_token": "claw-proxy-vended-token",
 		"token_type":   "Bearer",
 		"expires_in":   3600,
 	}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -234,7 +234,7 @@ func TestLeafCertGeneration(t *testing.T) {
 
 func TestTokenVendingResponse(t *testing.T) {
 	data := TokenVendingResponse()
-	assert.Contains(t, string(data), "openclaw-proxy-vended-token")
+	assert.Contains(t, string(data), "claw-proxy-vended-token")
 	assert.Contains(t, string(data), "Bearer")
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,7 +40,7 @@ var (
 	projectImage = "example.com/claw-operator:v0.0.1"
 
 	// proxyImage is the credential proxy sidecar image, built and loaded alongside the operator.
-	proxyImage = "example.com/openclaw-proxy:latest"
+	proxyImage = "example.com/claw-proxy:latest"
 )
 
 // TestMain runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -359,7 +359,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			t.Log("verifying CRED_GEMINI env var references the user's Secret")
 			jp := "jsonpath={.spec.template.spec.containers[?(@.name=='proxy')]" +
 				".env[?(@.name=='CRED_GEMINI')].valueFrom.secretKeyRef.name}"
-			cmd = exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+			cmd = exec.Command("kubectl", "get", "deployment", "claw-proxy",
 				"-o", jp, "-n", userNamespace)
 			output, err := utils.Run(t, cmd)
 			require.NoError(t, err)
@@ -367,16 +367,16 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				"CRED_GEMINI should reference gemini-api-key Secret")
 
 			t.Log("verifying proxy-config ConfigMap was generated")
-			cmd = exec.Command("kubectl", "get", "configmap", "openclaw-proxy-config",
+			cmd = exec.Command("kubectl", "get", "configmap", "claw-proxy-config",
 				"-o", "jsonpath={.data.proxy-config\\.json}",
 				"-n", userNamespace)
 			configOutput, err := utils.Run(t, cmd)
-			require.NoError(t, err, "openclaw-proxy-config ConfigMap should exist")
+			require.NoError(t, err, "claw-proxy-config ConfigMap should exist")
 			assert.Contains(t, configOutput, ".googleapis.com",
 				"proxy config should contain the credential domain")
 
 			t.Log("verifying the proxy CA Secret was created")
-			cmd = exec.Command("kubectl", "get", "secret", "openclaw-proxy-ca",
+			cmd = exec.Command("kubectl", "get", "secret", "claw-proxy-ca",
 				"-o", "jsonpath={.data.ca\\.crt}",
 				"-n", userNamespace)
 			caOutput, err := utils.Run(t, cmd)
@@ -384,13 +384,13 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			assert.NotEmpty(t, caOutput, "CA cert should not be empty")
 
 			t.Log("verifying the ingress NetworkPolicy exists")
-			cmd = exec.Command("kubectl", "get", "networkpolicy", "openclaw-ingress",
+			cmd = exec.Command("kubectl", "get", "networkpolicy", "claw-ingress",
 				"-n", userNamespace)
 			_, err = utils.Run(t, cmd)
 			require.NoError(t, err, "Ingress NetworkPolicy should exist")
 
 			t.Log("verifying the gateway Secret was created with a token")
-			cmd = exec.Command("kubectl", "get", "secret", "openclaw-gateway-token",
+			cmd = exec.Command("kubectl", "get", "secret", "claw-gateway-token",
 				"-o", "jsonpath={.data.token}",
 				"-n", userNamespace)
 			tokenOutput, err := utils.Run(t, cmd)
@@ -403,7 +403,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				"-n", userNamespace)
 			secretRefOutput, err := utils.Run(t, cmd)
 			require.NoError(t, err)
-			assert.Equal(t, "openclaw-gateway-token", secretRefOutput)
+			assert.Equal(t, "claw-gateway-token", secretRefOutput)
 
 			t.Log("verifying CredentialsResolved condition")
 			cmd = exec.Command("kubectl", "get", "claw", "instance",
@@ -452,10 +452,10 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			_, err = utils.Run(t, cmd)
 			require.NoError(t, err, "Failed to apply Claw CR")
 
-			t.Log("waiting for openclaw-proxy deployment")
+			t.Log("waiting for claw-proxy deployment")
 			deadline := time.Now().Add(2 * time.Minute)
 			for time.Now().Before(deadline) {
-				cmd := exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+				cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
 					"-n", userNamespace)
 				_, err := utils.Run(t, cmd)
 				if err == nil {
@@ -467,7 +467,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			t.Log("verifying CRED_GEMINI references the correct Secret name")
 			jp := "jsonpath={.spec.template.spec.containers[?(@.name=='proxy')]" +
 				".env[?(@.name=='CRED_GEMINI')].valueFrom.secretKeyRef.name}"
-			cmd = exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+			cmd = exec.Command("kubectl", "get", "deployment", "claw-proxy",
 				"-o", jp, "-n", userNamespace)
 			output, err := utils.Run(t, cmd)
 			require.NoError(t, err)
@@ -476,14 +476,14 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			t.Log("verifying CRED_GEMINI references the correct Secret key")
 			jp = "jsonpath={.spec.template.spec.containers[?(@.name=='proxy')]" +
 				".env[?(@.name=='CRED_GEMINI')].valueFrom.secretKeyRef.key}"
-			cmd = exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+			cmd = exec.Command("kubectl", "get", "deployment", "claw-proxy",
 				"-o", jp, "-n", userNamespace)
 			output, err = utils.Run(t, cmd)
 			require.NoError(t, err)
 			assert.Equal(t, "api-key", output)
 
 			t.Log("verifying the deployment uses the proxy container")
-			cmd = exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+			cmd = exec.Command("kubectl", "get", "deployment", "claw-proxy",
 				"-o", "jsonpath={.spec.template.spec.containers[0].name}",
 				"-n", userNamespace)
 			output, err = utils.Run(t, cmd)
@@ -493,7 +493,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			t.Log("verifying pods are running")
 			deadline = time.Now().Add(3 * time.Minute)
 			for time.Now().Before(deadline) {
-				cmd := exec.Command("kubectl", "get", "pods", "-l", "app=openclaw-proxy",
+				cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw-proxy",
 					"-o", "jsonpath={.items[*].status.phase}",
 					"-n", userNamespace)
 				output, err := utils.Run(t, cmd)
@@ -551,7 +551,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
 				func(ctx context.Context) (bool, error) {
 					cmd := exec.Command("kubectl", "get", "pods",
-						"-l", "app=openclaw-proxy",
+						"-l", "app=claw-proxy",
 						"-o", "jsonpath={.items[0].status.phase}",
 						"-n", userNamespace)
 					output, err := utils.Run(t, cmd)
@@ -560,7 +560,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "proxy pod did not reach Running phase")
 
 			t.Log("capturing original pod UID")
-			cmd = exec.Command("kubectl", "get", "pods", "-l", "app=openclaw-proxy",
+			cmd = exec.Command("kubectl", "get", "pods", "-l", "app=claw-proxy",
 				"-o", "jsonpath={.items[0].metadata.uid}",
 				"-n", userNamespace)
 			originalPodUID, err := utils.Run(t, cmd)
@@ -591,7 +591,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				func(ctx context.Context) (bool, error) {
 					jp := "jsonpath={.spec.template.spec.containers[?(@.name=='proxy')]" +
 						".env[?(@.name=='CRED_GEMINI')].valueFrom.secretKeyRef.name}"
-					cmd := exec.Command("kubectl", "get", "deployment", "openclaw-proxy",
+					cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
 						"-o", jp, "-n", userNamespace)
 					output, err := utils.Run(t, cmd)
 					return err == nil && output == "llm-key-2", nil
@@ -603,7 +603,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
 				func(ctx context.Context) (bool, error) {
 					cmd := exec.Command("kubectl", "get", "pods",
-						"-l", "app=openclaw-proxy",
+						"-l", "app=claw-proxy",
 						"-o", "jsonpath={.items[0].metadata.uid}",
 						"-n", userNamespace)
 					uid, err := utils.Run(t, cmd)
@@ -621,7 +621,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
 				func(ctx context.Context) (bool, error) {
 					cmd := exec.Command("kubectl", "get", "pods",
-						"-l", "app=openclaw-proxy",
+						"-l", "app=claw-proxy",
 						"-o", "jsonpath={.items[0].status.phase}",
 						"-n", userNamespace)
 					output, err := utils.Run(t, cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -491,6 +491,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			assert.Equal(t, "proxy", output, "First container should be named 'proxy'")
 
 			t.Log("verifying pods are running")
+			var podsRunning bool
 			deadline = time.Now().Add(3 * time.Minute)
 			for time.Now().Before(deadline) {
 				cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw-proxy",
@@ -498,10 +499,13 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 					"-n", userNamespace)
 				output, err := utils.Run(t, cmd)
 				if err == nil && strings.Contains(output, podPhaseRunning) {
+					podsRunning = true
 					break
 				}
 				time.Sleep(pollInterval)
 			}
+			require.True(t, podsRunning,
+				"claw-proxy pods in namespace %s never reached Running phase", userNamespace)
 		})
 
 		t.Run("should trigger pod restart when credential Secret reference changes", func(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -453,19 +453,15 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "Failed to apply Claw CR")
 
 			t.Log("waiting for claw-proxy deployment")
-			var deploymentFound bool
-			deadline := time.Now().Add(2 * time.Minute)
-			for time.Now().Before(deadline) {
-				cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
-					"-n", userNamespace)
-				_, err := utils.Run(t, cmd)
-				if err == nil {
-					deploymentFound = true
-					break
-				}
-				time.Sleep(pollInterval)
-			}
-			require.True(t, deploymentFound,
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, 2*time.Minute, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
+						"-n", userNamespace)
+					_, err := utils.Run(t, cmd)
+					return err == nil, nil
+				})
+			require.NoError(t, err,
 				"timed out waiting for claw-proxy deployment in namespace %s", userNamespace)
 
 			t.Log("verifying CRED_GEMINI references the correct Secret name")
@@ -495,20 +491,15 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			assert.Equal(t, "proxy", output, "First container should be named 'proxy'")
 
 			t.Log("verifying pods are running")
-			var podsRunning bool
-			deadline = time.Now().Add(3 * time.Minute)
-			for time.Now().Before(deadline) {
-				cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw-proxy",
-					"-o", "jsonpath={.items[*].status.phase}",
-					"-n", userNamespace)
-				output, err := utils.Run(t, cmd)
-				if err == nil && strings.Contains(output, podPhaseRunning) {
-					podsRunning = true
-					break
-				}
-				time.Sleep(pollInterval)
-			}
-			require.True(t, podsRunning,
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, 3*time.Minute, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw-proxy",
+						"-o", "jsonpath={.items[*].status.phase}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && strings.Contains(output, podPhaseRunning), nil
+				})
+			require.NoError(t, err,
 				"claw-proxy pods in namespace %s never reached Running phase", userNamespace)
 		})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -453,16 +453,20 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "Failed to apply Claw CR")
 
 			t.Log("waiting for claw-proxy deployment")
+			var deploymentFound bool
 			deadline := time.Now().Add(2 * time.Minute)
 			for time.Now().Before(deadline) {
 				cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
 					"-n", userNamespace)
 				_, err := utils.Run(t, cmd)
 				if err == nil {
+					deploymentFound = true
 					break
 				}
 				time.Sleep(pollInterval)
 			}
+			require.True(t, deploymentFound,
+				"timed out waiting for claw-proxy deployment in namespace %s", userNamespace)
 
 			t.Log("verifying CRED_GEMINI references the correct Secret name")
 			jp := "jsonpath={.spec.template.spec.containers[?(@.name=='proxy')]" +


### PR DESCRIPTION
- Rename all Kubernetes resource names: deployments (openclaw → claw, openclaw-proxy → claw-proxy), services, configmaps, PVC, networkpolicies, route, secrets (gateway-token, proxy-ca)
- Update app labels and kustomization label from openclaw to claw
- Rename proxy image from openclaw-proxy to claw-proxy in Makefile, manager config, and embedded manifests
- Update controller constants, error messages, and comments
- Update all unit tests, e2e tests, and documentation
- Upstream references preserved: openclaw.json, .openclaw/ dir, ghcr.io/openclaw/openclaw image, OPENCLAW_* env vars


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed resources, labels and default image references from "openclaw"/"openclaw-proxy" to "claw"/"claw-proxy" across manifests, deployment configs, Makefile, and project metadata; updated domain and leader-election identity.
* **Documentation**
  * Updated README, examples, status/diagnostic text and CLI/operational commands to use the new resource names.
* **Tests**
  * Updated unit, integration and e2e tests to reference the renamed resources and the new proxy image names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->