### PR TITLE
fix: enforce user 1000 in pod security contexts

### DIFF
--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       initContainers:

--- a/internal/assets/manifests/proxy-deployment.yaml
+++ b/internal/assets/manifests/proxy-deployment.yaml
@@ -16,6 +16,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
Explicitly configure pod security contexts to run as
user 1000:
- Add `runAsUser`, `runAsGroup`, and `fsGroup` to `claw`
deployment
- Add `runAsNonRoot`, `runAsUser`, `runAsGroup`, and `fsGroup`
to `proxy` deployment

This hardens the security posture by ensuring both
deployments run with a specific non-root user ID (1000),
improving compatibility with restricted security policies.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pod-level security context configuration across deployment manifests to enforce stricter container security policies. Updated settings include explicit user and group ID assignments, non-root execution enforcement, and filesystem group ownership configuration to strengthen container isolation and improve overall security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->