### PR TITLE
chore: cleanup podman and readme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
 - `Age`: Shows creation timestamp via JSONPath `.metadata.creationTimestamp`
 
 **Version Logging:**
-The operator logs version and build time at startup: `version` (short commit SHA) and `buildTime` (RFC3339). Injected via LDFLAGS during `docker-build`. Local builds show defaults (`dev`/`unknown`).
+The operator logs version and build time at startup: `version` (short commit SHA) and `buildTime` (RFC3339). Injected via LDFLAGS during `container-build`. Local builds show defaults (`dev`/`unknown`).
 
 ## Common Commands
 
@@ -96,8 +96,8 @@ make setup-test-e2e     # Create Kind cluster
 make test-e2e           # Run e2e tests
 make cleanup-test-e2e   # Tear down Kind cluster
 
-# Docker
-make docker-build IMG=<registry>/claw-operator:tag
+# Container
+make container-build IMG=<registry>/claw-operator:tag
 
 # Dev deployment (OpenShift/Kubernetes)
 make dev-setup REGISTRY=quay.io/myuser           # Build + push + deploy (one command)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ make container-build IMG=<registry>/claw-operator:tag
 # Dev deployment (OpenShift/Kubernetes)
 make dev-setup REGISTRY=quay.io/myuser           # Build + push + deploy (one command)
 make dev-build dev-push dev-deploy REGISTRY=...   # Iterate after code changes
+make wait-ready NS=claw-operator                  # Wait for ready, print URL + token
+make approve-pairing NS=claw-operator             # List & approve a device pairing request
 make dev-cleanup                                  # Tear down
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -80,32 +80,35 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
 	@mkdir -p tmp
-	@kubectl config current-context > tmp/.pre-e2e-context 2>/dev/null || true
-	@kubectl config use-context kind-$(KIND_CLUSTER)
+	@$(KUBECTL) config current-context > tmp/.pre-e2e-context 2>/dev/null || true
+	@$(KUBECTL) config use-context kind-$(KIND_CLUSTER)
 
 .PHONY: reset-test-e2e
 reset-test-e2e: ## Remove leftover operator resources from a previous e2e run
 	@echo "Resetting e2e test state..."
 	-$(MAKE) undeploy 2>/dev/null
 	-$(MAKE) uninstall 2>/dev/null
-	-kubectl delete ns claw-operator --ignore-not-found
+	-$(KUBECTL) delete ns claw-operator --ignore-not-found
 
 .PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet reset-test-e2e ## Run the e2e tests. Expected an isolated environment using Kind.
+test-e2e: ## Run the e2e tests. Expected an isolated environment using Kind.
+	@trap '$(MAKE) cleanup-test-e2e >/dev/null 2>&1 || true' EXIT; \
+	$(MAKE) setup-test-e2e manifests generate fmt vet reset-test-e2e; \
 	KIND_CLUSTER=$(KIND_CLUSTER) go test -v ./test/e2e/
-	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
-	@$(KIND) delete cluster --name $(KIND_CLUSTER)
-	@if [ -f tmp/.pre-e2e-context ]; then \
+	@status=0; \
+	$(KIND) delete cluster --name $(KIND_CLUSTER) || status=$$?; \
+	if [ -f tmp/.pre-e2e-context ]; then \
 		ctx=$$(cat tmp/.pre-e2e-context); \
 		rm -f tmp/.pre-e2e-context; \
-		if [ -n "$$ctx" ] && kubectl config get-contexts "$$ctx" >/dev/null 2>&1; then \
+		if [ -n "$$ctx" ] && $(KUBECTL) config get-contexts "$$ctx" >/dev/null 2>&1; then \
 			echo "Restoring kubectl context to $$ctx"; \
-			kubectl config use-context "$$ctx"; \
+			$(KUBECTL) config use-context "$$ctx"; \
 		fi; \
-	fi
+	fi; \
+	exit $$status
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
@@ -243,7 +246,8 @@ wait-ready: ## Wait for the Claw instance to become ready and print the URL.
 	@$(KUBECTL) wait --for=condition=Ready claw/instance -n $(NS) --timeout=300s
 	@echo
 	@echo "URL: $$($(KUBECTL) get claw instance -n $(NS) -o jsonpath='{.status.url}')"
-	@echo "Token: $$($(KUBECTL) get secret claw-gateway-token -n $(NS) -o jsonpath='{.data.token}' | base64 -d)"
+	@token_secret=$$($(KUBECTL) get claw instance -n $(NS) -o jsonpath='{.status.gatewayTokenSecretRef}'); \
+	echo "Token: $$($(KUBECTL) get secret $$token_secret -n $(NS) -o jsonpath='{.data.token}' | base64 -d)"
 
 .PHONY: approve-pairing
 approve-pairing: ## Approve a device pairing request. Usage: make approve-pairing NS=... [REQUEST_ID=...]

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@mkdir -p tmp
 	@kubectl config current-context > tmp/.pre-e2e-context 2>/dev/null || true
 	@kubectl config use-context kind-$(KIND_CLUSTER)
 
@@ -233,6 +234,33 @@ endif
 	$(MAKE) dev-build REGISTRY=$(REGISTRY) TAG=$(TAG)
 	$(MAKE) dev-push REGISTRY=$(REGISTRY) TAG=$(TAG)
 	$(MAKE) dev-deploy REGISTRY=$(REGISTRY) TAG=$(TAG)
+
+NS ?= my-claw-namespace
+
+.PHONY: wait-ready
+wait-ready: ## Wait for the Claw instance to become ready and print the URL.
+	@echo "Waiting for Claw instance to become ready in namespace $(NS)..."
+	@$(KUBECTL) wait --for=condition=Ready claw/instance -n $(NS) --timeout=300s
+	@echo
+	@echo "URL: $$($(KUBECTL) get claw instance -n $(NS) -o jsonpath='{.status.url}')"
+	@echo "Token: $$($(KUBECTL) get secret claw-gateway-token -n $(NS) -o jsonpath='{.data.token}' | base64 -d)"
+
+.PHONY: approve-pairing
+approve-pairing: ## Approve a device pairing request. Usage: make approve-pairing NS=... [REQUEST_ID=...]
+	@if [ -n "$(REQUEST_ID)" ]; then \
+		$(KUBECTL) exec -n $(NS) deployment/claw -- node /app/dist/index.js devices approve $(REQUEST_ID); \
+	else \
+		output=$$($(KUBECTL) exec -n $(NS) deployment/claw -- node /app/dist/index.js devices list 2>/dev/null); \
+		rid=$$(echo "$$output" | grep -oP '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1); \
+		if [ -z "$$rid" ]; then \
+			echo "No pending pairing requests found."; \
+			exit 1; \
+		fi; \
+		echo "Found pairing request: $$rid"; \
+		read -r -p "Approve? [y/N] " ans; \
+		case "$$ans" in [yY]*) ;; *) echo "Aborted."; exit 0;; esac; \
+		$(KUBECTL) exec -n $(NS) deployment/claw -- node /app/dist/index.js devices approve "$$rid"; \
+	fi
 
 .PHONY: dev-cleanup
 dev-cleanup: ## Remove deployed controller and CRDs.

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ approve-pairing: ## Approve a device pairing request. Usage: make approve-pairin
 		$(KUBECTL) exec -n $(NS) deployment/claw -- node /app/dist/index.js devices approve $(REQUEST_ID); \
 	else \
 		output=$$($(KUBECTL) exec -n $(NS) deployment/claw -- node /app/dist/index.js devices list 2>/dev/null); \
-		rid=$$(echo "$$output" | grep -oP '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1); \
+		rid=$$(echo "$$output" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1); \
 		if [ -z "$$rid" ]; then \
 			echo "No pending pairing requests found."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -1,54 +1,3 @@
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
-
-# CHANNELS define the bundle channels used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
-# To re-generate a bundle for other specific channels without changing the standard setup, you can:
-# - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
-# - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-
-# DEFAULT_CHANNEL defines the default channel used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
-# To re-generate a bundle for any other default channel without changing the default setup, you can:
-# - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
-# - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
-
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-# This variable is used to construct full image tags for bundle and catalog images.
-#
-# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# claw.sandbox.redhat.com/claw-operator-bundle:$VERSION and claw.sandbox.redhat.com/claw-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= claw.sandbox.redhat.com/claw-operator
-
-# BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
-
-# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-
-# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
-# You can enable this value if you would like to use SHA Based Digests
-# To enable set flag to true
-USE_IMAGE_DIGESTS ?= false
-ifeq ($(USE_IMAGE_DIGESTS), true)
-	BUNDLE_GEN_FLAGS += --use-image-digests
-endif
-
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.42.0
 # Image URL to use all building/pushing image targets
 IMG ?= claw-operator:latest
 PROXY_IMG ?= claw-proxy:latest
@@ -62,10 +11,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
-# Be aware that the target commands are only tested with Docker which is
-# scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= podman
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -115,7 +61,7 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
-# The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# The default setup assumes Kind is pre-installed and builds/loads the Manager container image locally.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= claw-operator-test-e2e
@@ -177,56 +123,31 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: ## Build docker image with the manager.
+# (i.e. podman build --platform linux/arm64)
+.PHONY: container-build
+container-build: ## Build container image with the manager.
 	$(CONTAINER_TOOL) build --platform=${PLATFORM} -t ${IMG} \
 		--build-arg VERSION=$$(git rev-parse --short HEAD) \
 		--build-arg BUILD_TIME=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 		-f Containerfile .
 
-.PHONY: docker-save
-docker-save: ## Save the docker image to a tar file
+.PHONY: container-save
+container-save: ## Save the container image to a tar file.
 	mkdir -p tmp 2>/dev/null 
 	rm -f ${OUTPUT_FILE} || true
 	$(CONTAINER_TOOL) save -o ${OUTPUT_FILE} ${IMG}
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
+.PHONY: container-push
+container-push: ## Push container image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
-.PHONY: docker-build-proxy
-docker-build-proxy: ## Build docker image for the credential proxy.
+.PHONY: container-build-proxy
+container-build-proxy: ## Build container image for the credential proxy.
 	$(CONTAINER_TOOL) build --platform=${PLATFORM} -t ${PROXY_IMG} -f Containerfile.proxy .
 
-.PHONY: docker-push-proxy
-docker-push-proxy: ## Push docker image for the credential proxy.
+.PHONY: container-push-proxy
+container-push-proxy: ## Push container image for the credential proxy.
 	$(CONTAINER_TOOL) push ${PROXY_IMG}
-
-# PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
-# - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
-# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-.PHONY: docker-buildx
-docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Containerfile and insert --platform=${BUILDPLATFORM} into Containerfile.cross, and preserve the original Containerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Containerfile > Containerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name claw-operator-builder
-	$(CONTAINER_TOOL) buildx use claw-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Containerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm claw-operator-builder
-	rm Containerfile.cross
-
-.PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	mkdir -p dist
-	$(call generate-deploy-overlay,$(IMG),$(PROXY_IMG))
-	$(KUSTOMIZE) build config/.deploy > dist/install.yaml
-	@rm -rf config/.deploy
 
 # generate-deploy-overlay creates a temporary kustomize overlay at config/.deploy/
 # that wraps config/default with image and PROXY_IMAGE overrides.
@@ -273,16 +194,16 @@ dev-build: ## Build operator and proxy images for dev.
 ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-build REGISTRY=quay.io/myuser)
 endif
-	$(MAKE) docker-build IMG=$(REGISTRY)/claw-operator:$(TAG)
-	$(MAKE) docker-build-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
+	$(MAKE) container-build IMG=$(REGISTRY)/claw-operator:$(TAG)
+	$(MAKE) container-build-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-push
 dev-push: ## Push operator and proxy images for dev.
 ifndef REGISTRY
 	$(error REGISTRY is required. Usage: make dev-push REGISTRY=quay.io/myuser)
 endif
-	$(MAKE) docker-push IMG=$(REGISTRY)/claw-operator:$(TAG)
-	$(MAKE) docker-push-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
+	$(MAKE) container-push IMG=$(REGISTRY)/claw-operator:$(TAG)
+	$(MAKE) container-push-proxy PROXY_IMG=$(REGISTRY)/claw-proxy:$(TAG)
 
 .PHONY: dev-deploy
 dev-deploy: manifests kustomize ## Install CRDs and deploy controller for dev (uses Always pull policy).
@@ -376,75 +297,3 @@ mv $(1) $(1)-$(3) ;\
 ln -sf $(1)-$(3) $(1)
 endef
 
-.PHONY: operator-sdk
-OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
-ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (, $(shell which operator-sdk 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-	chmod +x $(OPERATOR_SDK) ;\
-	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
-endif
-
-.PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./bundle
-
-.PHONY: bundle-build
-bundle-build: ## Build the bundle image.
-	$(CONTAINER_TOOL) build --platform=${PLATFORM} -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
-.PHONY: bundle-push
-bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
-
-.PHONY: opm
-OPM = $(LOCALBIN)/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.55.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
-
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@kubectl config current-context > tmp/.pre-e2e-context 2>/dev/null || true
+	@kubectl config use-context kind-$(KIND_CLUSTER)
 
 .PHONY: reset-test-e2e
 reset-test-e2e: ## Remove leftover operator resources from a previous e2e run
@@ -95,6 +97,14 @@ test-e2e: setup-test-e2e manifests generate fmt vet reset-test-e2e ## Run the e2
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
+	@if [ -f tmp/.pre-e2e-context ]; then \
+		ctx=$$(cat tmp/.pre-e2e-context); \
+		rm -f tmp/.pre-e2e-context; \
+		if [ -n "$$ctx" ] && kubectl config get-contexts "$$ctx" >/dev/null 2>&1; then \
+			echo "Restoring kubectl context to $$ctx"; \
+			kubectl config use-context "$$ctx"; \
+		fi; \
+	fi
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Make sure the `claw-operator` and `claw-proxy` repositories on quay.io are set t
 Then build, push, and deploy in one command:
 
 ```sh
-make dev-setup REGISTRY=quay.io/myuser
+make dev-setup REGISTRY=quay.io/<your-user>
 ```
 
 This builds both images (operator + proxy), pushes them, installs CRDs, and deploys the controller into the `claw-operator` namespace.
@@ -118,11 +118,7 @@ On first connection you'll see "pairing required". With the browser tab open, ap
 make approve-pairing NS=$NS
 ```
 
-This lists pending requests and prompts for the ID to approve. If you already know the ID:
-
-```sh
-make approve-pairing NS=$NS REQUEST_ID=<requestId>
-```
+This picks the first pending request and asks for confirmation.
 
 Refresh the browser after approval. The device is remembered across sessions.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The operator runs in `claw-operator`, but user workloads (Claw instances, secret
 
 ```sh
 export NS=my-claw-namespace
-oc new-project $NS 2>/dev/null || oc project $NS
+oc create namespace $NS
 ```
 
 ### 3. Create a Credential Secret

--- a/README.md
+++ b/README.md
@@ -1,262 +1,84 @@
 # Claw Operator
 
-An operator for managing OpenClaw instances in Red Hat's OpenShift.
+A Kubernetes operator that manages [OpenClaw](https://github.com/openclaw/openclaw) instances on OpenShift. It handles deployment, credential injection for LLM providers, HTTPS routing, and gateway authentication through a single `Claw` custom resource.
 
-## Description
+## Security
 
-The Claw Operator manages the lifecycle of OpenClaw instances through Kubernetes custom resources. It provides a declarative API for creating, configuring, and managing OpenClaw deployments within Kubernetes clusters.
+The operator applies multiple layers of defense:
 
-## Custom Resource Definition
+- **Sandboxing** -- each Claw instance runs in its own namespace with OpenShift's restricted SCC enforced automatically (UID isolation, SELinux, seccomp).
+- **Secret isolation** -- OpenClaw pods never see API keys or tokens. Credentials are only mounted in the proxy, which runs as a separate Deployment. The OpenClaw container has no Secret mounts and no environment variables containing credential values.
+- **Network isolation** -- OpenClaw pods cannot reach the internet directly; all outbound traffic is forced through the credential proxy via NetworkPolicy. The proxy only allows HTTPS (port 443) egress and rejects any domain not explicitly configured.
+- **Ingress restriction** -- only the OpenShift router namespace can reach the gateway port (NetworkPolicy on ingress).
+- **Credential injection** -- API keys and tokens are stored in user-managed Kubernetes Secrets and referenced by the proxy only (`secretKeyRef`/volume mount). The operator never reads or copies credential values.
+- **Gateway authentication** -- a cryptographically random 256-bit token is auto-generated per instance and required for all gateway access.
+- **Device pairing** -- remote browser connections require a one-time approval via CLI before they can interact with the instance.
+- **Pod hardening** -- all containers run as non-root, drop all Linux capabilities, use a read-only root filesystem, and set `seccompProfile: RuntimeDefault`.
+- **Minimal privileges** -- service account tokens are not mounted (`automountServiceAccountToken: false`).
+- **External secret management** -- credential Secrets are user-managed and fully compatible with [External Secrets Operator](https://external-secrets.io/), Sealed Secrets, or HashiCorp Vault. Using an external secret manager is recommended for production.
 
-### Claw
-
-The `Claw` custom resource represents a deployment of OpenClaw in your cluster.
-
-**API Group:** `claw.sandbox.redhat.com/v1alpha1`
-
-**Example:**
-```yaml
-apiVersion: claw.sandbox.redhat.com/v1alpha1
-kind: Claw
-metadata:
-  name: instance
-spec:
-  credentials:
-    - name: gemini
-      type: apiKey
-      secretRef:
-        name: gemini-api-key
-        key: api-key
-      domain: "generativelanguage.googleapis.com"
-      apiKey:
-        header: x-goog-api-key
-      provider: google
-```
-
-#### Spec Fields
-
-- `credentials` ([]CredentialSpec, optional): Configures proxy credential injection per domain. Each entry defines how the proxy authenticates outbound requests to a specific API provider.
-  - `name` (string, required): Unique identifier for this credential entry
-  - `type` (enum, required): Credential injection mechanism — one of `apiKey`, `bearer`, `gcp`, `pathToken`, `oauth2`, `none`
-  - `secretRef` (SecretRef, required for all types except `none`): Reference to a Kubernetes Secret holding the credential value
-    - `name` (string, required): Name of the Secret
-    - `key` (string, required): Key within the Secret's data map
-  - `domain` (string, required): Domain the proxy matches against the request Host header. Exact match (e.g., `api.github.com`) or suffix match with leading dot (e.g., `.googleapis.com`)
-  - `defaultHeaders` (map[string]string, optional): Headers injected on every proxied request for this credential
-  - `apiKey` (APIKeyConfig, required when type is `apiKey`): Custom header injection config
-    - `header` (string): Header name (e.g., `x-goog-api-key`, `x-api-key`)
-    - `valuePrefix` (string, optional): Prepended to the secret value before injection
-  - `gcp` (GCPConfig, required when type is `gcp`): GCP service account credential injection
-    - `project` (string): GCP project ID
-    - `location` (string): GCP region (e.g., `us-central1`)
-  - `pathToken` (PathTokenConfig, required when type is `pathToken`): URL path token injection
-    - `prefix` (string): Prepended before the token in the URL path (e.g., `/bot` for Telegram)
-  - `oauth2` (OAuth2Config, required when type is `oauth2`): Client credentials token exchange
-    - `clientID` (string): OAuth2 client ID
-    - `tokenURL` (string): OAuth2 token endpoint
-    - `scopes` ([]string, optional): Scopes requested during token exchange
-  - `provider` (string, optional): Maps this credential to an OpenClaw LLM provider (e.g., `google`, `anthropic`, `openai`, `openrouter`). When set, the controller configures the proxy's gateway mode for this credential and dynamically generates the provider entry in `openclaw.json` with a `baseUrl` pointing to the proxy. When omitted, the credential is used for MITM forward proxy only (no provider entry generated).
-
-#### Status Fields
-
-The controller automatically populates status conditions to track the deployment readiness of your Claw instance:
-
-- `conditions` (array): Standard Kubernetes conditions following the [metav1.Condition](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/condition/) format. Currently includes:
-  - **Ready**: Indicates whether the Claw instance is ready for use
-    - `status: "False"`, `reason: Provisioning` — Deployments are being created or are not yet ready
-    - `status: "True"`, `reason: Ready` — Both `claw` and `claw-proxy` Deployments are available
-  - **CredentialsResolved**: Indicates whether all credential Secrets have been validated
-    - `status: "False"`, `reason: ValidationFailed` — One or more credential Secrets are missing or invalid
-    - `status: "True"`, `reason: Resolved` — All credential Secrets are valid
-  - **ProxyConfigured**: Indicates whether the proxy configuration was generated successfully
-    - `status: "False"`, `reason: ConfigFailed` — Proxy config generation failed
-    - `status: "True"`, `reason: Configured` — Proxy config generated successfully
-- `gatewayTokenSecretRef` (string): Name of the Secret containing the gateway authentication token
-- `url` (string): HTTPS URL for accessing the Claw instance (populated when deployments are ready and Route is available)
-
-**Checking instance status:**
-
-```sh
-# View instance with status columns
-oc get claw
-# NAME       READY   REASON
-# instance   True    Ready
-
-# View full status
-oc get claw instance -o yaml
-
-# Check if instance is ready
-oc get claw instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-```
-
-The `oc get claw` output includes:
-- **Ready** column: Shows the Ready condition status (True/False/Unknown)
-- **Reason** column: Shows why the instance is in its current state (Provisioning/Ready)
-
-**Important:** Only Claw instances named `instance` will be reconciled by the controller.
-
-## Configuration
-
-### Secrets Management
-
-The operator manages two categories of Secrets:
-
-#### 1. Gateway Authentication Token (`claw-gateway-token`)
-
-The controller automatically generates and manages a secure authentication token for the OpenClaw gateway:
-- **Secret name:** `claw-gateway-token`
-- **Data entry:** `token` — A cryptographically secure 64-character hex string (256-bit entropy)
-- **Generation:** Automatically created on first reconciliation using Go's `crypto/rand` package
-- **Persistence:** Token is preserved across reconciliations (never regenerated unless the Secret is deleted)
-- **Lifecycle:** Automatically deleted when the Claw instance is removed (via owner references)
-
-**Example retrieval:**
-```sh
-oc get secret claw-gateway-token -o jsonpath='{.data.token}' | base64 -d
-```
-
-#### 2. Credential Secrets (User-Managed)
-
-Each entry in `spec.credentials` references a user-managed Secret. The controller:
-1. Validates that each referenced Secret exists in the same namespace
-2. Verifies the Secret contains the specified key
-3. Configures the `claw-proxy` deployment to reference Secrets directly (via env vars or volume mounts depending on credential type)
-4. Generates a proxy config JSON with credential routing rules and applies it as a ConfigMap
-
-**How credentials are injected into the proxy:**
-- **apiKey, bearer, pathToken, oauth2** types: Secret value is injected as an environment variable via `valueFrom.secretKeyRef`
-- **gcp** type: Secret is mounted as a volume at `/etc/proxy/credentials/<name>/sa-key.json`
-- **none** type: No Secret required — used for proxy allowlist entries (no authentication)
-
-**Security Considerations:**
-- Credential values are stored only in your user-managed Secrets (never copied by the controller)
-- Fully compatible with external secret management tools (Sealed Secrets, External Secrets Operator, Vault, etc.)
-- The controller validates and references your Secrets but never reads or stores credential values
-- The gateway token is never exposed in the CR, only in the operator-managed Secret
-- Consider enabling encryption at rest for etcd in your cluster
-
-## Version Information
-
-The operator logs its version and build time during startup for troubleshooting and deployment tracking:
-
-```
-INFO	setup	Starting Claw Operator	{"version": "fc7c72b0", "buildTime": "2026-04-07T13:17:26Z"}
-```
-
-**Version fields:**
-- `version`: Short commit SHA (7 characters) of the source code used to build the binary
-- `buildTime`: RFC3339 timestamp indicating when the binary was built
-
-**How it works:**
-- Version information is injected at build time via LDFLAGS in the `docker-build` Makefile target
-- Local development builds (e.g., `make run`) show default values: `version="dev"` and `buildTime="unknown"`
-- Production container builds automatically capture the git commit SHA and build timestamp
-
-This allows operators to quickly identify which version is running in any environment by checking the startup logs.
-
-## Getting Started
+## Quick Start
 
 ### Prerequisites
-- go version v1.25.0+
-- docker version 17.03+.
-- oc version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
 
-### Dev Deployment (Quick Start)
+- OpenShift cluster (or Kubernetes with manual port-forward)
+- `oc` CLI logged into the cluster
+- `podman` installed locally
+- A container registry accessible from your cluster (e.g., `quay.io`)
 
-Dev targets build both the operator and proxy images, push them, install CRDs, and deploy the controller in one command. You need a container registry accessible from your cluster (e.g., `quay.io`, `ghcr.io`, or an OpenShift internal registry).
+### 1. Deploy the Operator
 
-**Full setup (build + push + deploy):**
+Log in to your container registry and OpenShift cluster:
+
+```sh
+podman login quay.io
+oc login --server=https://api.your-cluster.example.com:6443
+```
+
+Make sure the `claw-operator` and `claw-proxy` repositories on quay.io are set to **public** (or configure a pull secret), so the cluster can pull the images.
+
+Then build, push, and deploy in one command:
+
 ```sh
 make dev-setup REGISTRY=quay.io/myuser
 ```
 
-**Or step by step:**
-```sh
-make dev-build  REGISTRY=quay.io/myuser   # Build operator + proxy images
-make dev-push   REGISTRY=quay.io/myuser   # Push both images
-make dev-deploy REGISTRY=quay.io/myuser   # Install CRDs + deploy controller
-```
+This builds both images (operator + proxy), pushes them, installs CRDs, and deploys the controller into the `claw-operator` namespace.
 
-**Iterate after code changes:**
-```sh
-make dev-build dev-push dev-deploy REGISTRY=quay.io/myuser
-```
+### 2. Set Up Your Namespace
 
-**Tear down:**
-```sh
-make dev-cleanup
-```
-
-Images are tagged with `dev` by default. Override with `TAG`:
-```sh
-make dev-setup REGISTRY=quay.io/myuser TAG=my-branch
-```
-
-### To Deploy on the cluster (Manual)
-**Build and push your image to the location specified by `IMG`:**
+The operator runs in `claw-operator`, but user workloads (Claw instances, secrets) go in your own namespace. Set it once and all commands below will use it:
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/claw-operator:tag
+export NS=my-claw-namespace
+oc new-project $NS 2>/dev/null || oc project $NS
 ```
 
-**NOTE:** This image ought to be published in the personal registry you specified.
-And it is required to have access to pull the image from the working environment.
-Make sure you have the proper permission to the registry if the above commands don’t work.
-
-**Install the CRDs into the cluster:**
-
-```sh
-make install
-```
-
-**Deploy the Manager to the cluster with the image specified by `IMG`:**
-
-```sh
-make deploy IMG=<some-registry>/claw-operator:tag PROXY_IMG=<some-registry>/claw-proxy:tag
-```
-
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
-
-**Create instances of your solution**
-You can apply the samples (examples) from the config/sample:
-
-```sh
-oc apply -k config/samples/
-```
-
->**NOTE**: Ensure that the samples has default values to test it out.
-
-### Creating an OpenClaw Instance
-
-After deploying the operator, create an OpenClaw instance:
-
-**1. Create a Secret with your Gemini API key:**
+### 3. Create a Credential Secret
 
 ```sh
 oc create secret generic gemini-api-key \
   --from-literal=api-key=YOUR_GEMINI_API_KEY \
-  -n claw-operator
+  -n $NS
 ```
 
 Get your API key from [Google AI Studio](https://aistudio.google.com/apikey).
 
-**2. Create the Claw CR** (must be named `instance`):
+### 4. Create a Claw Instance
+
+Apply the sample CR, or use the inline version below:
 
 ```sh
-oc apply -f config/samples/claw_v1alpha1_claw.yaml -n <user-namespace>
+oc apply -f config/samples/claw_v1alpha1_claw.yaml -n $NS
 ```
 
-Or create it directly:
-
 ```sh
-oc apply -f - <<'EOF'
+oc apply -f - <<EOF
 apiVersion: claw.sandbox.redhat.com/v1alpha1
 kind: Claw
 metadata:
   name: instance
-  namespace: claw-operator
+  namespace: $NS
 spec:
   credentials:
     - name: gemini
@@ -271,144 +93,62 @@ spec:
 EOF
 ```
 
-**3. Watch the instance become ready:**
+Watch it become ready:
 
 ```sh
-oc get claw instance -n claw-operator -w
+oc get claw -n $NS -w
+# NAME       READY   REASON
+# instance   True    Ready
 ```
 
-The `Ready` column will transition from `Provisioning` to `Ready` once both the OpenClaw and proxy deployments are available.
-
-**4. Access the instance:**
-
-On **OpenShift**, a Route is created automatically. Get the URL from the Claw status:
+### 5. Get the URL and Log In
 
 ```sh
-oc get claw instance -n claw-operator -o jsonpath='{.status.url}'
+# Get the instance URL (OpenShift)
+oc get claw instance -n $NS -o jsonpath='{.status.url}'
+
+# Get the gateway token
+oc get secret claw-gateway-token -n $NS -o jsonpath='{.data.token}' | base64 -d
 ```
 
-On **vanilla Kubernetes** (no Route CRD), use port-forwarding:
+On vanilla Kubernetes (no Route), use port-forwarding instead:
 
 ```sh
-oc port-forward svc/claw 18789:18789 -n claw-operator
+oc port-forward svc/claw 18789:18789 -n $NS
+# Then open http://localhost:18789
 ```
 
-Then open http://localhost:18789 in your browser.
+### 6. Pair Your Device
 
-**5. Approve device pairing:**
-
-On first connection from a new browser you'll see **"pairing required"**. This is OpenClaw's device authentication -- remote connections require a one-time approval.
-
-With the browser tab open (so the pairing request stays active), list pending requests and approve:
+On first connection you'll see "pairing required". With the browser tab open, approve the request:
 
 ```sh
 # List pending pairing requests
-oc exec -n claw-operator deployment/claw -- \
+oc exec -n $NS deployment/claw -- \
   node /app/dist/index.js devices list
 
-# Approve by request ID (replace <requestId> with the ID from the Pending table above)
-oc exec -n claw-operator deployment/claw -- \
+# Approve (replace <requestId> with the ID shown above)
+oc exec -n $NS deployment/claw -- \
   node /app/dist/index.js devices approve <requestId>
 ```
 
-Refresh the browser after approval. The device is remembered -- you won't need to pair again unless you clear browser data or switch browsers.
+Refresh the browser after approval. The device is remembered across sessions.
 
-**6. Authenticate with the gateway token:**
+## Makefile Targets
 
-The operator generates a gateway authentication token stored in a Secret. Retrieve it with:
+Run `make help` for a full list. Key targets:
 
-```sh
-oc get secret claw-gateway-token -n claw-operator -o jsonpath='{.data.token}' | base64 -d
-```
+| Target | Description |
+|---|---|
+| `make dev-setup REGISTRY=...` | Full dev cycle: build, push, deploy |
+| `make dev-build dev-push dev-deploy REGISTRY=...` | Step-by-step dev iteration |
+| `make dev-cleanup` | Tear down deployed controller and CRDs |
+| `make test` | Run unit tests |
+| `make test-e2e` | Run e2e tests (requires Kind) |
+| `make lint` | Run golangci-lint |
+| `make build` | Build manager binary locally |
+| `make run` | Run controller locally against cluster |
+| `make manifests` | Regenerate CRD YAML and RBAC from markers |
+| `make generate` | Regenerate DeepCopy methods |
 
-### To Uninstall
-**Delete the instances (CRs) from the cluster:**
-
-```sh
-oc delete -k config/samples/
-```
-
-**Delete the APIs(CRDs) from the cluster:**
-
-```sh
-make uninstall
-```
-
-**UnDeploy the controller from the cluster:**
-
-```sh
-make undeploy
-```
-
-## Project Distribution
-
-Following the options to release and provide this solution to the users.
-
-### By providing a bundle with all YAML files
-
-1. Build the installer for the image built and published in the registry:
-
-```sh
-make build-installer IMG=<some-registry>/claw-operator:tag
-```
-
-**NOTE:** The makefile target mentioned above generates an 'install.yaml'
-file in the dist directory. This file contains all the resources built
-with Kustomize, which are necessary to install this project without its
-dependencies.
-
-2. Using the installer
-
-Users can just run 'oc apply -f <URL for YAML BUNDLE>' to install
-the project, i.e.:
-
-```sh
-oc apply -f https://raw.githubusercontent.com/<org>/claw-operator/<tag or branch>/dist/install.yaml
-```
-
-### By providing a Helm Chart
-
-1. Build the chart using the optional helm plugin
-
-```sh
-operator-sdk edit --plugins=helm/v1-alpha
-```
-
-2. See that a chart was generated under 'dist/chart', and users
-can obtain this solution from there.
-
-**NOTE:** If you change the project, you need to update the Helm Chart
-using the same command above to sync the latest changes. Furthermore,
-if you create webhooks, you need to use the above command with
-the '--force' flag and manually ensure that any custom configuration
-previously added to 'dist/chart/values.yaml' or 'dist/chart/manager/manager.yaml'
-is manually re-applied afterwards.
-
-## Contributing
-
-Contributions are welcome! Please ensure that:
-- All tests pass with `make test`
-- Code passes linting with `make lint`
-- Changes are covered by appropriate unit or e2e tests
-- Commits follow the repository's commit message conventions
-
-**NOTE:** Run `make help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
-
-## License
-
-Copyright 2026 Red Hat.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+Override the container tool with `CONTAINER_TOOL=docker` if needed. Default is `podman`.

--- a/README.md
+++ b/README.md
@@ -93,23 +93,15 @@ spec:
 EOF
 ```
 
-Watch it become ready:
+Wait for it to become ready and get the URL and gateway token:
 
 ```sh
-oc get claw -n $NS -w
-# NAME       READY   REASON
-# instance   True    Ready
+make wait-ready NS=$NS
 ```
 
-### 5. Get the URL and Log In
+### 5. Log In
 
-```sh
-# Get the instance URL (OpenShift)
-oc get claw instance -n $NS -o jsonpath='{.status.url}'
-
-# Get the gateway token
-oc get secret claw-gateway-token -n $NS -o jsonpath='{.data.token}' | base64 -d
-```
+Open the URL printed above and enter the gateway token to log in.
 
 On vanilla Kubernetes (no Route), use port-forwarding instead:
 
@@ -123,13 +115,13 @@ oc port-forward svc/claw 18789:18789 -n $NS
 On first connection you'll see "pairing required". With the browser tab open, approve the request:
 
 ```sh
-# List pending pairing requests
-oc exec -n $NS deployment/claw -- \
-  node /app/dist/index.js devices list
+make approve-pairing NS=$NS
+```
 
-# Approve (replace <requestId> with the ID shown above)
-oc exec -n $NS deployment/claw -- \
-  node /app/dist/index.js devices approve <requestId>
+This lists pending requests and prompts for the ID to approve. If you already know the ID:
+
+```sh
+make approve-pairing NS=$NS REQUEST_ID=<requestId>
 ```
 
 Refresh the browser after approval. The device is remembered across sessions.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
+      # build your manager image with the appropriate --platform flag.
       # affinity:
       #   nodeAffinity:
       #     requiredDuringSchedulingIgnoredDuringExecution:

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/elazarl/goproxy v1.8.3
 	golang.org/x/oauth2 v0.36.0
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
 require (
@@ -99,7 +100,6 @@ require (
 	k8s.io/component-base v0.34.6 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -18,7 +18,6 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -32,8 +31,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           command:
             - sh
             - -c
@@ -78,8 +75,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           command:
             - sh
             - -c

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -45,7 +45,7 @@ var (
 
 // TestMain runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the purposed to be used in CI jobs.
-// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
+// The default setup requires Kind, builds/loads the Manager container image locally, and installs
 // CertManager.
 func TestMain(m *testing.M) {
 	fmt.Println("Starting claw-operator integration test suite")
@@ -61,11 +61,11 @@ func TestMain(m *testing.M) {
 	// Images are saved to tar first because podman and kind do not work well
 	// together when loading from a docker registry.
 	// See https://github.com/kubernetes-sigs/kind/issues/2038
-	if err := buildAndLoadImage("manager", "docker-build", "IMG", projectImage, kindCluster); err != nil {
+	if err := buildAndLoadImage("manager", "container-build", "IMG", projectImage, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "manager image setup failed: %v\n", err)
 		os.Exit(1)
 	}
-	if err := buildAndLoadImage("proxy", "docker-build-proxy", "PROXY_IMG", proxyImage, kindCluster); err != nil {
+	if err := buildAndLoadImage("proxy", "container-build-proxy", "PROXY_IMG", proxyImage, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "proxy image setup failed: %v\n", err)
 		os.Exit(1)
 	}
@@ -101,9 +101,9 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// buildAndLoadImage builds a Docker image, saves it to a tar, and loads it into
+// buildAndLoadImage builds a container image, saves it to a tar, and loads it into
 // a Kind cluster. label is a human-readable name for log messages, buildTarget
-// is the make target (e.g. "docker-build"), imgVar is the make variable that
+// is the make target (e.g. "container-build"), imgVar is the make variable that
 // receives the image name (e.g. "IMG" or "PROXY_IMG").
 func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) error {
 	tarFile := fmt.Sprintf("tmp/%s.tar", label)
@@ -114,7 +114,7 @@ func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) er
 	}
 
 	fmt.Printf("Loading %s image into Kind cluster...\n", label)
-	if err := runStreaming("make", "docker-save",
+	if err := runStreaming("make", "container-save",
 		fmt.Sprintf("IMG=%s", image),
 		fmt.Sprintf("OUTPUT_FILE=%s", tarFile)); err != nil {
 		return fmt.Errorf("save %s image: %w", label, err)
@@ -127,7 +127,7 @@ func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) er
 }
 
 // runStreaming executes a command with stdout/stderr streamed directly to the
-// console so that long-running setup steps (Docker build, image load) produce
+// console so that long-running setup steps (container build, image load) produce
 // visible progress output instead of appearing to hang.
 func runStreaming(name string, args ...string) error {
 	dir, err := utils.GetProjectDir()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime make targets: wait-ready and approve-pairing (namespace-aware)

* **Documentation**
  * Renamed build examples to use container-build and added container-* usage notes
  * Streamlined Quick Start and added a Security section; documented namespace-driven workflow

* **Chores**
  * Switched default container engine to Podman and replaced docker-* targets with container-* variants
  * Removed bundle/catalog and installer packaging targets
  * e2e setup now preserves/restores prior kubectl context
  * Adjusted pod security comment/configuration entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->