### PR TITLE
fix: resolve OpenShift deployment issues and improve dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,12 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 # generate-deploy-overlay creates a temporary kustomize overlay at config/.deploy/
 # that wraps config/default with image and PROXY_IMAGE overrides.
 # This avoids mutating committed files (manager.yaml, kustomization.yaml).
-# Usage: $(call generate-deploy-overlay,<controller-image>,<proxy-image>)
+# Usage: $(call generate-deploy-overlay,<controller-image>,<proxy-image>[,<pull-policy>])
+# pull-policy defaults to IfNotPresent; dev-deploy passes Always to force re-pulls.
 define generate-deploy-overlay
 	@rm -rf config/.deploy && mkdir -p config/.deploy
 	@printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n- ../default\nimages:\n- name: controller\n  newName: $(shell echo $(1) | cut -d: -f1)\n  newTag: $(shell echo $(1) | cut -d: -f2)\npatches:\n- path: proxy_image_patch.yaml\n  target:\n    kind: Deployment\n' > config/.deploy/kustomization.yaml
-	@printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: controller-manager\nspec:\n  template:\n    spec:\n      containers:\n      - name: manager\n        env:\n        - name: PROXY_IMAGE\n          value: "$(2)"\n' > config/.deploy/proxy_image_patch.yaml
+	@printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: controller-manager\nspec:\n  template:\n    spec:\n      containers:\n      - name: manager\n        imagePullPolicy: $(or $(3),IfNotPresent)\n        env:\n        - name: PROXY_IMAGE\n          value: "$(2)"\n' > config/.deploy/proxy_image_patch.yaml
 endef
 
 ##@ Deployment
@@ -285,12 +286,14 @@ endif
 	$(MAKE) docker-push-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-deploy
-dev-deploy: ## Install CRDs and deploy controller for dev.
+dev-deploy: manifests kustomize ## Install CRDs and deploy controller for dev (uses Always pull policy).
 ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-deploy REGISTRY=quay.io/myuser)
 endif
 	$(MAKE) install
-	$(MAKE) deploy IMG=$(REGISTRY)/claw-operator:$(TAG) PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
+	$(call generate-deploy-overlay,$(REGISTRY)/claw-operator:$(TAG),$(REGISTRY)/claw-proxy:$(TAG),Always)
+	$(KUSTOMIZE) build config/.deploy | $(KUBECTL) apply -f -
+	@rm -rf config/.deploy
 
 .PHONY: dev-setup
 dev-setup: ## Full dev setup: build, push, and deploy.

--- a/Makefile
+++ b/Makefile
@@ -256,8 +256,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(call generate-deploy-overlay,$(IMG),$(PROXY_IMG))
-	$(KUSTOMIZE) build config/.deploy | $(KUBECTL) apply -f -
-	@rm -rf config/.deploy
+	@trap 'rm -rf config/.deploy' EXIT; $(KUSTOMIZE) build config/.deploy | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -292,8 +291,7 @@ ifndef REGISTRY
 endif
 	$(MAKE) install
 	$(call generate-deploy-overlay,$(REGISTRY)/claw-operator:$(TAG),$(REGISTRY)/claw-proxy:$(TAG),Always)
-	$(KUSTOMIZE) build config/.deploy | $(KUBECTL) apply -f -
-	@rm -rf config/.deploy
+	@trap 'rm -rf config/.deploy' EXIT; $(KUSTOMIZE) build config/.deploy | $(KUBECTL) apply -f -
 
 .PHONY: dev-setup
 dev-setup: ## Full dev setup: build, push, and deploy.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ oc apply -f config/samples/claw_v1alpha1_claw.yaml -n <user-namespace>
 
 Or create it directly:
 
-```yaml
+```sh
+oc apply -f - <<'EOF'
 apiVersion: claw.sandbox.redhat.com/v1alpha1
 kind: Claw
 metadata:
@@ -264,6 +265,7 @@ spec:
       domain: ".googleapis.com"
       apiKey:
         header: x-goog-api-key
+EOF
 ```
 
 **3. Watch the instance become ready:**
@@ -290,7 +292,25 @@ oc port-forward svc/claw 18789:18789 -n claw-operator
 
 Then open http://localhost:18789 in your browser.
 
-**5. Authenticate with the gateway token:**
+**5. Approve device pairing:**
+
+On first connection from a new browser you'll see **"pairing required"**. This is OpenClaw's device authentication -- remote connections require a one-time approval.
+
+With the browser tab open (so the pairing request stays active), list pending requests and approve:
+
+```sh
+# List pending pairing requests
+oc exec -n claw-operator deployment/claw -- \
+  node /app/dist/index.js devices list
+
+# Approve by request ID (copy from the Pending table above)
+oc exec -n claw-operator deployment/claw -- \
+  node /app/dist/index.js devices approve <requestId>
+```
+
+Refresh the browser after approval. The device is remembered -- you won't need to pair again unless you clear browser data or switch browsers.
+
+**6. Authenticate with the gateway token:**
 
 The operator generates a gateway authentication token stored in a Secret. Retrieve it with:
 

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -18,9 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsUser: 65532
         runAsNonRoot: true
-        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       initContainers:

--- a/internal/controller/claw_credentials_test.go
+++ b/internal/controller/claw_credentials_test.go
@@ -194,16 +194,22 @@ func TestOpenClawCredentialValidation(t *testing.T) {
 		updated := &clawv1alpha1.Claw{}
 		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: ClawInstanceName, Namespace: namespace}, updated))
 
-		var found bool
+		var credFound, readyFound bool
 		for _, c := range updated.Status.Conditions {
 			if c.Type == clawv1alpha1.ConditionTypeCredentialsResolved {
-				found = true
+				credFound = true
 				assert.Equal(t, "False", string(c.Status))
 				assert.Equal(t, clawv1alpha1.ConditionReasonValidationFailed, c.Reason)
-				break
+			}
+			if c.Type == clawv1alpha1.ConditionTypeReady {
+				readyFound = true
+				assert.Equal(t, "False", string(c.Status))
+				assert.Equal(t, clawv1alpha1.ConditionReasonValidationFailed, c.Reason)
+				assert.Contains(t, c.Message, "Secret \"missing\" not found")
 			}
 		}
-		assert.True(t, found, "CredentialsResolved=False condition should be set on validation failure")
+		assert.True(t, credFound, "CredentialsResolved=False condition should be set on validation failure")
+		assert.True(t, readyFound, "Ready=False condition should be set on validation failure")
 	})
 
 	t.Run("should set CredentialsResolved condition", func(t *testing.T) {

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -137,6 +137,7 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.validateCredentials(ctx, instance); err != nil {
 		logger.Error(err, "Credential validation failed")
 		setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
+		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
 		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after credential validation failure")
 		}
@@ -155,6 +156,7 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		logger.Error(err, "Failed to generate proxy config")
 		setCondition(instance, clawv1alpha1.ConditionTypeProxyConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
+		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
 		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after proxy config failure")
 		}
@@ -164,6 +166,7 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.applyProxyConfigMap(ctx, instance, proxyConfigJSON); err != nil {
 		logger.Error(err, "Failed to apply proxy config")
 		setCondition(instance, clawv1alpha1.ConditionTypeProxyConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
+		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
 		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after proxy config failure")
 		}


### PR DESCRIPTION
- Remove hardcoded runAsUser/fsGroup from claw deployment to comply with OpenShift restricted-v2 SCC (namespace-allocated UIDs)
- Set Ready=False condition on credential validation and proxy config failures so `oc get claws` shows errors immediately
- Add imagePullPolicy override to dev-deploy (Always) so rebuilds with the same tag are picked up without manual intervention
- Add device pairing instructions to README (step 5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status now includes a `Ready` condition alongside credential and proxy configuration states for clearer failure reporting.

* **Documentation**
  * Deployment docs updated: initial browser connection now requires approving device pairing; includes commands to list and approve pairing requests.

* **Infrastructure**
  * Deployment overlay accepts an optional image pull policy; developer deploy uses Always by default.
  * Pod security defaults adjusted to enforce non-root execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->