### PR TITLE
feat: add kubernetes credential type for secure API server access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `ClawVertexADCConfigMapName = "claw-vertex-adc"` — ConfigMap containing stub ADC for Vertex AI SDK
 - `ClawKubeConfigMapName = "claw-kube-config"` — ConfigMap containing sanitized kubeconfig for kubernetes credentials
 - `ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"` — proxy egress NetworkPolicy (dynamically patched for non-443 kubernetes ports)
-- `DefaultKubectlImage = "registry.k8s.io/kubectl:v1.34.7"` — default image for the init-kubectl init container (overridable via `KUBECTL_IMAGE` env var)
+- `DefaultKubectlImage = "quay.io/openshift/origin-cli:4.21"` — default image for the init-kubectl init container; copies `oc` and `kubectl` to shared volume (overridable via `KUBECTL_IMAGE` env var)
 
 **NodePairingRequestApprovalReconciler** (`internal/controller/nodepairingrequestapproval_controller.go`):
 - Reconciles `NodePairingRequestApproval` CRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ The operator uses a **single unified controller** that manages all resources usi
 - Gracefully skips resources whose CRDs aren't registered (e.g., Route on vanilla Kubernetes)
 - Updates status conditions (Ready, CredentialsResolved, ProxyConfigured) based on Deployment readiness and credential validation
 - Supports proxy image override via `ProxyImage` field (set from `PROXY_IMAGE` env var on the manager)
+- Supports kubectl image override via `KubectlImage` field (set from `KUBECTL_IMAGE` env var on the manager, default `bitnami/kubectl:1.30`); when kubernetes credentials are present, adds an init container that copies kubectl into a shared emptyDir volume mounted at `/opt/kube-tools` on the gateway container
 - Configures proxy with multi-credential support for different LLM API domains
 
 **Key benefits:**
@@ -210,9 +211,12 @@ PHASE 3: ConfigMap Injection and Remaining Resources
  │  ├─ Add GOOGLE_APPLICATION_CREDENTIALS=/etc/vertex-adc/adc.json env var to gateway container
  │  ├─ Add ANTHROPIC_VERTEX_PROJECT_ID env var (from GCP config)
  │  └─ Mount claw-vertex-adc ConfigMap as read-only volume at /etc/vertex-adc/
-   ├─ configureClawDeploymentForKubernetes(objects, resolvedCreds) — when kubernetes credentials exist:
+   ├─ configureClawDeploymentForKubernetes(objects, resolvedCreds, kubectlImage) — when kubernetes credentials exist:
  │  ├─ Add KUBECONFIG=/etc/kube/config env var to gateway container
- │  └─ Mount claw-kube-config ConfigMap as read-only volume at /etc/kube/
+ │  ├─ Add PATH env var prepending /opt/kube-tools to standard PATH
+ │  ├─ Mount claw-kube-config ConfigMap as read-only volume at /etc/kube/
+ │  ├─ Add emptyDir volume (kubectl-bin) mounted at /opt/kube-tools on gateway
+ │  └─ Add init-kubectl init container that copies kubectl binary from kubectlImage to shared volume
  ├─ stampSecretVersionAnnotation(ctx, objects, instance)
  │  ├─ Fetch user's Secrets to get their ResourceVersions
  │  ├─ Find claw-proxy Deployment in parsed objects
@@ -295,7 +299,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `resolveProviderInfo()` — returns upstream host and base path for a credential's provider. GCP credentials route through Vertex AI with the provider name as the publisher (works for google, anthropic, meta, etc.). Google + apiKey uses Gemini REST API. All others fall back to domain
 - `usesVertexSDK()` — returns true when a credential should use the native Vertex AI SDK (type == gcp && provider != "" && provider != "google")
 - `configureClawDeploymentForVertex()` — adds GOOGLE_APPLICATION_CREDENTIALS, ANTHROPIC_VERTEX_PROJECT_ID env vars and stub ADC volume mount to the claw deployment when Vertex SDK credentials exist
-- `configureClawDeploymentForKubernetes()` — mounts the sanitized kubeconfig ConfigMap (`claw-kube-config`) at `/etc/kube/` and sets `KUBECONFIG=/etc/kube/config` env var on the gateway container when kubernetes credentials exist
+- `configureClawDeploymentForKubernetes()` — when kubernetes credentials exist: mounts the sanitized kubeconfig ConfigMap (`claw-kube-config`) at `/etc/kube/`, sets `KUBECONFIG=/etc/kube/config` and `PATH` env vars, adds an `init-kubectl` init container that copies kubectl from the configured image into a shared emptyDir volume mounted at `/opt/kube-tools`
 - `injectKubePortsIntoNetworkPolicy()` — adds non-443 ports from kubeconfig cluster server URLs to the `claw-proxy-egress` NetworkPolicy. In-memory patching before apply, same pattern as `injectRouteHostIntoConfigMap`
 - `injectKubernetesIntoAgentsMd()` — appends a "Kubernetes Access" section to the AGENTS.md content in `claw-config` ConfigMap listing available contexts, clusters, namespaces, and current-context
 - `applyVertexADCConfigMap()` — creates/updates the stub ADC ConfigMap (claw-vertex-adc) with dummy authorized_user credentials for Vertex SDK token refresh bootstrap. Only created when Vertex SDK credentials exist
@@ -324,6 +328,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `ClawVertexADCConfigMapName = "claw-vertex-adc"` — ConfigMap containing stub ADC for Vertex AI SDK
 - `ClawKubeConfigMapName = "claw-kube-config"` — ConfigMap containing sanitized kubeconfig for kubernetes credentials
 - `ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"` — proxy egress NetworkPolicy (dynamically patched for non-443 kubernetes ports)
+- `DefaultKubectlImage = "registry.k8s.io/kubectl:v1.34"` — default image for the init-kubectl init container (overridable via `KUBECTL_IMAGE` env var)
 
 **NodePairingRequestApprovalReconciler** (`internal/controller/nodepairingrequestapproval_controller.go`):
 - Reconciles `NodePairingRequestApproval` CRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
 **Spec Fields:**
 - `credentials` ([]CredentialSpec, optional): Array of credential configurations for proxy credential injection per domain. Each entry defines a credential with:
   - `name` (string, required, minLength=1): Unique identifier for this credential
-  - `type` (CredentialType, required): Credential injection mechanism. Enum: `apiKey`, `bearer`, `gcp`, `pathToken`, `oauth2`, `none`
+  - `type` (CredentialType, required): Credential injection mechanism. Enum: `apiKey`, `bearer`, `gcp`, `pathToken`, `oauth2`, `none`, `kubernetes`
   - `secretRef` (SecretRef, optional): Reference to Kubernetes Secret holding credential value. Required for all types except `none`. SecretRef has fields `name` (Secret name, minLength=1) and `key` (data key, minLength=1)
   - `domain` (string, optional): Domain to match against request Host header. Exact match: "api.github.com". Suffix match: ".googleapis.com" (leading dot). Optional for known providers (google, anthropic) and gcp type — the operator infers the default
   - `defaultHeaders` (map[string]string, optional): Headers injected on every proxied request (e.g., "anthropic-version: 2023-06-01")
@@ -50,6 +50,7 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
 - `CredentialTypePathToken = "pathToken"` — Token injection into URL path
 - `CredentialTypeOAuth2 = "oauth2"` — Client credentials token exchange
 - `CredentialTypeNone = "none"` — Proxy allowlist, no authentication
+- `CredentialTypeKubernetes = "kubernetes"` — Kubernetes API server auth via kubeconfig (token-based only). The Secret holds a standard kubeconfig file; the operator parses it to extract cluster servers, contexts, and tokens. A sanitized kubeconfig (tokens replaced with placeholder) is mounted on the gateway pod. The proxy injects real tokens per `hostname:port`
 
 **Validation Rules:**
 - CE validation ensures type-specific config fields are present when required
@@ -154,15 +155,25 @@ PHASE 1: Gateway Secret
    ├─ Set owner reference (for garbage collection)
    └─ Server-side apply Secret (Patch with Apply)
   ↓
-3b. resolveProviderDefaults for each credential
-   ├─ Known apiKey providers (google, anthropic): fill domain and apiKey.header if not set
-   ├─ GCP credentials: fill domain ".googleapis.com" if not set
-   ├─ Explicit values are preserved (escape hatch)
-   └─ Error if domain or apiKey still missing after defaults
+3b. resolveAndApplyCredentials(ctx, instance)
+   ├─ resolveProviderDefaults for each credential
+   │  ├─ Known apiKey providers (google, anthropic): fill domain and apiKey.header if not set
+   │  ├─ GCP credentials: fill domain ".googleapis.com" if not set
+   │  ├─ Kubernetes credentials: skip domain requirement (domains from kubeconfig)
+   │  ├─ Explicit values are preserved (escape hatch)
+   │  └─ Error if domain or apiKey still missing after defaults
+   ├─ resolveCredentials: validate Secrets, parse kubeconfig for kubernetes type
+   │  └─ Returns []resolvedCredential with parsed kubeconfigData
+   ├─ applySanitizedKubeconfig (if any kubernetes credentials):
+   │  ├─ Replace all tokens with "proxy-managed-token" placeholder
+   │  ├─ Create/update ConfigMap "claw-kube-config" with sanitized kubeconfig
+   │  └─ Set owner reference for garbage collection
+   └─ applyProxyCA: generate self-signed ECDSA CA for MITM proxy
   ↓
-3c. applyProxyResources(ctx, instance)
+3c. applyProxyResources(ctx, instance, resolvedCreds)
    ├─ generateProxyConfig: build proxy config JSON (routes, injectors, gateway paths)
-   │  └─ usesVertexSDK credentials skip gateway route (no PathPrefix/Upstream)
+   │  ├─ usesVertexSDK credentials skip gateway route (no PathPrefix/Upstream)
+   │  └─ Kubernetes routes include `caCert` (base64-encoded CA PEM) from kubeconfig's `certificate-authority-data`
    ├─ applyProxyConfigMap: server-side apply proxy config ConfigMap
    ├─ applyVertexADCConfigMap (if any Vertex SDK credentials exist):
    │  ├─ Create ConfigMap "claw-vertex-adc" with stub authorized_user ADC JSON
@@ -199,6 +210,9 @@ PHASE 3: ConfigMap Injection and Remaining Resources
  │  ├─ Add GOOGLE_APPLICATION_CREDENTIALS=/etc/vertex-adc/adc.json env var to gateway container
  │  ├─ Add ANTHROPIC_VERTEX_PROJECT_ID env var (from GCP config)
  │  └─ Mount claw-vertex-adc ConfigMap as read-only volume at /etc/vertex-adc/
+   ├─ configureClawDeploymentForKubernetes(objects, resolvedCreds) — when kubernetes credentials exist:
+ │  ├─ Add KUBECONFIG=/etc/kube/config env var to gateway container
+ │  └─ Mount claw-kube-config ConfigMap as read-only volume at /etc/kube/
  ├─ stampSecretVersionAnnotation(ctx, objects, instance)
  │  ├─ Fetch user's Secrets to get their ResourceVersions
  │  ├─ Find claw-proxy Deployment in parsed objects
@@ -220,6 +234,16 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    ├─ remapVertexProviderModels: rename "anthropic/..." model entries to "anthropic-vertex/..." when vertex variant exists but base provider does not
    ├─ filterAgentDefaultsForProviders: remove model entries whose provider is not in the injected providers map
    └─ Credentials without Provider are MITM-only (no provider entry)
+  ↓
+7c. injectKubernetesIntoAgentsMd(objects, resolvedCreds)
+   ├─ Collect contexts from all kubernetes credentials
+   ├─ Append "## Kubernetes Access" section to AGENTS.md in claw-config ConfigMap
+   └─ No-op when no kubernetes credentials present
+  ↓
+7d. injectKubePortsIntoNetworkPolicy(objects, resolvedCreds)
+   ├─ Collect unique non-443 ports from kubernetes credential clusters
+   ├─ Append port entries to claw-proxy-egress NetworkPolicy egress[0].ports[]
+   └─ No-op when all ports are 443 or no kubernetes credentials present
   ↓
 8. Filter for remaining resources (kind != "Route")
   ↓
@@ -261,10 +285,19 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in ConfigMap with Route host (or localhost fallback)
 - `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `openclaw.json`. Gateway-routed providers get a baseUrl through the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since MITM proxy handles credential injection transparently
 - `remapVertexProviderModels()` — renames model entries from "provider/model" to "provider-vertex/model" when a Vertex variant exists but the base provider does not (e.g., "anthropic/claude-sonnet-4-6" → "anthropic-vertex/claude-sonnet-4-6")
-- `resolveProviderDefaults()` — fills missing `domain` and `apiKey` fields for known providers (google, anthropic) before validation. Explicit values are preserved as escape hatch. Returns error if required fields are still missing
+- `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA. Extracted from `Reconcile()` to reduce cyclomatic complexity
+- `resolveCredentials()` — validates all credentials and referenced Secrets. For `kubernetes` type, parses kubeconfig with `client-go/tools/clientcmd`, validates token-only auth, extracts cluster/context metadata. Returns `[]resolvedCredential` (replaces former `validateCredentials`)
+- `parseAndValidateKubeconfig()` — parses kubeconfig bytes, validates all users use token-based auth (rejects client certs, exec, auth provider), validates unique token per server `hostname:port`, returns `kubeconfigData`
+- `sanitizeKubeconfig()` — replaces all user tokens with `"proxy-managed-token"` placeholder, clears `TokenFile` fields, preserves clusters/contexts/namespaces/CA data
+- `applySanitizedKubeconfig()` — creates/updates the `claw-kube-config` ConfigMap with sanitized kubeconfig. Server-side apply with owner reference
+- `hasKubernetesCredentials()` — returns true when any resolved credential has type `kubernetes`
+- `resolveProviderDefaults()` — fills missing `domain` and `apiKey` fields for known providers (google, anthropic) before validation. Skips domain requirement for `kubernetes` type. Explicit values are preserved as escape hatch. Returns error if required fields are still missing
 - `resolveProviderInfo()` — returns upstream host and base path for a credential's provider. GCP credentials route through Vertex AI with the provider name as the publisher (works for google, anthropic, meta, etc.). Google + apiKey uses Gemini REST API. All others fall back to domain
 - `usesVertexSDK()` — returns true when a credential should use the native Vertex AI SDK (type == gcp && provider != "" && provider != "google")
 - `configureClawDeploymentForVertex()` — adds GOOGLE_APPLICATION_CREDENTIALS, ANTHROPIC_VERTEX_PROJECT_ID env vars and stub ADC volume mount to the claw deployment when Vertex SDK credentials exist
+- `configureClawDeploymentForKubernetes()` — mounts the sanitized kubeconfig ConfigMap (`claw-kube-config`) at `/etc/kube/` and sets `KUBECONFIG=/etc/kube/config` env var on the gateway container when kubernetes credentials exist
+- `injectKubePortsIntoNetworkPolicy()` — adds non-443 ports from kubeconfig cluster server URLs to the `claw-proxy-egress` NetworkPolicy. In-memory patching before apply, same pattern as `injectRouteHostIntoConfigMap`
+- `injectKubernetesIntoAgentsMd()` — appends a "Kubernetes Access" section to the AGENTS.md content in `claw-config` ConfigMap listing available contexts, clusters, namespaces, and current-context
 - `applyVertexADCConfigMap()` — creates/updates the stub ADC ConfigMap (claw-vertex-adc) with dummy authorized_user credentials for Vertex SDK token refresh bootstrap. Only created when Vertex SDK credentials exist
 - `applyProxyResources()` — generates proxy config, applies proxy ConfigMap and Vertex ADC ConfigMap. Returns proxy config JSON for hash stamping
 - `applyResources()` — applies list of unstructured objects using server-side apply
@@ -289,6 +322,8 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `GatewayTokenKeyName = "token"` — data key for gateway token in gateway Secret
 - `ClawGatewayContainerName = "gateway"` — container name in the claw deployment
 - `ClawVertexADCConfigMapName = "claw-vertex-adc"` — ConfigMap containing stub ADC for Vertex AI SDK
+- `ClawKubeConfigMapName = "claw-kube-config"` — ConfigMap containing sanitized kubeconfig for kubernetes credentials
+- `ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"` — proxy egress NetworkPolicy (dynamically patched for non-443 kubernetes ports)
 
 **NodePairingRequestApprovalReconciler** (`internal/controller/nodepairingrequestapproval_controller.go`):
 - Reconciles `NodePairingRequestApproval` CRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `ClawVertexADCConfigMapName = "claw-vertex-adc"` — ConfigMap containing stub ADC for Vertex AI SDK
 - `ClawKubeConfigMapName = "claw-kube-config"` — ConfigMap containing sanitized kubeconfig for kubernetes credentials
 - `ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"` — proxy egress NetworkPolicy (dynamically patched for non-443 kubernetes ports)
-- `DefaultKubectlImage = "registry.k8s.io/kubectl:v1.34"` — default image for the init-kubectl init container (overridable via `KUBECTL_IMAGE` env var)
+- `DefaultKubectlImage = "registry.k8s.io/kubectl:v1.34.7"` — default image for the init-kubectl init container (overridable via `KUBECTL_IMAGE` env var)
 
 **NodePairingRequestApprovalReconciler** (`internal/controller/nodepairingrequestapproval_controller.go`):
 - Reconciles `NodePairingRequestApproval` CRs

--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -21,16 +21,17 @@ import (
 )
 
 // CredentialType selects the credential injection mechanism used by the proxy.
-// +kubebuilder:validation:Enum=apiKey;bearer;gcp;pathToken;oauth2;none
+// +kubebuilder:validation:Enum=apiKey;bearer;gcp;pathToken;oauth2;none;kubernetes
 type CredentialType string
 
 const (
-	CredentialTypeAPIKey    CredentialType = "apiKey"
-	CredentialTypeBearer    CredentialType = "bearer"
-	CredentialTypeGCP       CredentialType = "gcp"
-	CredentialTypePathToken CredentialType = "pathToken"
-	CredentialTypeOAuth2    CredentialType = "oauth2"
-	CredentialTypeNone      CredentialType = "none"
+	CredentialTypeAPIKey     CredentialType = "apiKey"
+	CredentialTypeBearer     CredentialType = "bearer"
+	CredentialTypeGCP        CredentialType = "gcp"
+	CredentialTypePathToken  CredentialType = "pathToken"
+	CredentialTypeOAuth2     CredentialType = "oauth2"
+	CredentialTypeNone       CredentialType = "none"
+	CredentialTypeKubernetes CredentialType = "kubernetes"
 )
 
 // Condition types for Claw status.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -217,6 +217,7 @@ func main() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProxyImage:      os.Getenv("PROXY_IMAGE"),
+		KubectlImage:    os.Getenv("KUBECTL_IMAGE"),
 		ImagePullPolicy: imagePullPolicy,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Claw")

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -169,6 +169,7 @@ spec:
                       - pathToken
                       - oauth2
                       - none
+                      - kubernetes
                       type: string
                   required:
                   - name

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,8 @@ spec:
         env:
           - name: PROXY_IMAGE
             value: claw-proxy:latest
+          - name: KUBECTL_IMAGE
+            value: registry.k8s.io/kubectl:v1.34
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
           - name: PROXY_IMAGE
             value: claw-proxy:latest
           - name: KUBECTL_IMAGE
-            value: registry.k8s.io/kubectl:v1.34
+            value: registry.k8s.io/kubectl:v1.34.7
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
           - name: PROXY_IMAGE
             value: claw-proxy:latest
           - name: KUBECTL_IMAGE
-            value: registry.k8s.io/kubectl:v1.34.7
+            value: quay.io/openshift/origin-cli:4.21
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/docs/proposals/kubernetes-credential-design.md
+++ b/docs/proposals/kubernetes-credential-design.md
@@ -290,7 +290,11 @@ One route per cluster server `hostname:port`. All share the same kubeconfig file
 
 ### Proxy Config Struct Changes
 
-The `Route` struct in `internal/proxy/config.go` needs a new `KubeconfigPath` field. The controller-side `proxyRoute` struct (used in `generateProxyConfig`) needs a corresponding field so that the JSON config can carry the path from the controller to the proxy.
+The `Route` struct in `internal/proxy/config.go` needs a new `KubeconfigPath` field and a `CACert` field. The controller-side `proxyRoute` struct (used in `generateProxyConfig`) needs corresponding fields so that the JSON config can carry the path and CA data from the controller to the proxy.
+
+### Upstream TLS CA Trust
+
+The proxy's transport verifies upstream server TLS certificates. Kubernetes API servers typically use cluster-specific CAs not present in the system trust store (Kind, OpenShift, kubeadm, etc.). The controller passes each kubeconfig cluster's `certificate-authority-data` through the proxy config as a base64-encoded PEM `caCert` field on the route. At startup, `NewServer()` collects all route CA certs into the transport's root CA pool (alongside system CAs) via `buildRootCAPool()`.
 
 ### Auth Header Stripping
 
@@ -346,7 +350,7 @@ The original kubeconfig Secret is user-managed and mounted directly (not copied)
 
 ## Implementation Plan
 
-### Phase 1: CRD + Controller + Proxy Injector
+### Phase 1: CRD + Controller + Proxy Injector - DONE
 
 1. Add `CredentialTypeKubernetes` to CRD types + enum marker
 2. Refactor `validateCredentials` → `resolveCredentials` returning `[]resolvedCredential` (all existing tests updated to use new signature)

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -218,3 +218,152 @@ The operator uses two different routing strategies depending on the provider:
 3. The MITM proxy transparently intercepts GCP auth traffic and injects real OAuth2 tokens from the service account
 
 This ensures **real GCP credentials stay on the proxy pod only** — the application pod never sees them.
+
+## Kubernetes API Access
+
+The `kubernetes` credential type lets the AI assistant interact with Kubernetes API servers through the credential-injecting proxy. You provide a standard kubeconfig file in a Secret — the operator parses it to extract server URLs, contexts, namespaces, and tokens. The assistant gets a sanitized kubeconfig (real tokens replaced with placeholders) and all API requests are transparently authenticated by the proxy.
+
+**Requirements:**
+- The kubeconfig must use **token-based authentication** (static tokens or projected service account tokens). Client certificate, exec-based, and auth provider-based auth are not supported yet.
+- Each cluster server URL must map to exactly one token. If the same cluster is referenced by multiple contexts with different users/tokens, split into separate kubeconfigs.
+
+### Single Cluster
+
+**1. Create a ServiceAccount with RBAC:**
+
+```sh
+oc create sa claw-assistant -n my-workspace
+oc create rolebinding claw-assistant-edit \
+  --clusterrole=edit \
+  --serviceaccount=my-workspace:claw-assistant \
+  -n my-workspace
+```
+
+**2. Build a kubeconfig from your current cluster:**
+
+This extracts the server URL and CA from your existing kubeconfig, then creates a new one with the SA token — no need to find CA files manually.
+
+```sh
+# Get the API server URL and CA data from the current context
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
+# Request a token for the ServiceAccount
+SA_TOKEN=$(oc create token claw-assistant -n my-workspace --duration=8760h)
+
+# Build the kubeconfig
+kubectl config set-cluster target \
+  --server="$SERVER" \
+  --kubeconfig=/tmp/kubeconfig
+kubectl config set clusters.target.certificate-authority-data "$CA_DATA" \
+  --kubeconfig=/tmp/kubeconfig
+kubectl config set-credentials claw-sa \
+  --token="$SA_TOKEN" \
+  --kubeconfig=/tmp/kubeconfig
+kubectl config set-context workspace \
+  --cluster=target \
+  --user=claw-sa \
+  --namespace=my-workspace \
+  --kubeconfig=/tmp/kubeconfig
+kubectl config use-context workspace --kubeconfig=/tmp/kubeconfig
+```
+
+> **Tip:** If your cluster uses a CA file instead of inline `certificate-authority-data`, you can embed it:
+> ```sh
+> CA_FILE=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.certificate-authority}')
+> kubectl config set-cluster target \
+>   --server="$SERVER" \
+>   --certificate-authority="$CA_FILE" \
+>   --embed-certs=true \
+>   --kubeconfig=/tmp/kubeconfig
+> ```
+
+**3. Create the Secret:**
+
+```sh
+oc create secret generic my-kubeconfig \
+  --from-file=kubeconfig=/tmp/kubeconfig \
+  -n $NS
+```
+
+**4. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: k8s-workspace
+      type: kubernetes
+      secretRef:
+        name: my-kubeconfig
+        key: kubeconfig
+EOF
+```
+
+### Multi-Cluster
+
+A single kubeconfig can contain multiple clusters. The operator creates a proxy route per cluster server and the assistant can switch contexts with `kubectl config use-context`.
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: k8s-multi
+      type: kubernetes
+      secretRef:
+        name: multi-cluster-kubeconfig
+        key: kubeconfig
+EOF
+```
+
+The operator automatically:
+- Creates proxy routes for each cluster server `hostname:port`
+- Patches the proxy egress NetworkPolicy to allow non-443 ports (e.g., 6443)
+- Mounts a sanitized kubeconfig on the gateway pod (tokens replaced with placeholders)
+- Injects a "Kubernetes Access" section into AGENTS.md listing available contexts and namespaces
+
+### Combining with LLM Providers
+
+Kubernetes credentials work alongside LLM provider credentials in the same Claw instance:
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        name: gemini-api-key
+        key: api-key
+      provider: google
+    - name: k8s-workspace
+      type: kubernetes
+      secretRef:
+        name: my-kubeconfig
+        key: kubeconfig
+EOF
+```
+
+### How Kubernetes Routing Works
+
+The `kubernetes` credential uses the proxy's existing **MITM forward proxy mode** (CONNECT tunneling). The gateway pod's `HTTP_PROXY` / `HTTPS_PROXY` env vars route all traffic through the proxy, which:
+
+1. Matches the request `hostname:port` against cluster servers from the kubeconfig
+2. TLS-terminates via MITM
+3. Strips all existing auth headers
+4. Injects the real `Authorization: Bearer <token>` for the matched cluster
+5. Re-encrypts and forwards to the upstream API server
+
+The gateway pod **cannot** reach any API server directly — egress is restricted to the proxy by NetworkPolicy. The assistant never sees real tokens; only the sanitized kubeconfig with placeholder values.

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -25,7 +25,6 @@ spec:
           image: ghcr.io/openclaw/openclaw:slim
           imagePullPolicy: IfNotPresent
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
@@ -64,7 +63,6 @@ spec:
           image: mirror.gcr.io/library/busybox:1.37
           imagePullPolicy: IfNotPresent
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
@@ -174,7 +172,6 @@ spec:
               mountPath: /etc/proxy-ca
               readOnly: true
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -38,14 +38,14 @@ spec:
               set -e
               cp -r /app/dist/. /patched-dist/
               patched=0
-              guard_target='mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured()'
-              guard_files=$(grep -rl "$guard_target" /patched-dist --include='*.js' 2>/dev/null || true)
+              guard_pattern='mode[[:space:]]*===[[:space:]]*GUARDED_FETCH_MODE\.TRUSTED_ENV_PROXY[[:space:]]*&&[[:space:]]*hasProxyEnvConfigured\(\)'
+              guard_files=$(grep -rEl "$guard_pattern" /patched-dist --include='*.js' 2>/dev/null || true)
               if [ -z "$guard_files" ]; then
                 echo "[proxy-patch] ERROR: no files contain SSRF guard conditional — upstream may have changed" >&2
                 exit 1
               fi
               for file in $guard_files; do
-                sed -i "s|$guard_target|hasProxyEnvConfigured()|g" "$file"
+                sed -Ei "s|$guard_pattern|hasProxyEnvConfigured()|g" "$file"
                 echo "[proxy-patch] Patched SSRF guard: $file"
                 patched=$((patched + 1))
               done

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -37,24 +37,19 @@ spec:
             - |
               set -e
               cp -r /app/dist/. /patched-dist/
-              candidates=$(grep -rl 'fetchWithWebToolsNetworkGuard({' /patched-dist --include='*.js' 2>/dev/null || true)
-              if [ -z "$candidates" ]; then
-                echo "[proxy-patch] ERROR: no files contain fetchWithWebToolsNetworkGuard({ — upstream may have changed" >&2
+              patched=0
+              guard_target='mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured()'
+              guard_files=$(grep -rl "$guard_target" /patched-dist --include='*.js' 2>/dev/null || true)
+              if [ -z "$guard_files" ]; then
+                echo "[proxy-patch] ERROR: no files contain SSRF guard conditional — upstream may have changed" >&2
                 exit 1
               fi
-              patched=0
-              for file in $candidates; do
-                if ! grep -q 'useEnvProxy:true' "$file" 2>/dev/null; then
-                  sed -i 's|fetchWithWebToolsNetworkGuard({|fetchWithWebToolsNetworkGuard({useEnvProxy:true,|g' "$file"
-                  echo "[proxy-patch] Patched: $file"
-                  patched=$((patched + 1))
-                fi
+              for file in $guard_files; do
+                sed -i "s|$guard_target|hasProxyEnvConfigured()|g" "$file"
+                echo "[proxy-patch] Patched SSRF guard: $file"
+                patched=$((patched + 1))
               done
-              if [ "$patched" -eq 0 ]; then
-                echo "[proxy-patch] All files already patched"
-              else
-                echo "[proxy-patch] Patched $patched file(s)"
-              fi
+              echo "[proxy-patch] Patched $patched file(s)"
           resources:
             requests:
               memory: 128Mi

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -89,7 +89,7 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -132,7 +132,7 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig

--- a/internal/controller/claw_credentials.go
+++ b/internal/controller/claw_credentials.go
@@ -22,9 +22,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -32,6 +34,36 @@ import (
 
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
+
+// kubeconfigCluster holds parsed cluster info from a kubeconfig.
+type kubeconfigCluster struct {
+	Name     string
+	Server   string
+	Hostname string
+	Port     string
+	CAData   []byte
+}
+
+// kubeconfigContext holds parsed context info from a kubeconfig.
+type kubeconfigContext struct {
+	Name      string
+	Cluster   string
+	Namespace string
+	Current   bool
+}
+
+// kubeconfigData holds all parsed data from a kubeconfig needed by downstream functions.
+type kubeconfigData struct {
+	Clusters []kubeconfigCluster
+	Contexts []kubeconfigContext
+	RawBytes []byte
+}
+
+// resolvedCredential wraps a CredentialSpec with parsed kubeconfig data (non-nil for kubernetes type only).
+type resolvedCredential struct {
+	clawv1alpha1.CredentialSpec
+	KubeConfig *kubeconfigData
+}
 
 // generateGatewayToken generates a cryptographically secure random token
 // using crypto/rand. Returns a 64-character hex string (32 random bytes).
@@ -119,14 +151,17 @@ var knownProviders = map[string]bool{
 	"openrouter": true,
 }
 
-// validateCredentials validates all credential entries: checks that referenced Secrets exist,
-// that type-specific configuration is present, and that provider values are valid and unique.
-// Returns an error describing all failures.
-func (r *ClawResourceReconciler) validateCredentials(ctx context.Context, instance *clawv1alpha1.Claw) error {
+// resolveCredentials validates all credential entries and returns resolved credentials
+// with parsed data (e.g., kubeconfig). Checks that referenced Secrets exist, that
+// type-specific configuration is present, and that provider values are valid and unique.
+func (r *ClawResourceReconciler) resolveCredentials(ctx context.Context, instance *clawv1alpha1.Claw) ([]resolvedCredential, error) {
 	var errs []error
+	var resolved []resolvedCredential
 	seenProviders := map[string]string{} // provider -> credential name
 
 	for _, cred := range instance.Spec.Credentials {
+		rc := resolvedCredential{CredentialSpec: cred}
+
 		// Validate SecretRef exists for types that require it
 		if cred.Type != clawv1alpha1.CredentialTypeNone {
 			if cred.SecretRef == nil {
@@ -142,8 +177,19 @@ func (r *ClawResourceReconciler) validateCredentials(ctx context.Context, instan
 				}
 				continue
 			}
-			if _, ok := secret.Data[cred.SecretRef.Key]; !ok {
+			data, ok := secret.Data[cred.SecretRef.Key]
+			if !ok {
 				errs = append(errs, fmt.Errorf("credential %q: key %q not found in Secret %q", cred.Name, cred.SecretRef.Key, cred.SecretRef.Name))
+				continue
+			}
+
+			if cred.Type == clawv1alpha1.CredentialTypeKubernetes {
+				kd, err := parseAndValidateKubeconfig(data)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("credential %q: %w", cred.Name, err))
+					continue
+				}
+				rc.KubeConfig = kd
 			}
 		}
 
@@ -178,10 +224,195 @@ func (r *ClawResourceReconciler) validateCredentials(ctx context.Context, instan
 				errs = append(errs, fmt.Errorf("credential %q: oauth2 config is required for type oauth2", cred.Name))
 			}
 		}
+
+		resolved = append(resolved, rc)
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("credential validation failed: %w", errors.Join(errs...))
+		return nil, fmt.Errorf("credential validation failed: %w", errors.Join(errs...))
 	}
+	return resolved, nil
+}
+
+// parseAndValidateKubeconfig parses kubeconfig bytes and validates that all users
+// use token-based auth. Returns extracted cluster and context metadata.
+func parseAndValidateKubeconfig(data []byte) (*kubeconfigData, error) {
+	cfg, err := clientcmd.Load(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	// Validate all users use token auth only
+	for userName, authInfo := range cfg.AuthInfos {
+		if len(authInfo.ClientCertificateData) > 0 || authInfo.ClientCertificate != "" {
+			return nil, fmt.Errorf("user %q uses client certificate auth (not supported, use token auth)", userName)
+		}
+		if authInfo.Exec != nil {
+			return nil, fmt.Errorf("user %q uses exec-based auth (not supported, use token auth)", userName)
+		}
+		if authInfo.AuthProvider != nil {
+			return nil, fmt.Errorf("user %q uses auth provider (not supported, use token auth)", userName)
+		}
+		if authInfo.Token == "" && len(authInfo.TokenFile) == 0 {
+			return nil, fmt.Errorf("user %q has no token configured", userName)
+		}
+	}
+
+	// Parse clusters and validate server URLs
+	serverTokens := map[string]string{} // "hostname:port" -> token (for uniqueness check)
+	var clusters []kubeconfigCluster
+	for clusterName, cluster := range cfg.Clusters {
+		if cluster.Server == "" {
+			return nil, fmt.Errorf("cluster %q has no server URL", clusterName)
+		}
+		hostname, port, err := parseServerURL(cluster.Server)
+		if err != nil {
+			return nil, fmt.Errorf("cluster %q: %w", clusterName, err)
+		}
+		clusters = append(clusters, kubeconfigCluster{
+			Name:     clusterName,
+			Server:   cluster.Server,
+			Hostname: hostname,
+			Port:     port,
+			CAData:   cluster.CertificateAuthorityData,
+		})
+	}
+
+	// Validate one-token-per-server: build server -> token mapping via contexts
+	for ctxName, ctxInfo := range cfg.Contexts {
+		cluster, ok := cfg.Clusters[ctxInfo.Cluster]
+		if !ok {
+			continue
+		}
+		authInfo, ok := cfg.AuthInfos[ctxInfo.AuthInfo]
+		if !ok {
+			continue
+		}
+		hostname, port, err := parseServerURL(cluster.Server)
+		if err != nil {
+			continue
+		}
+		key := hostname + ":" + port
+		token := authInfo.Token
+		if existing, seen := serverTokens[key]; seen && existing != token {
+			return nil, fmt.Errorf("context %q: server %s has conflicting tokens from different users "+
+				"(split into separate kubeconfigs or use the same user)", ctxName, key)
+		}
+		serverTokens[key] = token
+	}
+
+	// Parse contexts
+	var contexts []kubeconfigContext
+	for ctxName, ctxInfo := range cfg.Contexts {
+		contexts = append(contexts, kubeconfigContext{
+			Name:      ctxName,
+			Cluster:   ctxInfo.Cluster,
+			Namespace: ctxInfo.Namespace,
+			Current:   ctxName == cfg.CurrentContext,
+		})
+	}
+
+	return &kubeconfigData{
+		Clusters: clusters,
+		Contexts: contexts,
+		RawBytes: data,
+	}, nil
+}
+
+// parseServerURL extracts hostname and port from a Kubernetes API server URL.
+// Defaults port to "443" when not specified.
+func parseServerURL(server string) (string, string, error) {
+	u, err := url.Parse(server)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid server URL %q: %w", server, err)
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return "", "", fmt.Errorf("server URL %q has no hostname", server)
+	}
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	return hostname, port, nil
+}
+
+// sanitizeKubeconfig replaces all user tokens with a placeholder and returns
+// the sanitized kubeconfig YAML bytes.
+func sanitizeKubeconfig(rawBytes []byte) ([]byte, error) {
+	cfg, err := clientcmd.Load(rawBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig for sanitization: %w", err)
+	}
+
+	for _, authInfo := range cfg.AuthInfos {
+		if authInfo.Token != "" {
+			authInfo.Token = "proxy-managed-token"
+		}
+		if authInfo.TokenFile != "" {
+			authInfo.TokenFile = ""
+			authInfo.Token = "proxy-managed-token"
+		}
+	}
+
+	return clientcmd.Write(*cfg)
+}
+
+// applySanitizedKubeconfig creates or updates the sanitized kubeconfig ConfigMap
+// for the gateway pod. Only created when a kubernetes credential is present.
+func (r *ClawResourceReconciler) applySanitizedKubeconfig(ctx context.Context, instance *clawv1alpha1.Claw, resolvedCreds []resolvedCredential) error {
+	var kd *kubeconfigData
+	for i := range resolvedCreds {
+		if resolvedCreds[i].KubeConfig != nil {
+			kd = resolvedCreds[i].KubeConfig
+			break
+		}
+	}
+	if kd == nil {
+		existing := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: instance.Namespace}, existing); err == nil {
+			log.FromContext(ctx).Info("Cleaning up orphaned kubeconfig ConfigMap")
+			return r.Delete(ctx, existing)
+		}
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	sanitized, err := sanitizeKubeconfig(kd.RawBytes)
+	if err != nil {
+		return fmt.Errorf("failed to sanitize kubeconfig: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	cm.SetName(ClawKubeConfigMapName)
+	cm.SetNamespace(instance.Namespace)
+	cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	cm.Data = map[string]string{
+		"config": string(sanitized),
+	}
+
+	if err := controllerutil.SetControllerReference(instance, cm, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference on kubeconfig ConfigMap: %w", err)
+	}
+
+	if err := r.Patch(ctx, cm, client.Apply, &client.PatchOptions{
+		FieldManager: "claw-operator",
+		Force:        ptr.To(true),
+	}); err != nil {
+		return fmt.Errorf("failed to apply kubeconfig ConfigMap: %w", err)
+	}
+
+	logger.Info("Applied sanitized kubeconfig ConfigMap")
 	return nil
+}
+
+// hasKubernetesCredentials returns true if any resolved credential is type kubernetes.
+func hasKubernetesCredentials(creds []resolvedCredential) bool {
+	for i := range creds {
+		if creds[i].Type == clawv1alpha1.CredentialTypeKubernetes {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/claw_credentials.go
+++ b/internal/controller/claw_credentials.go
@@ -242,7 +242,8 @@ func parseAndValidateKubeconfig(data []byte) (*kubeconfigData, error) {
 		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 
-	// Validate all users use token auth only
+	// Validate all users use inline token auth only — reject file references and
+	// other auth mechanisms that won't work inside the proxy container.
 	for userName, authInfo := range cfg.AuthInfos {
 		if len(authInfo.ClientCertificateData) > 0 || authInfo.ClientCertificate != "" {
 			return nil, fmt.Errorf("user %q uses client certificate auth (not supported, use token auth)", userName)
@@ -253,7 +254,13 @@ func parseAndValidateKubeconfig(data []byte) (*kubeconfigData, error) {
 		if authInfo.AuthProvider != nil {
 			return nil, fmt.Errorf("user %q uses auth provider (not supported, use token auth)", userName)
 		}
-		if authInfo.Token == "" && len(authInfo.TokenFile) == 0 {
+		if authInfo.TokenFile != "" {
+			return nil, fmt.Errorf("user %q uses token-file auth (not supported, inline the token directly)", userName)
+		}
+		if authInfo.Username != "" || authInfo.Password != "" {
+			return nil, fmt.Errorf("user %q uses basic auth (not supported, use token auth)", userName)
+		}
+		if authInfo.Token == "" {
 			return nil, fmt.Errorf("user %q has no token configured", userName)
 		}
 	}
@@ -264,6 +271,10 @@ func parseAndValidateKubeconfig(data []byte) (*kubeconfigData, error) {
 	for clusterName, cluster := range cfg.Clusters {
 		if cluster.Server == "" {
 			return nil, fmt.Errorf("cluster %q has no server URL", clusterName)
+		}
+		if cluster.CertificateAuthority != "" {
+			return nil, fmt.Errorf("cluster %q uses certificate-authority file path (not supported, "+
+				"inline the CA with certificate-authority-data instead)", clusterName)
 		}
 		hostname, port, err := parseServerURL(cluster.Server)
 		if err != nil {

--- a/internal/controller/claw_credentials_test.go
+++ b/internal/controller/claw_credentials_test.go
@@ -370,7 +370,7 @@ func TestConfigureProxyForCredentials(t *testing.T) {
 				GCP:       &clawv1alpha1.GCPConfig{Project: "p", Location: "us-central1"},
 			},
 		}
-		require.NoError(t, configureProxyForCredentials(objects, creds))
+		require.NoError(t, configureProxyForCredentials(objects, toResolved(creds)))
 
 		container := findProxyContainer(t, objects)
 		mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
@@ -410,7 +410,7 @@ func TestConfigureProxyForCredentials(t *testing.T) {
 				APIKey: &clawv1alpha1.APIKeyConfig{Header: "x-api-key"},
 			},
 		}
-		require.NoError(t, configureProxyForCredentials(objects, creds))
+		require.NoError(t, configureProxyForCredentials(objects, toResolved(creds)))
 
 		container := findProxyContainer(t, objects)
 		envVars, _, _ := unstructured.NestedSlice(container, "env")
@@ -437,7 +437,7 @@ func TestConfigureProxyForCredentials(t *testing.T) {
 				Domain:    "api.openai.com",
 			},
 		}
-		require.NoError(t, configureProxyForCredentials(objects, creds))
+		require.NoError(t, configureProxyForCredentials(objects, toResolved(creds)))
 
 		container := findProxyContainer(t, objects)
 		envVars, _, _ := unstructured.NestedSlice(container, "env")

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -67,7 +67,7 @@ func TestConfigureClawDeploymentForVertex(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForVertex(objects, credentials))
+		require.NoError(t, configureClawDeploymentForVertex(objects, toResolved(credentials)))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)
@@ -116,7 +116,7 @@ func TestConfigureClawDeploymentForVertex(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForVertex(objects, credentials))
+		require.NoError(t, configureClawDeploymentForVertex(objects, toResolved(credentials)))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -483,7 +483,7 @@ func TestConfigureClawDeploymentForKubernetes(t *testing.T) {
 		return []*unstructured.Unstructured{dep}
 	}
 
-	t.Run("should add KUBECONFIG env and volume mount", func(t *testing.T) {
+	t.Run("should add KUBECONFIG env, PATH, volumes, and init container", func(t *testing.T) {
 		objects := makeDeployment()
 		creds := []resolvedCredential{
 			{
@@ -496,34 +496,45 @@ func TestConfigureClawDeploymentForKubernetes(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds))
+		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds, DefaultKubectlImage))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)
 
 		envVars := container["env"].([]any)
-		var kubeEnv map[string]any
+		envMap := map[string]string{}
 		for _, e := range envVars {
 			env := e.(map[string]any)
-			if env["name"] == "KUBECONFIG" {
-				kubeEnv = env
-			}
+			envMap[env["name"].(string)] = env["value"].(string)
 		}
-		require.NotNil(t, kubeEnv, "KUBECONFIG env var should be set")
-		assert.Equal(t, "/etc/kube/config", kubeEnv["value"])
+		assert.Equal(t, "/etc/kube/config", envMap["KUBECONFIG"])
+		assert.Contains(t, envMap["PATH"], "/opt/kube-tools")
 
 		volumeMounts := container["volumeMounts"].([]any)
-		require.Len(t, volumeMounts, 1)
-		vm := volumeMounts[0].(map[string]any)
-		assert.Equal(t, "kube-config", vm["name"])
-		assert.Equal(t, "/etc/kube", vm["mountPath"])
+		require.Len(t, volumeMounts, 2)
+		vmNames := map[string]string{}
+		for _, vm := range volumeMounts {
+			m := vm.(map[string]any)
+			vmNames[m["name"].(string)] = m["mountPath"].(string)
+		}
+		assert.Equal(t, "/etc/kube", vmNames["kube-config"])
+		assert.Equal(t, "/opt/kube-tools", vmNames["kubectl-bin"])
 
 		volumes, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "volumes")
-		require.Len(t, volumes, 1)
-		vol := volumes[0].(map[string]any)
-		assert.Equal(t, "kube-config", vol["name"])
-		cmRef := vol["configMap"].(map[string]any)
-		assert.Equal(t, ClawKubeConfigMapName, cmRef["name"])
+		require.Len(t, volumes, 2)
+		volNames := map[string]bool{}
+		for _, v := range volumes {
+			vol := v.(map[string]any)
+			volNames[vol["name"].(string)] = true
+		}
+		assert.True(t, volNames["kube-config"])
+		assert.True(t, volNames["kubectl-bin"])
+
+		initContainers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "initContainers")
+		require.Len(t, initContainers, 1)
+		initC := initContainers[0].(map[string]any)
+		assert.Equal(t, "init-kubectl", initC["name"])
+		assert.Equal(t, DefaultKubectlImage, initC["image"])
 	})
 
 	t.Run("should be no-op when no kubernetes credentials exist", func(t *testing.T) {
@@ -538,7 +549,7 @@ func TestConfigureClawDeploymentForKubernetes(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds))
+		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds, DefaultKubectlImage))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)
@@ -966,35 +977,40 @@ func TestKubernetesCredentialReconciliation(t *testing.T) {
 
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			if container.Name == ClawGatewayContainerName {
-				var foundEnv bool
+				envMap := map[string]string{}
 				for _, env := range container.Env {
-					if env.Name == "KUBECONFIG" {
-						foundEnv = true
-						assert.Equal(t, "/etc/kube/config", env.Value)
-					}
+					envMap[env.Name] = env.Value
 				}
-				assert.True(t, foundEnv, "gateway container should have KUBECONFIG env var")
+				assert.Equal(t, "/etc/kube/config", envMap["KUBECONFIG"], "KUBECONFIG env var")
+				assert.Contains(t, envMap["PATH"], "/opt/kube-tools", "PATH should include kubectl dir")
 
-				var foundMount bool
+				mountMap := map[string]string{}
 				for _, mount := range container.VolumeMounts {
-					if mount.Name == "kube-config" {
-						foundMount = true
-						assert.Equal(t, "/etc/kube", mount.MountPath)
-						assert.True(t, mount.ReadOnly)
-					}
+					mountMap[mount.Name] = mount.MountPath
 				}
-				assert.True(t, foundMount, "gateway container should have kube-config volume mount")
+				assert.Equal(t, "/etc/kube", mountMap["kube-config"], "kube-config volume mount")
+				assert.Equal(t, "/opt/kube-tools", mountMap["kubectl-bin"], "kubectl-bin volume mount")
 			}
 		}
 
-		var foundVol bool
+		volNames := map[string]bool{}
 		for _, vol := range deployment.Spec.Template.Spec.Volumes {
+			volNames[vol.Name] = true
 			if vol.Name == "kube-config" && vol.ConfigMap != nil {
-				foundVol = true
 				assert.Equal(t, ClawKubeConfigMapName, vol.ConfigMap.Name)
 			}
 		}
-		assert.True(t, foundVol, "claw deployment should have kube-config ConfigMap volume")
+		assert.True(t, volNames["kube-config"], "should have kube-config volume")
+		assert.True(t, volNames["kubectl-bin"], "should have kubectl-bin emptyDir volume")
+
+		var foundInitKubectl bool
+		for _, ic := range deployment.Spec.Template.Spec.InitContainers {
+			if ic.Name == "init-kubectl" {
+				foundInitKubectl = true
+				assert.Equal(t, DefaultKubectlImage, ic.Image)
+			}
+		}
+		assert.True(t, foundInitKubectl, "should have init-kubectl init container")
 	})
 
 	t.Run("should include kubernetes routes in proxy config ConfigMap", func(t *testing.T) {

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -1,0 +1,1116 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
+)
+
+const (
+	testKubeSecretName = "kube-secret"
+	testKubeCredVolume = "cred-k8s"
+)
+
+// --- Kubeconfig test helpers ---
+
+func buildTestKubeconfig(t *testing.T, clusters map[string]string, users map[string]string, contexts map[string][2]string, currentContext string) []byte {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	for name, server := range clusters {
+		cfg.Clusters[name] = &clientcmdapi.Cluster{Server: server}
+	}
+	for name, token := range users {
+		cfg.AuthInfos[name] = &clientcmdapi.AuthInfo{Token: token}
+	}
+	for name, pair := range contexts {
+		cfg.Contexts[name] = &clientcmdapi.Context{Cluster: pair[0], AuthInfo: pair[1]}
+	}
+	cfg.CurrentContext = currentContext
+	data, err := clientcmd.Write(*cfg)
+	require.NoError(t, err)
+	return data
+}
+
+// --- parseAndValidateKubeconfig tests ---
+
+func TestParseAndValidateKubeconfig(t *testing.T) {
+	t.Run("valid single cluster kubeconfig", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		kd, err := parseAndValidateKubeconfig(data)
+		require.NoError(t, err)
+		require.Len(t, kd.Clusters, 1)
+		assert.Equal(t, "api.example.com", kd.Clusters[0].Hostname)
+		assert.Equal(t, "6443", kd.Clusters[0].Port)
+		require.Len(t, kd.Contexts, 1)
+		assert.True(t, kd.Contexts[0].Current)
+	})
+
+	t.Run("valid multi-cluster kubeconfig", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{
+				"prod":    "https://api.prod.example.com:6443",
+				"staging": "https://api.staging.example.com",
+			},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{
+				"prod-ctx":    {"prod", "admin"},
+				"staging-ctx": {"staging", "admin"},
+			},
+			"prod-ctx",
+		)
+
+		kd, err := parseAndValidateKubeconfig(data)
+		require.NoError(t, err)
+		require.Len(t, kd.Clusters, 2)
+	})
+
+	t.Run("reject client certificate auth", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{ClientCertificateData: []byte("cert")}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client certificate auth")
+	})
+
+	t.Run("reject exec-based auth", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{Command: "/bin/get-token"}}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exec-based auth")
+	})
+
+	t.Run("reject auth provider", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{AuthProvider: &clientcmdapi.AuthProviderConfig{Name: "gcp"}}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth provider")
+	})
+
+	t.Run("reject user with no token", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no token configured")
+	})
+
+	t.Run("reject conflicting tokens for same server", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com:6443"}
+		cfg.AuthInfos["u1"] = &clientcmdapi.AuthInfo{Token: "token1"}
+		cfg.AuthInfos["u2"] = &clientcmdapi.AuthInfo{Token: "token2"}
+		cfg.Contexts["ctx1"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u1"}
+		cfg.Contexts["ctx2"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u2"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting tokens")
+	})
+
+	t.Run("default port 443 for https without explicit port", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+			"ctx",
+		)
+
+		kd, err := parseAndValidateKubeconfig(data)
+		require.NoError(t, err)
+		assert.Equal(t, "443", kd.Clusters[0].Port)
+	})
+
+	t.Run("reject client certificate file path auth", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{ClientCertificate: "/path/to/cert.pem"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client certificate auth")
+	})
+
+	t.Run("reject cluster with empty server URL", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: ""}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{Token: "t"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no server URL")
+	})
+
+	t.Run("should preserve certificate-authority-data", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		caData := []byte("fake-ca-data")
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{
+			Server:                   "https://api.example.com:6443",
+			CertificateAuthorityData: caData,
+		}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{Token: "my-token"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		kd, err := parseAndValidateKubeconfig(data)
+		require.NoError(t, err)
+		require.Len(t, kd.Clusters, 1)
+		assert.Equal(t, caData, kd.Clusters[0].CAData)
+	})
+
+	t.Run("should accept tokenFile-based auth", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com:6443"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{TokenFile: "/var/run/secrets/token"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		kd, err := parseAndValidateKubeconfig(data)
+		require.NoError(t, err)
+		require.Len(t, kd.Clusters, 1)
+		assert.Equal(t, "api.example.com", kd.Clusters[0].Hostname)
+	})
+}
+
+// --- sanitizeKubeconfig tests ---
+
+func TestSanitizeKubeconfig(t *testing.T) {
+	t.Run("should replace tokens with placeholder", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "real-secret-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+			"ctx",
+		)
+
+		sanitized, err := sanitizeKubeconfig(data)
+		require.NoError(t, err)
+
+		cfg, err := clientcmd.Load(sanitized)
+		require.NoError(t, err)
+		assert.Equal(t, "proxy-managed-token", cfg.AuthInfos["admin"].Token)
+		assert.NotContains(t, string(sanitized), "real-secret-token")
+
+		// Verify cluster info preserved
+		assert.Equal(t, "https://api.example.com:6443", cfg.Clusters["prod"].Server)
+		assert.Equal(t, "ctx", cfg.CurrentContext)
+	})
+
+	t.Run("should sanitize all users in multi-user kubeconfig", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{
+				"prod":    "https://api.prod.example.com:6443",
+				"staging": "https://api.staging.example.com:6443",
+			},
+			map[string]string{
+				"prod-admin":    "prod-secret-token",
+				"staging-admin": "staging-secret-token",
+			},
+			map[string][2]string{
+				"prod-ctx":    {"prod", "prod-admin"},
+				"staging-ctx": {"staging", "staging-admin"},
+			},
+			"prod-ctx",
+		)
+
+		sanitized, err := sanitizeKubeconfig(data)
+		require.NoError(t, err)
+
+		cfg, err := clientcmd.Load(sanitized)
+		require.NoError(t, err)
+		assert.Equal(t, "proxy-managed-token", cfg.AuthInfos["prod-admin"].Token)
+		assert.Equal(t, "proxy-managed-token", cfg.AuthInfos["staging-admin"].Token)
+		assert.NotContains(t, string(sanitized), "prod-secret-token")
+		assert.NotContains(t, string(sanitized), "staging-secret-token")
+	})
+}
+
+// --- generateProxyConfig kubernetes route tests ---
+
+func TestGenerateProxyConfigKubernetes(t *testing.T) {
+	t.Run("should generate routes per cluster from kubeconfig", func(t *testing.T) {
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name:      "k8s",
+					Type:      clawv1alpha1.CredentialTypeKubernetes,
+					SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+				},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Name: "prod", Hostname: "api.prod.example.com", Port: "6443"},
+						{Name: "staging", Hostname: "api.staging.example.com", Port: "443"},
+					},
+				},
+			},
+		}
+
+		data, err := generateProxyConfig(creds)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		prodRoute := findRouteByDomain(t, cfg.Routes, "api.prod.example.com:6443")
+		assert.Equal(t, "kubernetes", prodRoute.Injector)
+		assert.Equal(t, "/etc/proxy/credentials/k8s/kubeconfig", prodRoute.KubeconfigPath)
+
+		stagingRoute := findRouteByDomain(t, cfg.Routes, "api.staging.example.com:443")
+		assert.Equal(t, "kubernetes", stagingRoute.Injector)
+	})
+
+	t.Run("should skip kubernetes credential with nil kubeconfig", func(t *testing.T) {
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "k8s",
+					Type: clawv1alpha1.CredentialTypeKubernetes,
+				},
+				KubeConfig: nil,
+			},
+		}
+
+		data, err := generateProxyConfig(creds)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+		// Only builtin passthrough routes
+		assert.Len(t, cfg.Routes, len(builtinPassthroughDomains))
+	})
+
+	t.Run("should include caCert when cluster has CAData", func(t *testing.T) {
+		caData := []byte("-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----\n")
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name:      "k8s",
+					Type:      clawv1alpha1.CredentialTypeKubernetes,
+					SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+				},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Name: "prod", Hostname: "api.prod.example.com", Port: "6443", CAData: caData},
+						{Name: "staging", Hostname: "api.staging.example.com", Port: "443"},
+					},
+				},
+			},
+		}
+
+		data, err := generateProxyConfig(creds)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		prodRoute := findRouteByDomain(t, cfg.Routes, "api.prod.example.com:6443")
+		assert.NotEmpty(t, prodRoute.CACert, "route with CAData should have caCert set")
+
+		decoded, err := base64.StdEncoding.DecodeString(prodRoute.CACert)
+		require.NoError(t, err)
+		assert.Equal(t, caData, decoded)
+
+		stagingRoute := findRouteByDomain(t, cfg.Routes, "api.staging.example.com:443")
+		assert.Empty(t, stagingRoute.CACert, "route without CAData should have empty caCert")
+	})
+}
+
+// --- configureProxyForCredentials kubernetes volume mount tests ---
+
+func TestConfigureProxyForKubernetesCredentials(t *testing.T) {
+	buildObjects := func(t *testing.T) []*unstructured.Unstructured {
+		t.Helper()
+		reconciler := createClawReconciler()
+		objects, err := reconciler.buildKustomizedObjects()
+		require.NoError(t, err)
+		return objects
+	}
+
+	t.Run("should add kubernetes kubeconfig volume mount", func(t *testing.T) {
+		objects := buildObjects(t)
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name:      "k8s",
+					Type:      clawv1alpha1.CredentialTypeKubernetes,
+					SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+				},
+			},
+		}
+
+		require.NoError(t, configureProxyForCredentials(objects, creds))
+
+		for _, obj := range objects {
+			if obj.GetKind() != DeploymentKind || obj.GetName() != ClawProxyDeploymentName {
+				continue
+			}
+			volumes, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+			var foundVol bool
+			for _, v := range volumes {
+				vol := v.(map[string]any)
+				if vol["name"] == testKubeCredVolume {
+					foundVol = true
+					secret := vol["secret"].(map[string]any)
+					assert.Equal(t, testKubeSecretName, secret["secretName"])
+					items := secret["items"].([]any)
+					item := items[0].(map[string]any)
+					assert.Equal(t, "config", item["key"])
+					assert.Equal(t, "kubeconfig", item["path"])
+				}
+			}
+			assert.True(t, foundVol, "kubernetes credential volume should be present")
+		}
+	})
+}
+
+// --- configureClawDeploymentForKubernetes tests ---
+
+func TestConfigureClawDeploymentForKubernetes(t *testing.T) {
+	makeDeployment := func() []*unstructured.Unstructured {
+		dep := &unstructured.Unstructured{}
+		dep.SetKind(DeploymentKind)
+		dep.SetName(ClawDeploymentName)
+		dep.Object["spec"] = map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":         ClawGatewayContainerName,
+							"env":          []any{},
+							"volumeMounts": []any{},
+						},
+					},
+					"volumes": []any{},
+				},
+			},
+		}
+		return []*unstructured.Unstructured{dep}
+	}
+
+	t.Run("should add KUBECONFIG env and volume mount", func(t *testing.T) {
+		objects := makeDeployment()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name:      "k8s",
+					Type:      clawv1alpha1.CredentialTypeKubernetes,
+					SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+				},
+				KubeConfig: &kubeconfigData{},
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+
+		envVars := container["env"].([]any)
+		var kubeEnv map[string]any
+		for _, e := range envVars {
+			env := e.(map[string]any)
+			if env["name"] == "KUBECONFIG" {
+				kubeEnv = env
+			}
+		}
+		require.NotNil(t, kubeEnv, "KUBECONFIG env var should be set")
+		assert.Equal(t, "/etc/kube/config", kubeEnv["value"])
+
+		volumeMounts := container["volumeMounts"].([]any)
+		require.Len(t, volumeMounts, 1)
+		vm := volumeMounts[0].(map[string]any)
+		assert.Equal(t, "kube-config", vm["name"])
+		assert.Equal(t, "/etc/kube", vm["mountPath"])
+
+		volumes, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "volumes")
+		require.Len(t, volumes, 1)
+		vol := volumes[0].(map[string]any)
+		assert.Equal(t, "kube-config", vol["name"])
+		cmRef := vol["configMap"].(map[string]any)
+		assert.Equal(t, ClawKubeConfigMapName, cmRef["name"])
+	})
+
+	t.Run("should be no-op when no kubernetes credentials exist", func(t *testing.T) {
+		objects := makeDeployment()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name:   "gemini",
+					Type:   clawv1alpha1.CredentialTypeAPIKey,
+					Domain: "generativelanguage.googleapis.com",
+				},
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForKubernetes(objects, creds))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+		envVars := container["env"].([]any)
+		assert.Empty(t, envVars)
+	})
+}
+
+// --- injectKubePortsIntoNetworkPolicy tests ---
+
+func TestInjectKubePortsIntoNetworkPolicy(t *testing.T) {
+	makeNP := func() []*unstructured.Unstructured {
+		np := &unstructured.Unstructured{}
+		np.SetKind(NetworkPolicyKind)
+		np.SetName(ClawProxyEgressNetworkPolicyName)
+		np.Object["spec"] = map[string]any{
+			"egress": []any{
+				map[string]any{
+					"ports": []any{
+						map[string]any{"port": int64(443), "protocol": "TCP"},
+					},
+				},
+			},
+		}
+		return []*unstructured.Unstructured{np}
+	}
+
+	t.Run("should add non-443 port", func(t *testing.T) {
+		objects := makeNP()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "k8s",
+					Type: clawv1alpha1.CredentialTypeKubernetes,
+				},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Hostname: "api.example.com", Port: "6443"},
+						{Hostname: "api.other.com", Port: "443"},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, injectKubePortsIntoNetworkPolicy(objects, creds))
+
+		egress, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "egress")
+		rule := egress[0].(map[string]any)
+		ports := rule["ports"].([]any)
+		assert.Len(t, ports, 2, "should have original 443 + new 6443")
+
+		var found6443 bool
+		for _, p := range ports {
+			port := p.(map[string]any)
+			if port["port"] == int64(6443) {
+				found6443 = true
+			}
+		}
+		assert.True(t, found6443, "port 6443 should be added")
+	})
+
+	t.Run("should be no-op when all ports are 443", func(t *testing.T) {
+		objects := makeNP()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "k8s",
+					Type: clawv1alpha1.CredentialTypeKubernetes,
+				},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Hostname: "api.example.com", Port: "443"},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, injectKubePortsIntoNetworkPolicy(objects, creds))
+
+		egress, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "egress")
+		rule := egress[0].(map[string]any)
+		ports := rule["ports"].([]any)
+		assert.Len(t, ports, 1, "should not add duplicate 443")
+	})
+
+	t.Run("should be no-op with no kubernetes credentials", func(t *testing.T) {
+		objects := makeNP()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "gemini",
+					Type: clawv1alpha1.CredentialTypeAPIKey,
+				},
+			},
+		}
+
+		require.NoError(t, injectKubePortsIntoNetworkPolicy(objects, creds))
+
+		egress, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "egress")
+		rule := egress[0].(map[string]any)
+		ports := rule["ports"].([]any)
+		assert.Len(t, ports, 1)
+	})
+
+	t.Run("should deduplicate same port across multiple kubeconfigs", func(t *testing.T) {
+		objects := makeNP()
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{Name: "k8s-a", Type: clawv1alpha1.CredentialTypeKubernetes},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Hostname: "api.cluster-a.com", Port: "6443"},
+					},
+				},
+			},
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{Name: "k8s-b", Type: clawv1alpha1.CredentialTypeKubernetes},
+				KubeConfig: &kubeconfigData{
+					Clusters: []kubeconfigCluster{
+						{Hostname: "api.cluster-b.com", Port: "6443"},
+						{Hostname: "api.cluster-c.com", Port: "8443"},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, injectKubePortsIntoNetworkPolicy(objects, creds))
+
+		egress, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "egress")
+		rule := egress[0].(map[string]any)
+		ports := rule["ports"].([]any)
+		assert.Len(t, ports, 3, "should have 443 + 6443 + 8443 (no duplicate 6443)")
+	})
+}
+
+// --- injectKubernetesIntoAgentsMd tests ---
+
+func TestInjectKubernetesIntoAgentsMd(t *testing.T) {
+	makeCM := func(agentsMd string) []*unstructured.Unstructured {
+		cm := &unstructured.Unstructured{}
+		cm.SetKind(ConfigMapKind)
+		cm.SetName(ClawConfigMapName)
+		cm.Object["data"] = map[string]any{
+			"AGENTS.md": agentsMd,
+		}
+		return []*unstructured.Unstructured{cm}
+	}
+
+	t.Run("should append kubernetes section to AGENTS.md", func(t *testing.T) {
+		objects := makeCM("# Existing content\n")
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "k8s",
+					Type: clawv1alpha1.CredentialTypeKubernetes,
+				},
+				KubeConfig: &kubeconfigData{
+					Contexts: []kubeconfigContext{
+						{Name: "prod-ctx", Cluster: "prod", Namespace: "default", Current: true},
+						{Name: "staging-ctx", Cluster: "staging", Namespace: "staging"},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, injectKubernetesIntoAgentsMd(objects, creds))
+
+		agentsMd, _, _ := unstructured.NestedString(objects[0].Object, "data", "AGENTS.md")
+		assert.Contains(t, agentsMd, "# Existing content")
+		assert.Contains(t, agentsMd, "## Kubernetes Access")
+		assert.Contains(t, agentsMd, "`prod-ctx`")
+		assert.Contains(t, agentsMd, "[current]")
+		assert.Contains(t, agentsMd, "namespace: staging")
+	})
+
+	t.Run("should be no-op with no kubernetes credentials", func(t *testing.T) {
+		objects := makeCM("# Original\n")
+		creds := []resolvedCredential{
+			{
+				CredentialSpec: clawv1alpha1.CredentialSpec{
+					Name: "gemini",
+					Type: clawv1alpha1.CredentialTypeAPIKey,
+				},
+			},
+		}
+
+		require.NoError(t, injectKubernetesIntoAgentsMd(objects, creds))
+
+		agentsMd, _, _ := unstructured.NestedString(objects[0].Object, "data", "AGENTS.md")
+		assert.Equal(t, "# Original\n", agentsMd)
+	})
+}
+
+// --- resolveProviderDefaults kubernetes tests ---
+
+func TestResolveProviderDefaultsKubernetes(t *testing.T) {
+	t.Run("should return nil for kubernetes type (no domain required)", func(t *testing.T) {
+		cred := clawv1alpha1.CredentialSpec{
+			Name: "k8s",
+			Type: clawv1alpha1.CredentialTypeKubernetes,
+		}
+		err := resolveProviderDefaults(&cred)
+		require.NoError(t, err)
+		assert.Empty(t, cred.Domain)
+	})
+}
+
+// --- Integration test: full reconciliation with kubernetes credential ---
+
+func TestKubernetesCredentialReconciliation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should create sanitized kubeconfig ConfigMap after reconciliation", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "real-secret-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		// Verify sanitized kubeconfig ConfigMap was created
+		cm := &corev1.ConfigMap{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawKubeConfigMapName,
+				Namespace: namespace,
+			}, cm) == nil
+		}, "sanitized kubeconfig ConfigMap should be created")
+
+		sanitizedConfig := cm.Data["config"]
+		assert.NotEmpty(t, sanitizedConfig)
+		assert.NotContains(t, sanitizedConfig, "real-secret-token", "real token should be stripped")
+		assert.Contains(t, sanitizedConfig, "proxy-managed-token", "sanitized placeholder should be present")
+		assert.Contains(t, sanitizedConfig, "api.prod.example.com", "cluster info should be preserved")
+	})
+
+	t.Run("should inject AGENTS.md with kubernetes context info", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		cm := &corev1.ConfigMap{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawConfigMapName,
+				Namespace: namespace,
+			}, cm) == nil
+		}, "ConfigMap should be created")
+
+		agentsMd := cm.Data["AGENTS.md"]
+		assert.True(t, strings.Contains(agentsMd, "Kubernetes Access"),
+			"AGENTS.md should contain Kubernetes Access section, got: %s", agentsMd)
+		assert.Contains(t, agentsMd, "prod-ctx")
+	})
+
+	t.Run("should configure proxy deployment with kubernetes volume mount", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawProxyDeploymentName,
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "proxy deployment should be created")
+
+		var foundVol bool
+		for _, vol := range deployment.Spec.Template.Spec.Volumes {
+			if vol.Name == testKubeCredVolume && vol.Secret != nil {
+				foundVol = true
+				assert.Equal(t, testKubeSecretName, vol.Secret.SecretName)
+				require.Len(t, vol.Secret.Items, 1)
+				assert.Equal(t, "config", vol.Secret.Items[0].Key)
+				assert.Equal(t, "kubeconfig", vol.Secret.Items[0].Path)
+			}
+		}
+		assert.True(t, foundVol, "proxy deployment should have kubeconfig Secret volume")
+
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == ClawProxyContainerName {
+				var foundMount bool
+				for _, mount := range container.VolumeMounts {
+					if mount.Name == testKubeCredVolume {
+						foundMount = true
+						assert.Equal(t, "/etc/proxy/credentials/k8s", mount.MountPath)
+						assert.True(t, mount.ReadOnly)
+					}
+				}
+				assert.True(t, foundMount, "proxy container should have kubeconfig volume mount")
+			}
+		}
+	})
+
+	t.Run("should configure gateway deployment with KUBECONFIG env and volume", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawDeploymentName,
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "claw deployment should be created")
+
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == ClawGatewayContainerName {
+				var foundEnv bool
+				for _, env := range container.Env {
+					if env.Name == "KUBECONFIG" {
+						foundEnv = true
+						assert.Equal(t, "/etc/kube/config", env.Value)
+					}
+				}
+				assert.True(t, foundEnv, "gateway container should have KUBECONFIG env var")
+
+				var foundMount bool
+				for _, mount := range container.VolumeMounts {
+					if mount.Name == "kube-config" {
+						foundMount = true
+						assert.Equal(t, "/etc/kube", mount.MountPath)
+						assert.True(t, mount.ReadOnly)
+					}
+				}
+				assert.True(t, foundMount, "gateway container should have kube-config volume mount")
+			}
+		}
+
+		var foundVol bool
+		for _, vol := range deployment.Spec.Template.Spec.Volumes {
+			if vol.Name == "kube-config" && vol.ConfigMap != nil {
+				foundVol = true
+				assert.Equal(t, ClawKubeConfigMapName, vol.ConfigMap.Name)
+			}
+		}
+		assert.True(t, foundVol, "claw deployment should have kube-config ConfigMap volume")
+	})
+
+	t.Run("should include kubernetes routes in proxy config ConfigMap", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		cm := &corev1.ConfigMap{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawProxyConfigMapName,
+				Namespace: namespace,
+			}, cm) == nil
+		}, "proxy config ConfigMap should be created")
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal([]byte(cm.Data["proxy-config.json"]), &cfg))
+
+		route := findRouteByDomain(t, cfg.Routes, "api.prod.example.com:6443")
+		assert.Equal(t, "kubernetes", route.Injector)
+		assert.Equal(t, "/etc/proxy/credentials/k8s/kubeconfig", route.KubeconfigPath)
+	})
+
+	t.Run("should clean up kubeconfig ConfigMap when kubernetes credential is removed", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
+			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		kubeconfig := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.prod.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"prod-ctx": {"prod", "admin"}},
+			"prod-ctx",
+		)
+
+		secret := &corev1.Secret{}
+		secret.Name = testKubeSecretName
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": kubeconfig}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		// Create Claw with kubernetes credential
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: testKubeSecretName, Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		// Verify kubeconfig ConfigMap exists
+		cm := &corev1.ConfigMap{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawKubeConfigMapName,
+				Namespace: namespace,
+			}, cm) == nil
+		}, "kubeconfig ConfigMap should be created")
+
+		// Remove kubernetes credential from Claw spec
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: ClawInstanceName, Namespace: namespace}, instance))
+		instance.Spec.Credentials = nil
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
+		reconcileClaw(t, ctx, reconciler, ClawInstanceName, namespace)
+
+		// Verify kubeconfig ConfigMap was deleted
+		waitFor(t, timeout, interval, func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{
+				Name:      ClawKubeConfigMapName,
+				Namespace: namespace,
+			}, cm)
+			return apierrors.IsNotFound(err)
+		}, "kubeconfig ConfigMap should be deleted after credential removal")
+	})
+
+	t.Run("should fail reconciliation with invalid kubeconfig in Secret", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: "bad-kube-secret", Namespace: namespace})
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		secret := &corev1.Secret{}
+		secret.Name = "bad-kube-secret"
+		secret.Namespace = namespace
+		secret.Data = map[string][]byte{"config": []byte("not-valid-kubeconfig")}
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = ClawInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "k8s",
+				Type:      clawv1alpha1.CredentialTypeKubernetes,
+				SecretRef: &clawv1alpha1.SecretRef{Name: "bad-kube-secret", Key: "config"},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKey{Name: ClawInstanceName, Namespace: namespace},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential validation failed")
+	})
+}

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -225,7 +225,7 @@ func TestParseAndValidateKubeconfig(t *testing.T) {
 		assert.Equal(t, caData, kd.Clusters[0].CAData)
 	})
 
-	t.Run("should accept tokenFile-based auth", func(t *testing.T) {
+	t.Run("should reject tokenFile-based auth", func(t *testing.T) {
 		cfg := clientcmdapi.NewConfig()
 		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com:6443"}
 		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{TokenFile: "/var/run/secrets/token"}
@@ -233,10 +233,38 @@ func TestParseAndValidateKubeconfig(t *testing.T) {
 		data, err := clientcmd.Write(*cfg)
 		require.NoError(t, err)
 
-		kd, err := parseAndValidateKubeconfig(data)
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token-file auth")
+	})
+
+	t.Run("should reject basic auth (username/password)", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{Server: "https://api.example.com:6443"}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{Username: "admin", Password: "secret"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
 		require.NoError(t, err)
-		require.Len(t, kd.Clusters, 1)
-		assert.Equal(t, "api.example.com", kd.Clusters[0].Hostname)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "basic auth")
+	})
+
+	t.Run("should reject cluster with certificate-authority file path", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["c"] = &clientcmdapi.Cluster{
+			Server:               "https://api.example.com:6443",
+			CertificateAuthority: "/etc/kubernetes/pki/ca.crt",
+		}
+		cfg.AuthInfos["u"] = &clientcmdapi.AuthInfo{Token: "my-token"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "c", AuthInfo: "u"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		_, err = parseAndValidateKubeconfig(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "certificate-authority file path")
 	})
 }
 

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -59,6 +60,8 @@ type proxyRoute struct {
 	TokenURL       string            `json:"tokenURL,omitempty"`
 	Scopes         []string          `json:"scopes,omitempty"`
 	DefaultHeaders map[string]string `json:"defaultHeaders,omitempty"`
+	KubeconfigPath string            `json:"kubeconfigPath,omitempty"`
+	CACert         string            `json:"caCert,omitempty"`
 }
 
 // proxyConfig is the top-level proxy configuration JSON.
@@ -117,6 +120,10 @@ func resolveProviderDefaults(cred *clawv1alpha1.CredentialSpec) error {
 		if cred.Domain == "" {
 			cred.Domain = ".googleapis.com"
 		}
+
+	case clawv1alpha1.CredentialTypeKubernetes:
+		// Domains are derived from the kubeconfig, not the domain field
+		return nil
 	}
 
 	if cred.Domain == "" {
@@ -164,14 +171,14 @@ var builtinPassthroughDomains = []string{
 	"openrouter.ai",
 }
 
-// generateProxyConfig builds the proxy config JSON from spec.credentials[].
+// generateProxyConfig builds the proxy config JSON from resolved credentials.
 // Exact-match domains are emitted before suffix-match domains for predictable matching.
-func generateProxyConfig(credentials []clawv1alpha1.CredentialSpec) ([]byte, error) {
+func generateProxyConfig(credentials []resolvedCredential) ([]byte, error) {
 	var exact, suffix []proxyRoute
 
 	coveredDomains := make(map[string]bool)
-	for _, cred := range credentials {
-		coveredDomains[strings.ToLower(cred.Domain)] = true
+	for _, rc := range credentials {
+		coveredDomains[strings.ToLower(rc.Domain)] = true
 	}
 
 	for _, domain := range builtinPassthroughDomains {
@@ -180,7 +187,29 @@ func generateProxyConfig(credentials []clawv1alpha1.CredentialSpec) ([]byte, err
 		}
 	}
 
-	for _, cred := range credentials {
+	for _, rc := range credentials {
+		cred := rc.CredentialSpec
+
+		if cred.Type == clawv1alpha1.CredentialTypeKubernetes {
+			if rc.KubeConfig == nil {
+				continue
+			}
+			kubeconfigPath := "/etc/proxy/credentials/" + cred.Name + "/kubeconfig"
+			for _, cluster := range rc.KubeConfig.Clusters {
+				route := proxyRoute{
+					Domain:         cluster.Hostname + ":" + cluster.Port,
+					Injector:       "kubernetes",
+					KubeconfigPath: kubeconfigPath,
+					DefaultHeaders: cred.DefaultHeaders,
+				}
+				if len(cluster.CAData) > 0 {
+					route.CACert = base64.StdEncoding.EncodeToString(cluster.CAData)
+				}
+				exact = append(exact, route)
+			}
+			continue
+		}
+
 		route := proxyRoute{
 			Domain:         cred.Domain,
 			DefaultHeaders: cred.DefaultHeaders,
@@ -275,9 +304,9 @@ func (r *ClawResourceReconciler) applyProxyConfigMap(ctx context.Context, instan
 }
 
 // hasVertexSDKCredentials returns true if any credential uses the native Vertex SDK.
-func hasVertexSDKCredentials(credentials []clawv1alpha1.CredentialSpec) bool {
-	for _, cred := range credentials {
-		if usesVertexSDK(cred) {
+func hasVertexSDKCredentials(credentials []resolvedCredential) bool {
+	for _, rc := range credentials {
+		if usesVertexSDK(rc.CredentialSpec) {
 			return true
 		}
 	}
@@ -287,8 +316,13 @@ func hasVertexSDKCredentials(credentials []clawv1alpha1.CredentialSpec) bool {
 // applyVertexADCConfigMap creates or updates the stub ADC ConfigMap used by the
 // OpenClaw pod's Vertex SDK to bootstrap GCP token refresh. The stub contains
 // dummy credentials — the MITM proxy replaces tokens with real ones.
-func (r *ClawResourceReconciler) applyVertexADCConfigMap(ctx context.Context, instance *clawv1alpha1.Claw) error {
-	if !hasVertexSDKCredentials(instance.Spec.Credentials) {
+func (r *ClawResourceReconciler) applyVertexADCConfigMap(ctx context.Context, instance *clawv1alpha1.Claw, resolvedCreds []resolvedCredential) error {
+	if !hasVertexSDKCredentials(resolvedCreds) {
+		existing := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{Name: ClawVertexADCConfigMapName, Namespace: instance.Namespace}, existing); err == nil {
+			log.FromContext(ctx).Info("Cleaning up orphaned Vertex ADC ConfigMap")
+			return r.Delete(ctx, existing)
+		}
 		return nil
 	}
 
@@ -394,9 +428,9 @@ func configureImagePullPolicy(objects []*unstructured.Unstructured, policy strin
 }
 
 // configureProxyForCredentials adds credential env vars and volume mounts to the
-// claw-proxy Deployment based on spec.credentials[]. This modifies the parsed
+// claw-proxy Deployment based on resolved credentials. This modifies the parsed
 // kustomize objects in-place before they are applied via SSA.
-func configureProxyForCredentials(objects []*unstructured.Unstructured, credentials []clawv1alpha1.CredentialSpec) error {
+func configureProxyForCredentials(objects []*unstructured.Unstructured, credentials []resolvedCredential) error {
 	for _, obj := range objects {
 		if obj.GetKind() != DeploymentKind || obj.GetName() != ClawProxyDeploymentName {
 			continue
@@ -431,7 +465,8 @@ func configureProxyForCredentials(objects []*unstructured.Unstructured, credenti
 		volumeMounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
 		volumes, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
 
-		for _, cred := range credentials {
+		for _, rc := range credentials {
+			cred := rc.CredentialSpec
 			switch cred.Type {
 			case clawv1alpha1.CredentialTypeAPIKey, clawv1alpha1.CredentialTypeBearer,
 				clawv1alpha1.CredentialTypePathToken, clawv1alpha1.CredentialTypeOAuth2:
@@ -471,6 +506,28 @@ func configureProxyForCredentials(objects []*unstructured.Unstructured, credenti
 					"readOnly":  true,
 				})
 
+			case clawv1alpha1.CredentialTypeKubernetes:
+				if cred.SecretRef == nil {
+					continue
+				}
+				volName := "cred-" + cred.Name
+				volumes = append(volumes, map[string]any{
+					"name": volName,
+					"secret": map[string]any{
+						"secretName": cred.SecretRef.Name,
+						"items": []any{
+							map[string]any{
+								"key":  cred.SecretRef.Key,
+								"path": "kubeconfig",
+							},
+						},
+					},
+				})
+				volumeMounts = append(volumeMounts, map[string]any{
+					"name":      volName,
+					"mountPath": "/etc/proxy/credentials/" + cred.Name,
+					"readOnly":  true,
+				})
 			}
 		}
 
@@ -497,11 +554,11 @@ func configureProxyForCredentials(objects []*unstructured.Unstructured, credenti
 // ADC volume mount to the claw (gateway) deployment when any credential uses the
 // native Vertex SDK (GCP + non-Google provider). The stub ADC allows google-auth-library
 // to bootstrap token refresh, which the MITM proxy intercepts with real credentials.
-func configureClawDeploymentForVertex(objects []*unstructured.Unstructured, credentials []clawv1alpha1.CredentialSpec) error {
+func configureClawDeploymentForVertex(objects []*unstructured.Unstructured, credentials []resolvedCredential) error {
 	var vertexCreds []clawv1alpha1.CredentialSpec
-	for _, cred := range credentials {
-		if usesVertexSDK(cred) {
-			vertexCreds = append(vertexCreds, cred)
+	for _, rc := range credentials {
+		if usesVertexSDK(rc.CredentialSpec) {
+			vertexCreds = append(vertexCreds, rc.CredentialSpec)
 		}
 	}
 	if len(vertexCreds) == 0 {
@@ -566,6 +623,83 @@ func configureClawDeploymentForVertex(objects []*unstructured.Unstructured, cred
 			"name": "vertex-adc",
 			"configMap": map[string]any{
 				"name": ClawVertexADCConfigMapName,
+			},
+		})
+
+		if err := unstructured.SetNestedSlice(container, envVars, "env"); err != nil {
+			return fmt.Errorf("failed to set env vars on claw deployment: %w", err)
+		}
+		if err := unstructured.SetNestedSlice(container, volumeMounts, "volumeMounts"); err != nil {
+			return fmt.Errorf("failed to set volume mounts on claw deployment: %w", err)
+		}
+		containers[containerIdx] = container
+		if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+			return fmt.Errorf("failed to set containers on claw deployment: %w", err)
+		}
+		if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
+			return fmt.Errorf("failed to set volumes on claw deployment: %w", err)
+		}
+
+		return nil
+	}
+	return fmt.Errorf("claw deployment not found in manifests")
+}
+
+// configureClawDeploymentForKubernetes mounts the sanitized kubeconfig ConfigMap and
+// sets KUBECONFIG env var on the claw (gateway) deployment when a kubernetes credential is present.
+func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, credentials []resolvedCredential) error {
+	if !hasKubernetesCredentials(credentials) {
+		return nil
+	}
+
+	for _, obj := range objects {
+		if obj.GetKind() != DeploymentKind || obj.GetName() != ClawDeploymentName {
+			continue
+		}
+
+		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		if err != nil {
+			return fmt.Errorf("failed to get containers from claw deployment: %w", err)
+		}
+		if !found {
+			return fmt.Errorf("containers field not found in claw deployment")
+		}
+
+		containerIdx := -1
+		var container map[string]any
+		for i, c := range containers {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(cm, "name"); name == ClawGatewayContainerName {
+				containerIdx = i
+				container = cm
+				break
+			}
+		}
+		if containerIdx < 0 {
+			return fmt.Errorf("container %q not found in claw deployment", ClawGatewayContainerName)
+		}
+
+		envVars, _, _ := unstructured.NestedSlice(container, "env")
+		volumeMounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
+		volumes, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+
+		envVars = append(envVars, map[string]any{
+			"name":  "KUBECONFIG",
+			"value": "/etc/kube/config",
+		})
+
+		volumeMounts = append(volumeMounts, map[string]any{
+			"name":      "kube-config",
+			"mountPath": "/etc/kube",
+			"readOnly":  true,
+		})
+		volumes = append(volumes, map[string]any{
+			"name": "kube-config",
+			"configMap": map[string]any{
+				"name": ClawKubeConfigMapName,
 			},
 		})
 

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -729,7 +729,7 @@ func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, 
 			"name":            "init-kubectl",
 			"image":           kubectlImage,
 			"imagePullPolicy": "IfNotPresent",
-			"command":         []any{"sh", "-c", "cp /bin/kubectl /tools/kubectl"},
+			"command":         []any{"sh", "-c", "cp /usr/bin/oc /usr/bin/kubectl /tools/"},
 			"securityContext": map[string]any{
 				"runAsNonRoot":             true,
 				"allowPrivilegeEscalation": false,

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -645,9 +645,10 @@ func configureClawDeploymentForVertex(objects []*unstructured.Unstructured, cred
 	return fmt.Errorf("claw deployment not found in manifests")
 }
 
-// configureClawDeploymentForKubernetes mounts the sanitized kubeconfig ConfigMap and
-// sets KUBECONFIG env var on the claw (gateway) deployment when a kubernetes credential is present.
-func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, credentials []resolvedCredential) error {
+// configureClawDeploymentForKubernetes mounts the sanitized kubeconfig ConfigMap,
+// sets KUBECONFIG and PATH env vars, and adds an init container that copies kubectl
+// into a shared volume on the claw (gateway) deployment when a kubernetes credential is present.
+func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, credentials []resolvedCredential, kubectlImage string) error {
 	if !hasKubernetesCredentials(credentials) {
 		return nil
 	}
@@ -685,21 +686,65 @@ func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, 
 		envVars, _, _ := unstructured.NestedSlice(container, "env")
 		volumeMounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
 		volumes, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+		initContainers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "initContainers")
 
-		envVars = append(envVars, map[string]any{
-			"name":  "KUBECONFIG",
-			"value": "/etc/kube/config",
-		})
+		envVars = append(envVars,
+			map[string]any{
+				"name":  "KUBECONFIG",
+				"value": "/etc/kube/config",
+			},
+			map[string]any{
+				"name":  "PATH",
+				"value": "/opt/kube-tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			},
+		)
 
-		volumeMounts = append(volumeMounts, map[string]any{
-			"name":      "kube-config",
-			"mountPath": "/etc/kube",
-			"readOnly":  true,
-		})
-		volumes = append(volumes, map[string]any{
-			"name": "kube-config",
-			"configMap": map[string]any{
-				"name": ClawKubeConfigMapName,
+		volumeMounts = append(volumeMounts,
+			map[string]any{
+				"name":      "kube-config",
+				"mountPath": "/etc/kube",
+				"readOnly":  true,
+			},
+			map[string]any{
+				"name":      "kubectl-bin",
+				"mountPath": "/opt/kube-tools",
+				"readOnly":  true,
+			},
+		)
+
+		volumes = append(volumes,
+			map[string]any{
+				"name": "kube-config",
+				"configMap": map[string]any{
+					"name": ClawKubeConfigMapName,
+				},
+			},
+			map[string]any{
+				"name":     "kubectl-bin",
+				"emptyDir": map[string]any{},
+			},
+		)
+
+		initContainers = append(initContainers, map[string]any{
+			"name":            "init-kubectl",
+			"image":           kubectlImage,
+			"imagePullPolicy": "IfNotPresent",
+			"command":         []any{"sh", "-c", "cp /bin/kubectl /tools/kubectl"},
+			"securityContext": map[string]any{
+				"runAsNonRoot":             true,
+				"allowPrivilegeEscalation": false,
+				"readOnlyRootFilesystem":   true,
+				"capabilities":             map[string]any{"drop": []any{"ALL"}},
+			},
+			"resources": map[string]any{
+				"requests": map[string]any{"memory": "32Mi", "cpu": "50m"},
+				"limits":   map[string]any{"memory": "64Mi", "cpu": "100m"},
+			},
+			"volumeMounts": []any{
+				map[string]any{
+					"name":      "kubectl-bin",
+					"mountPath": "/tools",
+				},
 			},
 		})
 
@@ -715,6 +760,9 @@ func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, 
 		}
 		if err := unstructured.SetNestedSlice(obj.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
 			return fmt.Errorf("failed to set volumes on claw deployment: %w", err)
+		}
+		if err := unstructured.SetNestedSlice(obj.Object, initContainers, "spec", "template", "spec", "initContainers"); err != nil {
+			return fmt.Errorf("failed to set init containers on claw deployment: %w", err)
 		}
 
 		return nil

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -173,7 +173,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -202,7 +202,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -228,7 +228,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -257,7 +257,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -290,7 +290,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -310,7 +310,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -336,7 +336,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -365,7 +365,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -395,7 +395,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -420,7 +420,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -447,7 +447,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -477,7 +477,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -491,7 +491,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 
 func TestBuiltinPassthroughDomains(t *testing.T) {
 	t.Run("should include openrouter.ai as none route with no credentials", func(t *testing.T) {
-		data, err := generateProxyConfig(nil)
+		data, err := generateProxyConfig(nil) //nolint:staticcheck
 		require.NoError(t, err)
 
 		var cfg proxyConfig
@@ -515,7 +515,7 @@ func TestBuiltinPassthroughDomains(t *testing.T) {
 			},
 		}
 
-		data, err := generateProxyConfig(credentials)
+		data, err := generateProxyConfig(toResolved(credentials))
 		require.NoError(t, err)
 
 		var cfg proxyConfig

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,26 +57,29 @@ const (
 	ClawInstanceName = "instance"
 
 	// Core resources
-	ClawConfigMapName            = "claw-config"
-	ClawPVCName                  = "claw-home-pvc"
-	ClawNetworkPolicyName        = "claw-egress"
-	ClawIngressNetworkPolicyName = "claw-ingress"
-	ClawRouteName                = "claw"
-	ClawServiceName              = "claw"
-	ClawDeploymentName           = "claw"
-	ClawGatewaySecretName        = "claw-gateway-token"
-	GatewayTokenKeyName          = "token"
-	ClawProxyServiceName         = "claw-proxy"
-	ClawProxyConfigMapName       = "claw-proxy-config"
-	ClawProxyDeploymentName      = "claw-proxy"
-	ClawProxyCACertSecretName    = "claw-proxy-ca"
-	ClawProxyContainerName       = "proxy"
-	ClawGatewayContainerName     = "gateway"
-	ClawVertexADCConfigMapName   = "claw-vertex-adc"
+	ClawConfigMapName                = "claw-config"
+	ClawPVCName                      = "claw-home-pvc"
+	ClawNetworkPolicyName            = "claw-egress"
+	ClawIngressNetworkPolicyName     = "claw-ingress"
+	ClawRouteName                    = "claw"
+	ClawServiceName                  = "claw"
+	ClawDeploymentName               = "claw"
+	ClawGatewaySecretName            = "claw-gateway-token"
+	GatewayTokenKeyName              = "token"
+	ClawProxyServiceName             = "claw-proxy"
+	ClawProxyConfigMapName           = "claw-proxy-config"
+	ClawProxyDeploymentName          = "claw-proxy"
+	ClawProxyCACertSecretName        = "claw-proxy-ca"
+	ClawProxyContainerName           = "proxy"
+	ClawGatewayContainerName         = "gateway"
+	ClawVertexADCConfigMapName       = "claw-vertex-adc"
+	ClawKubeConfigMapName            = "claw-kube-config"
+	ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"
 	// Kubernetes resource kinds
-	RouteKind      = "Route"
-	DeploymentKind = "Deployment"
-	ConfigMapKind  = "ConfigMap"
+	RouteKind         = "Route"
+	DeploymentKind    = "Deployment"
+	ConfigMapKind     = "ConfigMap"
+	NetworkPolicyKind = "NetworkPolicy"
 )
 
 // ClawResourceReconciler reconciles all resources for Claw
@@ -126,39 +130,14 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	// Resolve provider defaults (domain, apiKey) for known providers before validation
-	for i := range instance.Spec.Credentials {
-		if err := resolveProviderDefaults(&instance.Spec.Credentials[i]); err != nil {
-			logger.Error(err, "Failed to resolve provider defaults")
-			setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
-			setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
-			if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status after provider defaults failure")
-			}
-			return ctrl.Result{}, err
-		}
-	}
-
-	// Validate all credential entries (Secrets exist, type-specific config present)
-	if err := r.validateCredentials(ctx, instance); err != nil {
-		logger.Error(err, "Credential validation failed")
-		setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
-		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
-		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status after credential validation failure")
-		}
-		return ctrl.Result{}, err
-	}
-	setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionTrue, clawv1alpha1.ConditionReasonResolved, "All credential Secrets are valid")
-
-	// Ensure proxy CA certificate exists for MITM proxy
-	if err := r.applyProxyCA(ctx, instance); err != nil {
-		logger.Error(err, "Failed to apply proxy CA")
+	// Resolve credentials (provider defaults, validation, kubeconfig parsing)
+	resolvedCreds, err := r.resolveAndApplyCredentials(ctx, instance)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Generate proxy config, apply ConfigMaps (proxy config + Vertex AI stub ADC)
-	proxyConfigJSON, err := r.applyProxyResources(ctx, instance)
+	proxyConfigJSON, err := r.applyProxyResources(ctx, instance, resolvedCreds)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -170,7 +149,7 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Apply deployment overrides (proxy image, pull policy, credentials)
-	if err := r.configureDeployments(objects, instance); err != nil {
+	if err := r.configureDeployments(objects, resolvedCreds); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -221,6 +200,16 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to inject providers into ConfigMap: %w", err)
 	}
 
+	// Inject Kubernetes context info into AGENTS.md
+	if err := injectKubernetesIntoAgentsMd(objects, resolvedCreds); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes info into AGENTS.md: %w", err)
+	}
+
+	// Inject non-443 ports from kubernetes credentials into proxy egress NetworkPolicy
+	if err := injectKubePortsIntoNetworkPolicy(objects, resolvedCreds); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes ports into NetworkPolicy: %w", err)
+	}
+
 	// Filter out Route (applied in phase above) and proxy ConfigMap (controller-managed)
 	remainingObjects := []*unstructured.Unstructured{}
 	for _, obj := range objects {
@@ -254,10 +243,52 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
+// resolveAndApplyCredentials handles provider defaults, credential resolution/validation,
+// sanitized kubeconfig creation, and proxy CA generation in one cohesive step.
+func (r *ClawResourceReconciler) resolveAndApplyCredentials(ctx context.Context, instance *clawv1alpha1.Claw) ([]resolvedCredential, error) {
+	logger := log.FromContext(ctx)
+
+	for i := range instance.Spec.Credentials {
+		if err := resolveProviderDefaults(&instance.Spec.Credentials[i]); err != nil {
+			logger.Error(err, "Failed to resolve provider defaults")
+			setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
+			setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
+			if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
+				logger.Error(statusErr, "Failed to update status after provider defaults failure")
+			}
+			return nil, err
+		}
+	}
+
+	resolvedCreds, err := r.resolveCredentials(ctx, instance)
+	if err != nil {
+		logger.Error(err, "Credential validation failed")
+		setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
+		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonValidationFailed, err.Error())
+		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status after credential validation failure")
+		}
+		return nil, err
+	}
+	setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionTrue, clawv1alpha1.ConditionReasonResolved, "All credential Secrets are valid")
+
+	if err := r.applySanitizedKubeconfig(ctx, instance, resolvedCreds); err != nil {
+		logger.Error(err, "Failed to apply sanitized kubeconfig")
+		return nil, err
+	}
+
+	if err := r.applyProxyCA(ctx, instance); err != nil {
+		logger.Error(err, "Failed to apply proxy CA")
+		return nil, err
+	}
+
+	return resolvedCreds, nil
+}
+
 // configureDeployments applies deployment overrides (proxy image, pull policy, credentials)
 func (r *ClawResourceReconciler) configureDeployments(
 	objects []*unstructured.Unstructured,
-	instance *clawv1alpha1.Claw,
+	resolvedCreds []resolvedCredential,
 ) error {
 	if err := configureProxyImage(objects, r.ProxyImage); err != nil {
 		return fmt.Errorf("failed to configure proxy image: %w", err)
@@ -265,11 +296,14 @@ func (r *ClawResourceReconciler) configureDeployments(
 	if err := configureImagePullPolicy(objects, r.ImagePullPolicy); err != nil {
 		return fmt.Errorf("failed to configure image pull policy: %w", err)
 	}
-	if err := configureProxyForCredentials(objects, instance.Spec.Credentials); err != nil {
+	if err := configureProxyForCredentials(objects, resolvedCreds); err != nil {
 		return fmt.Errorf("failed to configure proxy deployment for credentials: %w", err)
 	}
-	if err := configureClawDeploymentForVertex(objects, instance.Spec.Credentials); err != nil {
+	if err := configureClawDeploymentForVertex(objects, resolvedCreds); err != nil {
 		return fmt.Errorf("failed to configure claw deployment for Vertex AI: %w", err)
+	}
+	if err := configureClawDeploymentForKubernetes(objects, resolvedCreds); err != nil {
+		return fmt.Errorf("failed to configure claw deployment for Kubernetes: %w", err)
 	}
 	return nil
 }
@@ -277,10 +311,10 @@ func (r *ClawResourceReconciler) configureDeployments(
 // applyProxyResources generates the proxy config, applies the proxy ConfigMap and
 // (when needed) the Vertex AI stub ADC ConfigMap. Returns the proxy config JSON
 // for use in config hash stamping.
-func (r *ClawResourceReconciler) applyProxyResources(ctx context.Context, instance *clawv1alpha1.Claw) ([]byte, error) {
+func (r *ClawResourceReconciler) applyProxyResources(ctx context.Context, instance *clawv1alpha1.Claw, resolvedCreds []resolvedCredential) ([]byte, error) {
 	logger := log.FromContext(ctx)
 
-	proxyConfigJSON, err := generateProxyConfig(instance.Spec.Credentials)
+	proxyConfigJSON, err := generateProxyConfig(resolvedCreds)
 	if err != nil {
 		logger.Error(err, "Failed to generate proxy config")
 		setCondition(instance, clawv1alpha1.ConditionTypeProxyConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
@@ -300,7 +334,7 @@ func (r *ClawResourceReconciler) applyProxyResources(ctx context.Context, instan
 		}
 		return nil, err
 	}
-	if err := r.applyVertexADCConfigMap(ctx, instance); err != nil {
+	if err := r.applyVertexADCConfigMap(ctx, instance, resolvedCreds); err != nil {
 		logger.Error(err, "Failed to apply Vertex ADC config")
 		setCondition(instance, clawv1alpha1.ConditionTypeProxyConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
 		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse, clawv1alpha1.ConditionReasonConfigFailed, err.Error())
@@ -614,6 +648,126 @@ func filterAgentDefaultsForProviders(config map[string]any, providers map[string
 			}
 		}
 	}
+}
+
+// injectKubePortsIntoNetworkPolicy adds non-443 ports from kubernetes credentials to
+// the proxy egress NetworkPolicy. This allows the proxy to reach API servers on
+// non-standard ports (e.g., 6443).
+func injectKubePortsIntoNetworkPolicy(objects []*unstructured.Unstructured, resolvedCreds []resolvedCredential) error {
+	uniquePorts := map[string]bool{}
+	for _, rc := range resolvedCreds {
+		if rc.KubeConfig == nil {
+			continue
+		}
+		for _, cluster := range rc.KubeConfig.Clusters {
+			if cluster.Port != "443" {
+				uniquePorts[cluster.Port] = true
+			}
+		}
+	}
+	if len(uniquePorts) == 0 {
+		return nil
+	}
+
+	for _, obj := range objects {
+		if obj.GetKind() != NetworkPolicyKind || obj.GetName() != ClawProxyEgressNetworkPolicyName {
+			continue
+		}
+
+		egress, found, err := unstructured.NestedSlice(obj.Object, "spec", "egress")
+		if err != nil {
+			return fmt.Errorf("failed to get egress rules from proxy NetworkPolicy: %w", err)
+		}
+		if !found || len(egress) == 0 {
+			return fmt.Errorf("egress rules not found in proxy NetworkPolicy")
+		}
+
+		// First egress rule is the HTTPS rule (ports only, no `to` restriction)
+		httpsRule, ok := egress[0].(map[string]any)
+		if !ok {
+			return fmt.Errorf("unexpected egress rule type in proxy NetworkPolicy")
+		}
+
+		ports, _, _ := unstructured.NestedSlice(httpsRule, "ports")
+		for port := range uniquePorts {
+			portInt, err := strconv.Atoi(port)
+			if err != nil {
+				return fmt.Errorf("invalid port %q from kubeconfig: %w", port, err)
+			}
+			ports = append(ports, map[string]any{
+				"port":     int64(portInt),
+				"protocol": "TCP",
+			})
+		}
+
+		if err := unstructured.SetNestedSlice(httpsRule, ports, "ports"); err != nil {
+			return fmt.Errorf("failed to set ports on proxy egress rule: %w", err)
+		}
+		egress[0] = httpsRule
+		if err := unstructured.SetNestedSlice(obj.Object, egress, "spec", "egress"); err != nil {
+			return fmt.Errorf("failed to set egress rules on proxy NetworkPolicy: %w", err)
+		}
+		return nil
+	}
+	return nil
+}
+
+// injectKubernetesIntoAgentsMd appends a Kubernetes section to AGENTS.md in the
+// claw-config ConfigMap when kubernetes credentials are present.
+func injectKubernetesIntoAgentsMd(objects []*unstructured.Unstructured, resolvedCreds []resolvedCredential) error {
+	var allContexts []kubeconfigContext
+	for _, rc := range resolvedCreds {
+		if rc.KubeConfig == nil {
+			continue
+		}
+		allContexts = append(allContexts, rc.KubeConfig.Contexts...)
+	}
+	if len(allContexts) == 0 {
+		return nil
+	}
+
+	for _, obj := range objects {
+		if obj.GetKind() != ConfigMapKind || obj.GetName() != ClawConfigMapName {
+			continue
+		}
+
+		agentsMd, _, err := unstructured.NestedString(obj.Object, "data", "AGENTS.md")
+		if err != nil {
+			return fmt.Errorf("failed to extract AGENTS.md from ConfigMap: %w", err)
+		}
+
+		var sb strings.Builder
+		sb.WriteString(agentsMd)
+		sb.WriteString("\n## Kubernetes Access\n\n")
+		sb.WriteString("You have access to Kubernetes clusters via `kubectl`. Your KUBECONFIG is\n")
+		sb.WriteString("pre-configured. Available contexts:\n")
+
+		// Sort contexts for stable output
+		sort.Slice(allContexts, func(i, j int) bool {
+			return allContexts[i].Name < allContexts[j].Name
+		})
+
+		for _, ctx := range allContexts {
+			entry := fmt.Sprintf("- `%s` (cluster: %s", ctx.Name, ctx.Cluster)
+			if ctx.Namespace != "" {
+				entry += ", namespace: " + ctx.Namespace
+			}
+			entry += ")"
+			if ctx.Current {
+				entry += " [current]"
+			}
+			sb.WriteString(entry + "\n")
+		}
+
+		sb.WriteString("\nUse `kubectl` commands to manage resources. The proxy handles authentication\n")
+		sb.WriteString("transparently — do not attempt to manage tokens or kubeconfig yourself.\n")
+
+		if err := unstructured.SetNestedField(obj.Object, sb.String(), "data", "AGENTS.md"); err != nil {
+			return fmt.Errorf("failed to set AGENTS.md in ConfigMap: %w", err)
+		}
+		return nil
+	}
+	return nil
 }
 
 // readEmbeddedFile reads a file from the embedded filesystem

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -75,7 +75,7 @@ const (
 	ClawVertexADCConfigMapName       = "claw-vertex-adc"
 	ClawKubeConfigMapName            = "claw-kube-config"
 	ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"
-	DefaultKubectlImage              = "registry.k8s.io/kubectl:v1.34"
+	DefaultKubectlImage              = "registry.k8s.io/kubectl:v1.34.7"
 	// Kubernetes resource kinds
 	RouteKind         = "Route"
 	DeploymentKind    = "Deployment"

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -75,7 +75,7 @@ const (
 	ClawVertexADCConfigMapName       = "claw-vertex-adc"
 	ClawKubeConfigMapName            = "claw-kube-config"
 	ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"
-	DefaultKubectlImage              = "registry.k8s.io/kubectl:v1.34.7"
+	DefaultKubectlImage              = "quay.io/openshift/origin-cli:4.21"
 	// Kubernetes resource kinds
 	RouteKind         = "Route"
 	DeploymentKind    = "Deployment"

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -75,6 +75,7 @@ const (
 	ClawVertexADCConfigMapName       = "claw-vertex-adc"
 	ClawKubeConfigMapName            = "claw-kube-config"
 	ClawProxyEgressNetworkPolicyName = "claw-proxy-egress"
+	DefaultKubectlImage              = "registry.k8s.io/kubectl:v1.34"
 	// Kubernetes resource kinds
 	RouteKind         = "Route"
 	DeploymentKind    = "Deployment"
@@ -87,6 +88,7 @@ type ClawResourceReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	ProxyImage      string
+	KubectlImage    string
 	ImagePullPolicy string
 }
 
@@ -302,7 +304,11 @@ func (r *ClawResourceReconciler) configureDeployments(
 	if err := configureClawDeploymentForVertex(objects, resolvedCreds); err != nil {
 		return fmt.Errorf("failed to configure claw deployment for Vertex AI: %w", err)
 	}
-	if err := configureClawDeploymentForKubernetes(objects, resolvedCreds); err != nil {
+	kubectlImage := r.KubectlImage
+	if kubectlImage == "" {
+		kubectlImage = DefaultKubectlImage
+	}
+	if err := configureClawDeploymentForKubernetes(objects, resolvedCreds, kubectlImage); err != nil {
 		return fmt.Errorf("failed to configure claw deployment for Kubernetes: %w", err)
 	}
 	return nil

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -689,11 +689,18 @@ func injectKubePortsIntoNetworkPolicy(objects []*unstructured.Unstructured, reso
 		}
 
 		ports, _, _ := unstructured.NestedSlice(httpsRule, "ports")
+
+		sortedPorts := make([]int, 0, len(uniquePorts))
 		for port := range uniquePorts {
 			portInt, err := strconv.Atoi(port)
 			if err != nil {
 				return fmt.Errorf("invalid port %q from kubeconfig: %w", port, err)
 			}
+			sortedPorts = append(sortedPorts, portInt)
+		}
+		sort.Ints(sortedPorts)
+
+		for _, portInt := range sortedPorts {
 			ports = append(ports, map[string]any{
 				"port":     int64(portInt),
 				"protocol": "TCP",

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -309,6 +309,15 @@ func testCredentialsMITMOnly() []clawv1alpha1.CredentialSpec {
 	}
 }
 
+// toResolved wraps a slice of CredentialSpec into resolvedCredential with nil KubeConfig.
+func toResolved(specs []clawv1alpha1.CredentialSpec) []resolvedCredential {
+	resolved := make([]resolvedCredential, len(specs))
+	for i, s := range specs {
+		resolved[i] = resolvedCredential{CredentialSpec: s}
+	}
+	return resolved
+}
+
 // createClawReconciler creates a ClawResourceReconciler for testing.
 func createClawReconciler() *ClawResourceReconciler {
 	return &ClawResourceReconciler{

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 )
@@ -69,10 +70,10 @@ func LoadConfig(path string) (*Config, error) {
 func (c *Config) MatchRoute(host string) *Route {
 	hostLower := strings.ToLower(host)
 
-	// Extract hostname without port for bare domain matching
+	// Extract hostname without port (IPv6-safe)
 	hostname := hostLower
-	if idx := strings.LastIndex(hostname, ":"); idx != -1 {
-		hostname = hostname[:idx]
+	if h, _, err := net.SplitHostPort(hostLower); err == nil {
+		hostname = h
 	}
 
 	for i := range c.Routes {
@@ -82,7 +83,7 @@ func (c *Config) MatchRoute(host string) *Route {
 			if strings.HasSuffix(hostname, domain) || hostname == domain[1:] {
 				return &c.Routes[i]
 			}
-		} else if strings.Contains(domain, ":") {
+		} else if _, _, err := net.SplitHostPort(domain); err == nil {
 			// Port-qualified domain: match against full host:port
 			if hostLower == domain {
 				return &c.Routes[i]

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -39,6 +39,8 @@ type Route struct {
 	TokenURL       string            `json:"tokenURL,omitempty"`
 	Scopes         []string          `json:"scopes,omitempty"`
 	DefaultHeaders map[string]string `json:"defaultHeaders,omitempty"`
+	KubeconfigPath string            `json:"kubeconfigPath,omitempty"`
+	CACert         string            `json:"caCert,omitempty"`
 }
 
 // Config is the top-level proxy configuration.
@@ -62,21 +64,34 @@ func LoadConfig(path string) (*Config, error) {
 // MatchRoute finds the first route matching the given host.
 // Exact matches are checked first (they appear first in the config by convention),
 // then suffix matches (domains starting with ".").
+// Port-qualified domains (e.g., "api.example.com:6443") match against the full
+// hostname:port from the request. Bare domains use hostname-only matching.
 func (c *Config) MatchRoute(host string) *Route {
-	// Strip port if present
-	if idx := strings.LastIndex(host, ":"); idx != -1 {
-		host = host[:idx]
+	hostLower := strings.ToLower(host)
+
+	// Extract hostname without port for bare domain matching
+	hostname := hostLower
+	if idx := strings.LastIndex(hostname, ":"); idx != -1 {
+		hostname = hostname[:idx]
 	}
-	host = strings.ToLower(host)
 
 	for i := range c.Routes {
 		domain := strings.ToLower(c.Routes[i].Domain)
 		if strings.HasPrefix(domain, ".") {
-			if strings.HasSuffix(host, domain) || host == domain[1:] {
+			// Suffix match always uses hostname only
+			if strings.HasSuffix(hostname, domain) || hostname == domain[1:] {
 				return &c.Routes[i]
 			}
-		} else if host == domain {
-			return &c.Routes[i]
+		} else if strings.Contains(domain, ":") {
+			// Port-qualified domain: match against full host:port
+			if hostLower == domain {
+				return &c.Routes[i]
+			}
+		} else {
+			// Bare domain: match hostname only
+			if hostname == domain {
+				return &c.Routes[i]
+			}
 		}
 	}
 	return nil

--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -103,6 +103,8 @@ func TestMatchRoutePortAware(t *testing.T) {
 			{Domain: "api.example.com:8443", Injector: "kubernetes"},
 			{Domain: "api.example.com", Injector: "bearer"},
 			{Domain: ".googleapis.com", Injector: "api_key"},
+			{Domain: "[::1]:6443", Injector: "kubernetes"},
+			{Domain: "[2001:db8::1]:8443", Injector: "kubernetes"},
 		},
 	}
 
@@ -118,6 +120,9 @@ func TestMatchRoutePortAware(t *testing.T) {
 		{name: "bare domain match without port", host: "api.example.com", wantDom: "api.example.com"},
 		{name: "suffix match still works with port-qualified routes", host: "storage.googleapis.com:443", wantDom: ".googleapis.com"},
 		{name: "no match on wrong port", host: "api.example.com:9999", wantDom: "api.example.com"},
+		{name: "IPv6 loopback with port", host: "[::1]:6443", wantDom: "[::1]:6443"},
+		{name: "IPv6 full address with port", host: "[2001:db8::1]:8443", wantDom: "[2001:db8::1]:8443"},
+		{name: "IPv6 no match on wrong port", host: "[::1]:9999", wantNil: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -95,3 +95,40 @@ func TestMatchRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchRoutePortAware(t *testing.T) {
+	cfg := &Config{
+		Routes: []Route{
+			{Domain: "api.example.com:6443", Injector: "kubernetes"},
+			{Domain: "api.example.com:8443", Injector: "kubernetes"},
+			{Domain: "api.example.com", Injector: "bearer"},
+			{Domain: ".googleapis.com", Injector: "api_key"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		host    string
+		wantNil bool
+		wantDom string
+	}{
+		{name: "port-qualified match on 6443", host: "api.example.com:6443", wantDom: "api.example.com:6443"},
+		{name: "port-qualified match on 8443", host: "api.example.com:8443", wantDom: "api.example.com:8443"},
+		{name: "bare domain match with standard port", host: "api.example.com:443", wantDom: "api.example.com"},
+		{name: "bare domain match without port", host: "api.example.com", wantDom: "api.example.com"},
+		{name: "suffix match still works with port-qualified routes", host: "storage.googleapis.com:443", wantDom: ".googleapis.com"},
+		{name: "no match on wrong port", host: "api.example.com:9999", wantDom: "api.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := cfg.MatchRoute(tt.host)
+			if tt.wantNil {
+				assert.Nil(t, route)
+			} else {
+				require.NotNil(t, route)
+				assert.Equal(t, tt.wantDom, route.Domain)
+			}
+		})
+	}
+}

--- a/internal/proxy/injector.go
+++ b/internal/proxy/injector.go
@@ -58,6 +58,8 @@ func NewInjector(route *Route) (Injector, error) {
 		return NewPathTokenInjector(route)
 	case "oauth2":
 		return NewOAuth2Injector(route)
+	case "kubernetes":
+		return NewKubernetesInjector(route)
 	default:
 		return nil, fmt.Errorf("unknown injector type: %s", route.Injector)
 	}

--- a/internal/proxy/injector.go
+++ b/internal/proxy/injector.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // Injector injects credentials into an HTTP request.
@@ -34,12 +35,21 @@ var authHeaders = []string{
 	"X-Api-Key",
 	"X-Goog-Api-Key",
 	"Proxy-Authorization",
+	"Impersonate-User",
+	"Impersonate-Group",
+	"Impersonate-Uid",
 }
 
-// StripAuthHeaders removes all known auth headers from the request.
+// StripAuthHeaders removes all known auth and impersonation headers from the request.
 func StripAuthHeaders(req *http.Request) {
 	for _, h := range authHeaders {
 		req.Header.Del(h)
+	}
+	// Strip any Impersonate-Extra-* headers (variable suffix)
+	for key := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), "impersonate-extra-") {
+			req.Header.Del(key)
+		}
 	}
 }
 

--- a/internal/proxy/injector_kubernetes.go
+++ b/internal/proxy/injector_kubernetes.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -52,8 +53,8 @@ func NewKubernetesInjector(route *Route) (*KubernetesInjector, error) {
 		clusterServers[name] = cluster.Server
 	}
 
-	// Walk contexts to map server -> token
-	for _, ctx := range cfg.Contexts {
+	// Walk contexts to map server -> token, validating non-empty tokens
+	for ctxName, ctx := range cfg.Contexts {
 		serverURL, ok := clusterServers[ctx.Cluster]
 		if !ok {
 			continue
@@ -61,6 +62,9 @@ func NewKubernetesInjector(route *Route) (*KubernetesInjector, error) {
 		authInfo, ok := cfg.AuthInfos[ctx.AuthInfo]
 		if !ok {
 			continue
+		}
+		if authInfo.Token == "" {
+			return nil, fmt.Errorf("context %q (user %q) has no token configured", ctxName, ctx.AuthInfo)
 		}
 		key := normalizeHost(serverURL)
 		if key == "" {
@@ -78,10 +82,7 @@ func NewKubernetesInjector(route *Route) (*KubernetesInjector, error) {
 // Inject sets the Authorization header with the appropriate Bearer token
 // for the request's target hostname:port.
 func (k *KubernetesInjector) Inject(req *http.Request) error {
-	host := strings.ToLower(req.URL.Host)
-	if !strings.Contains(host, ":") {
-		host += ":443"
-	}
+	host := normalizeRequestHost(req.URL.Host)
 
 	token, ok := k.tokens[host]
 	if !ok {
@@ -95,6 +96,20 @@ func (k *KubernetesInjector) Inject(req *http.Request) error {
 	}
 
 	return nil
+}
+
+// normalizeRequestHost converts a request Host (which may be bracketed IPv6 like
+// "[::1]:6443") into the same "hostname:port" canonical form that normalizeHost
+// produces, so token lookups work for both IPv4 and IPv6.
+func normalizeRequestHost(rawHost string) string {
+	h, port, err := net.SplitHostPort(rawHost)
+	if err != nil {
+		// No port — treat entire value as hostname, default port 443
+		h = rawHost
+		port = "443"
+	}
+	// SplitHostPort strips brackets from IPv6; lowercase for consistency
+	return strings.ToLower(h) + ":" + port
 }
 
 // normalizeHost extracts "hostname:port" from a server URL, defaulting port to "443".

--- a/internal/proxy/injector_kubernetes.go
+++ b/internal/proxy/injector_kubernetes.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// KubernetesInjector injects Bearer tokens from a kubeconfig file, mapping
+// each cluster's hostname:port to its corresponding user token.
+type KubernetesInjector struct {
+	tokens         map[string]string // normalized "hostname:port" -> bearer token
+	defaultHeaders map[string]string
+}
+
+// NewKubernetesInjector creates a KubernetesInjector from a route with a kubeconfigPath.
+// It parses the kubeconfig once and builds a hostname:port -> token lookup map.
+func NewKubernetesInjector(route *Route) (*KubernetesInjector, error) {
+	if route.KubeconfigPath == "" {
+		return nil, fmt.Errorf("kubeconfigPath is required for kubernetes injector")
+	}
+
+	cfg, err := clientcmd.LoadFromFile(route.KubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig from %s: %w", route.KubeconfigPath, err)
+	}
+
+	tokens := make(map[string]string)
+
+	// Build cluster name -> server URL map
+	clusterServers := make(map[string]string)
+	for name, cluster := range cfg.Clusters {
+		clusterServers[name] = cluster.Server
+	}
+
+	// Walk contexts to map server -> token
+	for _, ctx := range cfg.Contexts {
+		serverURL, ok := clusterServers[ctx.Cluster]
+		if !ok {
+			continue
+		}
+		authInfo, ok := cfg.AuthInfos[ctx.AuthInfo]
+		if !ok {
+			continue
+		}
+		key := normalizeHost(serverURL)
+		if key == "" {
+			continue
+		}
+		tokens[key] = authInfo.Token
+	}
+
+	return &KubernetesInjector{
+		tokens:         tokens,
+		defaultHeaders: route.DefaultHeaders,
+	}, nil
+}
+
+// Inject sets the Authorization header with the appropriate Bearer token
+// for the request's target hostname:port.
+func (k *KubernetesInjector) Inject(req *http.Request) error {
+	host := strings.ToLower(req.URL.Host)
+	if !strings.Contains(host, ":") {
+		host += ":443"
+	}
+
+	token, ok := k.tokens[host]
+	if !ok {
+		return fmt.Errorf("no token for host %s", host)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	for key, val := range k.defaultHeaders {
+		req.Header.Set(key, val)
+	}
+
+	return nil
+}
+
+// normalizeHost extracts "hostname:port" from a server URL, defaulting port to "443".
+func normalizeHost(serverURL string) string {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return ""
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	return strings.ToLower(hostname) + ":" + port
+}

--- a/internal/proxy/injector_kubernetes_test.go
+++ b/internal/proxy/injector_kubernetes_test.go
@@ -203,6 +203,73 @@ func TestKubernetesInjector(t *testing.T) {
 	})
 }
 
+func TestKubernetesInjectorIPv6(t *testing.T) {
+	t.Run("should inject token for IPv6 bracketed host", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{"ipv6": "https://[::1]:6443"},
+			map[string]string{"admin": "ipv6-token"},
+			map[string][2]string{"ctx": {"ipv6", "admin"}},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "[::1]:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+		})
+		require.NoError(t, err)
+
+		req := &http.Request{
+			URL:    &url.URL{Host: "[::1]:6443"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(req))
+		assert.Equal(t, "Bearer ipv6-token", req.Header.Get("Authorization"))
+	})
+
+	t.Run("should reject empty token at startup", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["prod"] = &clientcmdapi.Cluster{Server: "https://api.example.com:6443"}
+		cfg.AuthInfos["empty"] = &clientcmdapi.AuthInfo{Token: ""}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "prod", AuthInfo: "empty"}
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp("", "kubeconfig-*.yaml")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		_, err = NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: f.Name(),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no token configured")
+	})
+}
+
+func TestNormalizeRequestHost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"api.example.com:6443", "api.example.com:6443"},
+		{"api.example.com", "api.example.com:443"},
+		{"[::1]:6443", "::1:6443"},
+		{"[2001:db8::1]:8443", "2001:db8::1:8443"},
+		{"API.EXAMPLE.COM:8443", "api.example.com:8443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeRequestHost(tt.input))
+		})
+	}
+}
+
 func TestNormalizeHost(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/proxy/injector_kubernetes_test.go
+++ b/internal/proxy/injector_kubernetes_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func writeTestKubeconfig(t *testing.T, clusters map[string]string, users map[string]string, contexts map[string][2]string) string {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	for name, server := range clusters {
+		cfg.Clusters[name] = &clientcmdapi.Cluster{Server: server}
+	}
+	for name, token := range users {
+		cfg.AuthInfos[name] = &clientcmdapi.AuthInfo{Token: token}
+	}
+	for name, pair := range contexts {
+		cfg.Contexts[name] = &clientcmdapi.Context{Cluster: pair[0], AuthInfo: pair[1]}
+	}
+	data, err := clientcmd.Write(*cfg)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "kubeconfig-*.yaml")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestKubernetesInjector(t *testing.T) {
+	t.Run("should inject bearer token for matching host", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "my-secret-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+		})
+		require.NoError(t, err)
+
+		req := &http.Request{
+			URL:    &url.URL{Host: "api.example.com:6443"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(req))
+
+		assert.Equal(t, "Bearer my-secret-token", req.Header.Get("Authorization"))
+	})
+
+	t.Run("should return error for unmatched host", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+		})
+		require.NoError(t, err)
+
+		req := &http.Request{
+			URL:    &url.URL{Host: "other.example.com:6443"},
+			Header: http.Header{},
+		}
+		err = inj.Inject(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no token for host")
+	})
+
+	t.Run("should normalize port default to 443", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+		})
+		require.NoError(t, err)
+
+		req := &http.Request{
+			URL:    &url.URL{Host: "api.example.com"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(req))
+		assert.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
+	})
+
+	t.Run("should set default headers", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+			DefaultHeaders: map[string]string{"X-Custom": "value"},
+		})
+		require.NoError(t, err)
+
+		req := &http.Request{
+			URL:    &url.URL{Host: "api.example.com:6443"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(req))
+		assert.Equal(t, "value", req.Header.Get("X-Custom"))
+	})
+
+	t.Run("should error when kubeconfigPath is empty", func(t *testing.T) {
+		_, err := NewKubernetesInjector(&Route{
+			Domain:   "api.example.com:6443",
+			Injector: "kubernetes",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kubeconfigPath is required")
+	})
+
+	t.Run("should error when kubeconfig file does not exist", func(t *testing.T) {
+		_, err := NewKubernetesInjector(&Route{
+			Domain:         "api.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: "/nonexistent/path/kubeconfig",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load kubeconfig")
+	})
+
+	t.Run("should handle multi-cluster kubeconfig", func(t *testing.T) {
+		path := writeTestKubeconfig(t,
+			map[string]string{
+				"prod":    "https://api.prod.example.com:6443",
+				"staging": "https://api.staging.example.com:8443",
+			},
+			map[string]string{
+				"prod-admin":    "prod-token",
+				"staging-admin": "staging-token",
+			},
+			map[string][2]string{
+				"prod-ctx":    {"prod", "prod-admin"},
+				"staging-ctx": {"staging", "staging-admin"},
+			},
+		)
+
+		inj, err := NewKubernetesInjector(&Route{
+			Domain:         "api.prod.example.com:6443",
+			Injector:       "kubernetes",
+			KubeconfigPath: path,
+		})
+		require.NoError(t, err)
+
+		prodReq := &http.Request{
+			URL:    &url.URL{Host: "api.prod.example.com:6443"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(prodReq))
+		assert.Equal(t, "Bearer prod-token", prodReq.Header.Get("Authorization"))
+
+		stagingReq := &http.Request{
+			URL:    &url.URL{Host: "api.staging.example.com:8443"},
+			Header: http.Header{},
+		}
+		require.NoError(t, inj.Inject(stagingReq))
+		assert.Equal(t, "Bearer staging-token", stagingReq.Header.Get("Authorization"))
+	})
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://api.example.com:6443", "api.example.com:6443"},
+		{"https://api.example.com", "api.example.com:443"},
+		{"https://API.EXAMPLE.COM:8443", "api.example.com:8443"},
+		{"invalid-url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeHost(tt.input))
+		})
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"log/slog"
@@ -27,7 +28,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/elazarl/goproxy"
@@ -62,10 +62,12 @@ func NewServer(cfg *Config, caCertPEM, caKeyPEM []byte, logger *slog.Logger) (*S
 
 	proxy := goproxy.NewProxyHttpServer()
 
+	rootCAs := buildRootCAPool(cfg, logger)
+
 	// Override goproxy's default transport which uses InsecureSkipVerify: true.
 	// We MUST verify upstream server TLS certificates to prevent credential theft via MITM.
 	proxy.Tr = &http.Transport{
-		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: rootCAs},
 		DialContext: (&net.Dialer{
 			Timeout: 15 * time.Second,
 		}).DialContext,
@@ -88,27 +90,25 @@ func NewServer(cfg *Config, caCertPEM, caKeyPEM []byte, logger *slog.Logger) (*S
 
 	proxy.OnRequest().HandleConnectFunc(
 		func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-			hostname := stripPort(host)
-			route := cfg.MatchRoute(hostname)
+			route := cfg.MatchRoute(host)
 			if route == nil {
-				logger.Warn("blocked CONNECT to unknown domain", "host", hostname)
+				logger.Warn("blocked CONNECT to unknown domain", "host", host)
 				ctx.Resp = goproxy.NewResponse(
 					ctx.Req, goproxy.ContentTypeText, http.StatusForbidden,
 					`{"error":"domain not allowed"}`,
 				)
 				return rejectConnect, host
 			}
-			logger.Debug("CONNECT allowed", "host", hostname)
+			logger.Debug("CONNECT allowed", "host", host)
 			return mitmConnect, host
 		},
 	)
 
 	proxy.OnRequest().DoFunc(
 		func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-			hostname := stripPort(req.URL.Host)
-			route := cfg.MatchRoute(hostname)
+			route := cfg.MatchRoute(req.URL.Host)
 			if route == nil {
-				logger.Warn("blocked request to unknown domain", "host", hostname)
+				logger.Warn("blocked request to unknown domain", "host", req.URL.Host)
 				return req, goproxy.NewResponse(
 					req, goproxy.ContentTypeText, http.StatusForbidden,
 					`{"error":"domain not allowed"}`,
@@ -254,6 +254,35 @@ func (s *Server) serveGateway(w http.ResponseWriter, r *http.Request, route *Rou
 	gw.ServeHTTP(w, r)
 }
 
+// buildRootCAPool creates an x509.CertPool containing the system CAs plus any
+// route-specific CAs (e.g., Kubernetes API server CAs from kubeconfig). This
+// allows the proxy to verify upstream TLS for servers with non-public CAs.
+func buildRootCAPool(cfg *Config, logger *slog.Logger) *x509.CertPool {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		logger.Warn("failed to load system cert pool, using empty pool", "error", err)
+		pool = x509.NewCertPool()
+	}
+
+	for i := range cfg.Routes {
+		if cfg.Routes[i].CACert == "" {
+			continue
+		}
+		pemBytes, err := base64.StdEncoding.DecodeString(cfg.Routes[i].CACert)
+		if err != nil {
+			logger.Error("failed to base64-decode route CA cert", "domain", cfg.Routes[i].Domain, "error", err)
+			continue
+		}
+		if pool.AppendCertsFromPEM(pemBytes) {
+			logger.Info("loaded route CA cert", "domain", cfg.Routes[i].Domain)
+		} else {
+			logger.Error("failed to parse route CA cert PEM", "domain", cfg.Routes[i].Domain)
+		}
+	}
+
+	return pool
+}
+
 func parseCA(certPEM, keyPEM []byte) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	certBlock, _ := pem.Decode(certPEM)
 	if certBlock == nil {
@@ -291,12 +320,4 @@ func parseCA(certPEM, keyPEM []byte) (*x509.Certificate, *ecdsa.PrivateKey, erro
 	}
 
 	return cert, key, nil
-}
-
-func stripPort(hostPort string) string {
-	host, _, err := net.SplitHostPort(hostPort)
-	if err != nil {
-		return strings.ToLower(hostPort)
-	}
-	return strings.ToLower(host)
 }

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -147,6 +148,55 @@ func TestNewServer(t *testing.T) {
 		srv, err := NewServer(cfg, certPEM, keyPEM, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, srv.proxy)
+	})
+}
+
+func TestBuildRootCAPool(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("should include system CAs by default", func(t *testing.T) {
+		cfg := &Config{Routes: []Route{}}
+		pool := buildRootCAPool(cfg, logger)
+		require.NotNil(t, pool)
+	})
+
+	t.Run("should add route CA certs to pool", func(t *testing.T) {
+		caPEM, _ := generateTestCA(t)
+		encoded := base64.StdEncoding.EncodeToString(caPEM)
+
+		cfg := &Config{
+			Routes: []Route{
+				{Domain: "api.example.com:6443", Injector: "none", CACert: encoded},
+			},
+		}
+		pool := buildRootCAPool(cfg, logger)
+		require.NotNil(t, pool)
+
+		certPEM, keyPEM := generateTestCA(t)
+		srv, err := NewServer(cfg, certPEM, keyPEM, logger)
+		require.NoError(t, err)
+		require.NotNil(t, srv)
+	})
+
+	t.Run("should skip invalid base64 without crashing", func(t *testing.T) {
+		cfg := &Config{
+			Routes: []Route{
+				{Domain: "bad.example.com:6443", Injector: "kubernetes", CACert: "not-valid-base64!!!"},
+			},
+		}
+		pool := buildRootCAPool(cfg, logger)
+		require.NotNil(t, pool)
+	})
+
+	t.Run("should skip non-PEM content without crashing", func(t *testing.T) {
+		encoded := base64.StdEncoding.EncodeToString([]byte("not a PEM cert"))
+		cfg := &Config{
+			Routes: []Route{
+				{Domain: "bad.example.com:6443", Injector: "kubernetes", CACert: encoded},
+			},
+		}
+		pool := buildRootCAPool(cfg, logger)
+		require.NotNil(t, pool)
 	})
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,6 +41,10 @@ var (
 
 	// proxyImage is the credential proxy sidecar image, built and loaded alongside the operator.
 	proxyImage = "example.com/claw-proxy:latest"
+
+	// gatewayImage is the upstream OpenClaw image used by the claw deployment.
+	// Pre-loaded into Kind so e2e tests can verify init container patching.
+	gatewayImage = "ghcr.io/openclaw/openclaw:slim"
 )
 
 // TestMain runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -67,6 +71,11 @@ func TestMain(m *testing.M) {
 	}
 	if err := buildAndLoadImage("proxy", "container-build-proxy", "PROXY_IMG", proxyImage, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "proxy image setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := pullAndLoadImage(gatewayImage, kindCluster); err != nil {
+		fmt.Fprintf(os.Stderr, "gateway image setup failed: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -122,6 +131,27 @@ func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) er
 	if err := runStreaming("kind", "load", "image-archive", tarFile,
 		"--name", kindCluster); err != nil {
 		return fmt.Errorf("load %s image into Kind: %w", label, err)
+	}
+	return nil
+}
+
+// pullAndLoadImage pulls a public container image and loads it into Kind.
+func pullAndLoadImage(image, kindCluster string) error {
+	tarFile := fmt.Sprintf("tmp/%s.tar", strings.ReplaceAll(
+		strings.ReplaceAll(image, "/", "_"), ":", "_"))
+
+	fmt.Printf("Pulling gateway image %s...\n", image)
+	if err := runStreaming("podman", "pull", "--platform=linux/amd64", image); err != nil {
+		return fmt.Errorf("pull %s: %w", image, err)
+	}
+
+	fmt.Printf("Loading gateway image into Kind cluster...\n")
+	if err := runStreaming("podman", "save", "-o", tarFile, image); err != nil {
+		return fmt.Errorf("save %s: %w", image, err)
+	}
+	if err := runStreaming("kind", "load", "image-archive", tarFile,
+		"--name", kindCluster); err != nil {
+		return fmt.Errorf("load %s into Kind: %w", image, err)
 	}
 	return nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -148,6 +148,7 @@ func pullAndLoadImage(image, kindCluster string) error {
 	}
 
 	fmt.Printf("Loading gateway image into Kind cluster...\n")
+	_ = runStreaming("rm", "-f", tarFile)
 	if err := runStreaming("podman", "save", "-o", tarFile, image); err != nil {
 		return fmt.Errorf("save %s: %w", image, err)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -140,8 +141,9 @@ func pullAndLoadImage(image, kindCluster string) error {
 	tarFile := fmt.Sprintf("tmp/%s.tar", strings.ReplaceAll(
 		strings.ReplaceAll(image, "/", "_"), ":", "_"))
 
-	fmt.Printf("Pulling gateway image %s...\n", image)
-	if err := runStreaming("podman", "pull", "--platform=linux/amd64", image); err != nil {
+	platform := fmt.Sprintf("linux/%s", runtime.GOARCH)
+	fmt.Printf("Pulling gateway image %s (%s)...\n", image, platform)
+	if err := runStreaming("podman", "pull", fmt.Sprintf("--platform=%s", platform), image); err != nil {
 		return fmt.Errorf("pull %s: %w", image, err)
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -777,9 +777,14 @@ users:
 
 			// 7. Create Secret with kubeconfig
 			t.Log("creating kubeconfig Secret")
-			kubeconfigFile := filepath.Join("/tmp", "e2e-kubeconfig.yaml")
-			err = os.WriteFile(kubeconfigFile, []byte(kubeconfigYAML), os.FileMode(0o644))
+			f, err := os.CreateTemp("", "e2e-kubeconfig-*.yaml")
 			require.NoError(t, err)
+			kubeconfigFile := f.Name()
+			t.Cleanup(func() { os.Remove(kubeconfigFile) })
+			_, err = f.Write([]byte(kubeconfigYAML))
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			require.NoError(t, os.Chmod(kubeconfigFile, 0o600))
 
 			cmd = exec.Command("kubectl", "delete", "secret", kubeSecretNm,
 				"-n", userNamespace, "--ignore-not-found")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -638,6 +638,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				_, _ = utils.Run(t, cmd)
 				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
 				_, _ = utils.Run(t, cmd)
+				waitForPVCDeletion(t, userNamespace)
 			})
 
 			t.Log("creating the credential Secret")
@@ -713,6 +714,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				_, _ = utils.Run(t, cmd)
 				cmd = exec.Command("kubectl", "delete", "ns", kubeWorkspace, "--ignore-not-found")
 				_, _ = utils.Run(t, cmd)
+				waitForPVCDeletion(t, userNamespace)
 			})
 
 			// 1. Create workspace namespace
@@ -829,18 +831,17 @@ spec:
 				})
 			require.NoError(t, err, "Claw ProxyConfigured did not become True")
 
-			// Wait for proxy pods to be running
-			t.Log("waiting for proxy pod to be running")
-			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+			// Wait for both deployments to be fully available (readiness probes passing)
+			t.Log("waiting for claw-proxy deployment to be available")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
 				func(ctx context.Context) (bool, error) {
-					cmd := exec.Command("kubectl", "get", "pods",
-						"-l", "app=claw-proxy",
-						"-o", "jsonpath={.items[0].status.phase}",
+					cmd := exec.Command("kubectl", "get", "deployment", "claw-proxy",
+						"-o", "jsonpath={.status.availableReplicas}",
 						"-n", userNamespace)
 					output, err := utils.Run(t, cmd)
-					return err == nil && output == podPhaseRunning, nil
+					return err == nil && output == "1", nil
 				})
-			require.NoError(t, err, "proxy pod did not reach Running phase")
+			require.NoError(t, err, "claw-proxy deployment did not become available")
 
 			// 10. Extract MITM CA cert from claw-proxy-ca Secret
 			t.Log("extracting MITM CA cert")
@@ -1032,4 +1033,16 @@ type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`
 	} `json:"status"`
+}
+
+func waitForPVCDeletion(t *testing.T, namespace string) {
+	t.Helper()
+	ctx := context.Background()
+	_ = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			cmd := exec.Command("kubectl", "get", "pvc", "claw-home-pvc",
+				"-n", namespace, "--no-headers")
+			_, err := utils.Run(t, cmd)
+			return err != nil, nil
+		})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,7 +46,9 @@ const (
 	pollInterval    = 1 * time.Second
 	extendedTimeout = 5 * time.Minute
 
-	podPhaseRunning = "Running"
+	podPhaseRunning   = "Running"
+	podPhaseSucceeded = "Succeeded"
+	conditionTrue     = "True"
 )
 
 // clawYAMLWithGemini returns a Claw CR YAML using spec.credentials[] with apiKey type.
@@ -306,7 +308,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 					"-o", "jsonpath={.status.phase}",
 					"-n", operatorNamespace)
 				output, err := utils.Run(t, cmd)
-				if err == nil && output == "Succeeded" {
+				if err == nil && output == podPhaseSucceeded {
 					break
 				}
 				time.Sleep(pollInterval)
@@ -352,7 +354,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
 						"-n", userNamespace)
 					output, err := utils.Run(t, cmd)
-					return err == nil && output == "True", nil
+					return err == nil && output == conditionTrue, nil
 				})
 			require.NoError(t, err, "Claw ProxyConfigured did not become True within %v", defaultTimeout)
 
@@ -411,7 +413,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				"-n", userNamespace)
 			condOutput, err := utils.Run(t, cmd)
 			require.NoError(t, err)
-			assert.Equal(t, "True", condOutput, "CredentialsResolved should be True")
+			assert.Equal(t, conditionTrue, condOutput, "CredentialsResolved should be True")
 
 			t.Log("verifying ProxyConfigured condition")
 			cmd = exec.Command("kubectl", "get", "claw", "instance",
@@ -419,7 +421,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				"-n", userNamespace)
 			condOutput, err = utils.Run(t, cmd)
 			require.NoError(t, err)
-			assert.Equal(t, "True", condOutput, "ProxyConfigured should be True")
+			assert.Equal(t, conditionTrue, condOutput, "ProxyConfigured should be True")
 
 			t.Log("verifying reconciliation success in metrics")
 			metricsOutput := fetchFreshMetrics(t, "curl-metrics-reconcile")
@@ -542,7 +544,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
 						"-n", userNamespace)
 					output, err := utils.Run(t, cmd)
-					return err == nil && output == "True", nil
+					return err == nil && output == conditionTrue, nil
 				})
 			require.NoError(t, err, "Claw ProxyConfigured did not become True within %v", defaultTimeout)
 
@@ -627,6 +629,228 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 					return err == nil && output == podPhaseRunning, nil
 				})
 			require.NoError(t, err, "new pod did not reach Running phase")
+		})
+
+		t.Run("should proxy kubectl requests with kubernetes credential type", func(t *testing.T) {
+			const (
+				kubeWorkspace = "e2e-kube-workspace"
+				kubeSAName    = "claw-e2e-sa"
+				kubeSecretNm  = "e2e-kubeconfig"
+				curlPodName   = "curl-kube-proxy"
+			)
+
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", kubeSecretNm, "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "pod", curlPodName, "-n", userNamespace, "--ignore-not-found")
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "ns", kubeWorkspace, "--ignore-not-found")
+				_, _ = utils.Run(t, cmd)
+			})
+
+			// 1. Create workspace namespace
+			t.Log("creating workspace namespace")
+			cmd := exec.Command("kubectl", "create", "ns", kubeWorkspace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create workspace namespace")
+
+			// 2. Create ServiceAccount in workspace
+			t.Log("creating ServiceAccount in workspace")
+			cmd = exec.Command("kubectl", "create", "sa", kubeSAName, "-n", kubeWorkspace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create ServiceAccount")
+
+			// 3. Grant edit role
+			t.Log("granting edit role to ServiceAccount")
+			cmd = exec.Command("kubectl", "create", "rolebinding", "claw-e2e-edit",
+				"--clusterrole=edit",
+				fmt.Sprintf("--serviceaccount=%s:%s", kubeWorkspace, kubeSAName),
+				"-n", kubeWorkspace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create RoleBinding")
+
+			// 4. Get SA token
+			t.Log("requesting token for ServiceAccount")
+			cmd = exec.Command("kubectl", "create", "token", kubeSAName,
+				"-n", kubeWorkspace, "--duration=1h")
+			saToken, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create token")
+			saToken = strings.TrimSpace(saToken)
+			require.NotEmpty(t, saToken)
+
+			// 5. Get cluster CA from host kubeconfig (--minify to get current context only)
+			t.Log("extracting cluster CA from kubeconfig")
+			cmd = exec.Command("kubectl", "config", "view", "--raw", "--minify",
+				"-o", "jsonpath={.clusters[0].cluster.certificate-authority-data}")
+			clusterCAB64, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to get cluster CA")
+			clusterCAB64 = strings.TrimSpace(clusterCAB64)
+			require.NotEmpty(t, clusterCAB64, "cluster CA should not be empty")
+
+			// 6. Build kubeconfig YAML
+			kubeconfigYAML := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+  - name: kind-cluster
+    cluster:
+      server: https://kubernetes.default.svc
+      certificate-authority-data: %s
+contexts:
+  - name: workspace
+    context:
+      cluster: kind-cluster
+      user: claw-sa
+      namespace: %s
+current-context: workspace
+users:
+  - name: claw-sa
+    user:
+      token: %s
+`, clusterCAB64, kubeWorkspace, saToken)
+
+			// 7. Create Secret with kubeconfig
+			t.Log("creating kubeconfig Secret")
+			kubeconfigFile := filepath.Join("/tmp", "e2e-kubeconfig.yaml")
+			err = os.WriteFile(kubeconfigFile, []byte(kubeconfigYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "delete", "secret", kubeSecretNm,
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", kubeSecretNm,
+				fmt.Sprintf("--from-file=kubeconfig=%s", kubeconfigFile),
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create kubeconfig Secret")
+
+			// 8. Apply Claw CR with kubernetes credential
+			t.Log("applying Claw CR with kubernetes credential")
+			clawYAML := fmt.Sprintf(`apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: k8s-test
+      type: kubernetes
+      secretRef:
+        name: %s
+        key: kubeconfig
+`, kubeSecretNm)
+			crFile := filepath.Join("/tmp", "claw-e2e-kube.yaml")
+			err = os.WriteFile(crFile, []byte(clawYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "failed to apply Claw CR")
+
+			// 9. Wait for ProxyConfigured=True
+			t.Log("waiting for Claw ProxyConfigured condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw ProxyConfigured did not become True")
+
+			// Wait for proxy pods to be running
+			t.Log("waiting for proxy pod to be running")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods",
+						"-l", "app=claw-proxy",
+						"-o", "jsonpath={.items[0].status.phase}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == podPhaseRunning, nil
+				})
+			require.NoError(t, err, "proxy pod did not reach Running phase")
+
+			// 10. Extract MITM CA cert from claw-proxy-ca Secret
+			t.Log("extracting MITM CA cert")
+			var mitmCAB64 string
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "secret", "claw-proxy-ca",
+						"-o", "jsonpath={.data.ca\\.crt}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					if err == nil && output != "" {
+						mitmCAB64 = strings.TrimSpace(output)
+						return true, nil
+					}
+					return false, nil
+				})
+			require.NoError(t, err, "failed to get MITM CA cert")
+			require.NotEmpty(t, mitmCAB64)
+
+			// 11. Run curl pod through proxy to hit the Kubernetes API
+			t.Log("running curl pod through proxy to access Kubernetes API")
+			cmd = exec.Command("kubectl", "delete", "pod", curlPodName,
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+
+			curlScript := fmt.Sprintf(
+				"echo '%s' | base64 -d > /tmp/mitm-ca.crt && "+
+					"curl -s -o /tmp/response.json -w '%%{http_code}' "+
+					"--proxy http://claw-proxy.%s.svc.cluster.local:8080 "+
+					"--cacert /tmp/mitm-ca.crt "+
+					"https://kubernetes.default.svc/api/v1/namespaces/%s/configmaps && "+
+					"echo && cat /tmp/response.json",
+				mitmCAB64, userNamespace, kubeWorkspace)
+
+			cmd = exec.Command("kubectl", "run", curlPodName, "--restart=Never",
+				"--namespace", userNamespace,
+				"--image=curlimages/curl:latest",
+				"--overrides", fmt.Sprintf(`{
+					"spec": {
+						"containers": [{
+							"name": "curl",
+							"image": "curlimages/curl:latest",
+							"command": ["/bin/sh", "-c"],
+							"args": [%q],
+							"securityContext": {
+								"allowPrivilegeEscalation": false,
+								"capabilities": {"drop": ["ALL"]},
+								"runAsNonRoot": true,
+								"runAsUser": 1000,
+								"seccompProfile": {"type": "RuntimeDefault"}
+							}
+						}]
+					}
+				}`, curlScript))
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "failed to create curl pod")
+
+			// 12. Wait for curl pod to complete and check results
+			t.Log("waiting for curl pod to complete")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods", curlPodName,
+						"-o", "jsonpath={.status.phase}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && (output == podPhaseSucceeded || output == "Failed"), nil
+				})
+			require.NoError(t, err, "curl pod did not complete")
+
+			t.Log("checking curl pod logs")
+			cmd = exec.Command("kubectl", "logs", curlPodName, "-n", userNamespace)
+			curlOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to get curl pod logs")
+			t.Logf("curl output:\n%s", curlOutput)
+
+			assert.Contains(t, curlOutput, "200",
+				"curl through proxy to Kubernetes API should return 200")
+			assert.Contains(t, curlOutput, "ConfigMapList",
+				"response should contain ConfigMapList kind")
 		})
 	})
 }
@@ -724,7 +948,7 @@ func fetchFreshMetrics(t *testing.T, podName string) string {
 				"-o", "jsonpath={.status.phase}",
 				"-n", operatorNamespace)
 			output, err := utils.Run(t, cmd)
-			return err == nil && output == "Succeeded", nil
+			return err == nil && output == podPhaseSucceeded, nil
 		})
 	require.NoError(t, err, "pod %s did not reach Succeeded phase within %v", podName, defaultTimeout)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -631,6 +631,70 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "new pod did not reach Running phase")
 		})
 
+		t.Run("should patch SSRF guard in claw gateway init container", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create Secret")
+
+			t.Log("applying the Claw CR")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				"config/samples/claw_v1alpha1_claw.yaml", "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for claw pod to reach Running")
+			ctx := context.Background()
+			var podName string
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw",
+						"-o", "go-template={{ range .items }}"+
+							"{{ if not .metadata.deletionTimestamp }}"+
+							"{{ .metadata.name }} {{ .status.phase }}"+
+							"{{ \"\\n\" }}{{ end }}{{ end }}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					if err != nil {
+						return false, nil
+					}
+					for _, line := range utils.GetNonEmptyLines(output) {
+						parts := strings.Fields(line)
+						if len(parts) == 2 && parts[1] == podPhaseRunning {
+							podName = parts[0]
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			require.NoError(t, err, "claw pod did not reach Running — init containers may have failed")
+
+			t.Log("verifying patch-proxy init container logs")
+			cmd = exec.Command("kubectl", "logs", podName, "-c", "patch-proxy",
+				"-n", userNamespace)
+			logOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to get patch-proxy logs")
+			t.Logf("patch-proxy logs:\n%s", logOutput)
+
+			assert.Contains(t, logOutput, "[proxy-patch] Patched SSRF guard:",
+				"init container should report patching at least one file")
+			assert.NotContains(t, logOutput, "ERROR",
+				"init container should not report errors")
+		})
+
 		t.Run("should proxy kubectl requests with kubernetes credential type", func(t *testing.T) {
 			const (
 				kubeWorkspace = "e2e-kube-workspace"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -780,7 +780,7 @@ users:
 			f, err := os.CreateTemp("", "e2e-kubeconfig-*.yaml")
 			require.NoError(t, err)
 			kubeconfigFile := f.Name()
-			t.Cleanup(func() { os.Remove(kubeconfigFile) })
+			t.Cleanup(func() { _ = os.Remove(kubeconfigFile) })
 			_, err = f.Write([]byte(kubeconfigYAML))
 			require.NoError(t, err)
 			require.NoError(t, f.Close())


### PR DESCRIPTION
- Add `kubernetes` credential type to Claw CRD with kubeconfig-based auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes credential type: token-only kubeconfigs are sanitized, stored, mounted into gateway/proxy, used to inject Bearer tokens, and per-cluster CA data is trusted by the proxy. Proxy routes become port-aware and include CA data; NetworkPolicy egress ports and AGENTS.md are updated automatically.

* **Documentation**
  * Added Kubernetes API Access design and setup docs with usage, constraints, and examples.

* **Tests**
  * Expanded unit and e2e coverage for kubeconfig parsing/sanitization, injection, routing, NetworkPolicy, proxy TLS trust, and reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->