### PR TITLE
build: add multi-platform container build support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.25 AS builder
+FROM --platform=${BUILDPLATFORM} mirror.gcr.io/library/golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Containerfile.proxy
+++ b/Containerfile.proxy
@@ -1,5 +1,5 @@
 # Build the proxy binary
-FROM mirror.gcr.io/library/golang:1.25 AS builder
+FROM --platform=${BUILDPLATFORM} mirror.gcr.io/library/golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -15,7 +15,7 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
 	-o proxy cmd/proxy/main.go
 
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/proxy .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} \
+	$(CONTAINER_TOOL) build --platform=${PLATFORM} -t ${IMG} \
 		--build-arg VERSION=$$(git rev-parse --short HEAD) \
 		--build-arg BUILD_TIME=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 		-f Containerfile .
@@ -198,7 +198,7 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: docker-build-proxy
 docker-build-proxy: ## Build docker image for the credential proxy.
-	$(CONTAINER_TOOL) build -t ${PROXY_IMG} -f Containerfile.proxy .
+	$(CONTAINER_TOOL) build --platform=${PLATFORM} -t ${PROXY_IMG} -f Containerfile.proxy .
 
 .PHONY: docker-push-proxy
 docker-push-proxy: ## Push docker image for the credential proxy.
@@ -402,7 +402,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_TOOL) build --platform=${PLATFORM} -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.


### PR DESCRIPTION
Enable cross-platform container builds by adding platform-specific
flags to Containerfile and Makefile build targets.

Changes:
- Add `--platform=${BUILDPLATFORM}` to builder stage in
`Containerfile` and `Containerfile.proxy` to use native build platform
for faster compilation
- Add `--platform=${TARGETPLATFORM}` to runtime stage for correct
target architecture
- Add `--platform=${PLATFORM}` flag to `docker-build`,
`docker-build-proxy`, and `bundle-build` targets in `Makefile`

This enables building container images for different architectures
(e.g., `amd64`, `arm64`) and supports Docker/Podman multi-platform
builds.

Assisted-by: Claude Sonnet 4.5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to explicitly specify target platforms for multi-stage builds, which enhances cross-platform compatibility and improves build reliability across different system architectures.
  * Enhanced Docker and OCI build recipes with explicit platform targeting parameters to ensure consistent and reliable container image deployments across multiple system architectures and deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->