### PR TITLE
docs: warn against deploying to the default namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ endif
 	$(MAKE) dev-push REGISTRY=$(REGISTRY) TAG=$(TAG)
 	$(MAKE) dev-deploy REGISTRY=$(REGISTRY) TAG=$(TAG)
 
-NS ?= my-claw-namespace
+NS ?= my-claw
 
 .PHONY: wait-ready
 wait-ready: ## Wait for the Claw instance to become ready and print the URL.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ export NS=my-claw-namespace
 oc create namespace $NS
 ```
 
+> **Do not use the `default` namespace.** On OpenShift, the `default` namespace uses a different SCC assignment that may not inject a numeric `runAsUser` into pods. This causes containers whose image declares a non-numeric `USER` (e.g., `node`) to fail with `runAsNonRoot` verification errors. Always create a dedicated namespace for your Claw instance.
+
 ### 3. Create a Credential Secret
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ This builds both images (operator + proxy), pushes them, installs CRDs, and depl
 
 ### 2. Set Up Your Namespace
 
-The operator runs in `claw-operator`, but user workloads (Claw instances, secrets) go in your own namespace. Set it once and all commands below will use it:
+The operator runs in `claw-operator`, but user workloads (Claw instances, secrets) go in your own namespace. Set `NS` once and all commands below will use it (Makefile targets also default to `my-claw`):
 
 ```sh
-export NS=my-claw-namespace
+export NS=my-claw   # or pick your own name
 oc create namespace $NS
 ```
 


### PR DESCRIPTION
- Add note in Quick Start explaining that the default namespace on OpenShift uses a different SCC assignment that may skip runAsUser injection, causing runAsNonRoot verification failures for images with non-numeric USER directives

- Rename the default my-claw-namespace NS to my-claw NS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for OpenShift users regarding namespace configuration best practices. Documentation now warns against using the default namespace and recommends creating a dedicated namespace to prevent security context constraint complications and ensure proper handling of container specifications and runtime verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->