### PR TITLE
feat: preserve user config across reconciles via $include layering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
   - `gcp` (GCPConfig, optional): Required when type is `gcp`. Fields: `project` (GCP project ID, minLength=1), `location` (GCP region, minLength=1)
   - `pathToken` (PathTokenConfig, optional): Required when type is `pathToken`. Fields: `prefix` (URL path prefix, minLength=1)
   - `oauth2` (OAuth2Config, optional): Required when type is `oauth2`. Fields: `clientID` (minLength=1), `tokenURL` (minLength=1), `scopes` ([]string, optional)
-  - `provider` (string, optional): Maps this credential to an OpenClaw LLM provider (e.g., "google", "anthropic", "openai", "openrouter"). When set, the controller configures gateway routing and dynamically generates the provider entry in `openclaw.json`. When omitted, the credential is used for MITM forward proxy only. For `provider: "google"` with `type: apiKey`, the controller uses the Gemini REST API upstream (`generativelanguage.googleapis.com/v1beta`). For `provider: "google"` with `type: gcp`, it uses Vertex AI upstream (`{location}-aiplatform.googleapis.com`).
+  - `provider` (string, optional): Maps this credential to an OpenClaw LLM provider (e.g., "google", "anthropic", "openai", "openrouter"). When set, the controller configures gateway routing and dynamically generates the provider entry in `operator.json` (included by the user-owned `openclaw.json` via `$include`). When omitted, the credential is used for MITM forward proxy only. For `provider: "google"` with `type: apiKey`, the controller uses the Gemini REST API upstream (`generativelanguage.googleapis.com/v1beta`). For `provider: "google"` with `type: gcp`, it uses Vertex AI upstream (`{location}-aiplatform.googleapis.com`).
 
 **Status Fields:**
 - `gatewayTokenSecretRef` (string, optional): Name of the Secret containing the gateway authentication token (`claw-gateway-token`)
@@ -136,6 +136,20 @@ The operator uses a **single unified controller** that manages all resources usi
 - Graceful fallback: localhost CORS origin on vanilla Kubernetes (no Route CRD)
 - Future-proof: adding new resources only requires updating kustomization.yaml
 
+### Config layering via $include
+
+The `claw-config` ConfigMap uses a **split config** approach to preserve user and application changes across reconciles:
+
+**Operator-managed files** (always overwritten on PVC by init container):
+- `operator.json` — Gateway settings, CORS origins, providers, proxy config. Rewritten every reconcile.
+- `KUBERNETES.md` — Kubernetes context info (only when k8s credentials present). Always overwritten.
+
+**User-owned files** (seeded once, then owned by user/OpenClaw):
+- `openclaw.json` — Contains `"$include": "./operator.json"` plus agent defaults (model aliases, primary model, agent list). Seeded only if file doesn't exist on PVC. User and OpenClaw Control UI changes survive pod restarts.
+- `AGENTS.md` — System prompt. Seeded only if file doesn't exist on PVC.
+
+OpenClaw's `$include` mechanism deep-merges the included file with sibling keys at config load time. Sibling keys (user's root file) win over included values for primitives, objects merge recursively, arrays concatenate. The write-back logic avoids pulling included values into the root file on save.
+
 ### Reconciliation flow
 
 The controller uses a **three-phase reconciliation** approach to enable dynamic Route host injection into ConfigMap:
@@ -226,7 +240,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
   ↓
 7. injectRouteHostIntoConfigMap(objects, routeHost)
    ├─ Find claw-config ConfigMap in objects
-   ├─ Extract data["openclaw.json"] string
+   ├─ Extract data["operator.json"] string
    ├─ Replace "OPENCLAW_ROUTE_HOST" placeholder with routeHost (https://...)
    ├─ If routeHost is empty (vanilla Kubernetes): use "http://localhost:18789" fallback
    └─ Set modified JSON back into ConfigMap
@@ -235,13 +249,12 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    ├─ Filter credentials with Provider set
    ├─ For gateway-routed providers: resolveProviderInfo(cred) → upstream + basePath, build baseUrl via proxy
    ├─ For Vertex SDK providers (GCP + non-Google, e.g., anthropic): map to "{provider}-vertex" key with real Vertex AI URL, api mapping, and "gcp-vertex-credentials" apiKey
-   ├─ remapVertexProviderModels: rename "anthropic/..." model entries to "anthropic-vertex/..." when vertex variant exists but base provider does not
-   ├─ filterAgentDefaultsForProviders: remove model entries whose provider is not in the injected providers map
+   ├─ Write providers into data["operator.json"] (agent defaults are user-owned in openclaw.json seed)
    └─ Credentials without Provider are MITM-only (no provider entry)
   ↓
-7c. injectKubernetesIntoAgentsMd(objects, resolvedCreds)
+7c. injectKubernetesContextFile(objects, resolvedCreds)
    ├─ Collect contexts from all kubernetes credentials
-   ├─ Append "## Kubernetes Access" section to AGENTS.md in claw-config ConfigMap
+   ├─ Write data["KUBERNETES.md"] in claw-config ConfigMap (separate from user-owned AGENTS.md)
    └─ No-op when no kubernetes credentials present
   ↓
 7d. injectKubePortsIntoNetworkPolicy(objects, resolvedCreds)
@@ -286,10 +299,9 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `applyRouteOnly()` — applies only Route resource from Kustomize manifests (Phase 2)
 - `getRouteURL()` — fetches Route and extracts `.status.ingress[0].host`, returns empty string if status not populated
 - `buildKustomizedObjects()` — builds Kustomize manifests, configures proxy deployment, stamps Secret version, returns parsed objects
-- `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in ConfigMap with Route host (or localhost fallback)
-- `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `openclaw.json`. Gateway-routed providers get a baseUrl through the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since MITM proxy handles credential injection transparently
-- `remapVertexProviderModels()` — renames model entries from "provider/model" to "provider-vertex/model" when a Vertex variant exists but the base provider does not (e.g., "anthropic/claude-sonnet-4-6" → "anthropic-vertex/claude-sonnet-4-6")
-- `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA. Extracted from `Reconcile()` to reduce cyclomatic complexity
+- `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in `operator.json` with Route host (or localhost fallback)
+- `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `operator.json`. Gateway-routed providers get a baseUrl through the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since MITM proxy handles credential injection transparently. Does not touch agent defaults (user-owned in openclaw.json seed)
+- `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA
 - `resolveCredentials()` — validates all credentials and referenced Secrets. For `kubernetes` type, parses kubeconfig with `client-go/tools/clientcmd`, validates token-only auth, extracts cluster/context metadata. Returns `[]resolvedCredential` (replaces former `validateCredentials`)
 - `parseAndValidateKubeconfig()` — parses kubeconfig bytes, validates all users use token-based auth (rejects client certs, exec, auth provider), validates unique token per server `hostname:port`, returns `kubeconfigData`
 - `sanitizeKubeconfig()` — replaces all user tokens with `"proxy-managed-token"` placeholder, clears `TokenFile` fields, preserves clusters/contexts/namespaces/CA data
@@ -301,7 +313,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `configureClawDeploymentForVertex()` — adds GOOGLE_APPLICATION_CREDENTIALS, ANTHROPIC_VERTEX_PROJECT_ID env vars and stub ADC volume mount to the claw deployment when Vertex SDK credentials exist
 - `configureClawDeploymentForKubernetes()` — when kubernetes credentials exist: mounts the sanitized kubeconfig ConfigMap (`claw-kube-config`) at `/etc/kube/`, sets `KUBECONFIG=/etc/kube/config` and `PATH` env vars, adds an `init-kubectl` init container that copies kubectl from the configured image into a shared emptyDir volume mounted at `/opt/kube-tools`
 - `injectKubePortsIntoNetworkPolicy()` — adds non-443 ports from kubeconfig cluster server URLs to the `claw-proxy-egress` NetworkPolicy. In-memory patching before apply, same pattern as `injectRouteHostIntoConfigMap`
-- `injectKubernetesIntoAgentsMd()` — appends a "Kubernetes Access" section to the AGENTS.md content in `claw-config` ConfigMap listing available contexts, clusters, namespaces, and current-context
+- `injectKubernetesContextFile()` — writes a `KUBERNETES.md` key into the `claw-config` ConfigMap (separate from user-owned AGENTS.md) listing available contexts, clusters, namespaces, and current-context
 - `applyVertexADCConfigMap()` — creates/updates the stub ADC ConfigMap (claw-vertex-adc) with dummy authorized_user credentials for Vertex SDK token refresh bootstrap. Only created when Vertex SDK credentials exist
 - `applyProxyResources()` — generates proxy config, applies proxy ConfigMap and Vertex ADC ConfigMap. Returns proxy config JSON for hash stamping
 - `applyResources()` — applies list of unstructured objects using server-side apply
@@ -347,7 +359,7 @@ var ManifestsFS embed.FS
 
 The `internal/assets/manifests/` directory contains:
 - **kustomization.yaml** — defines labels and resource list
-- **configmap.yaml** — OpenClaw configuration
+- **configmap.yaml** — OpenClaw configuration (operator.json for operator-managed settings, openclaw.json as user-owned seed with `$include`, AGENTS.md seed, KUBERNETES.md for k8s context)
 - **pvc.yaml** — persistent storage (10Gi ReadWriteOnce)
 - **deployment.yaml** — OpenClaw application pods (init container with full security context hardening)
 - **service.yaml** — ClusterIP service exposing OpenClaw gateway (port 18789)

--- a/docs/adr/0002-config-preservation.md
+++ b/docs/adr/0002-config-preservation.md
@@ -1,0 +1,153 @@
+# ADR-0002: Config Preservation via $include Layering
+
+**Status:** Implemented
+
+**Date:** 2026-04-21
+
+---
+
+## Overview
+
+The Claw Operator manages a `claw-config` ConfigMap containing OpenClaw's configuration (`openclaw.json`), agent system prompt (`AGENTS.md`), and optionally Kubernetes context documentation (`KUBERNETES.md`). Prior to this change, every reconciliation rebuilt the entire ConfigMap from an embedded template and applied it via server-side apply, unconditionally overwriting all keys. This destroyed any changes made by the user through the Control UI or by the OpenClaw application itself (e.g., model preferences, agent definitions, system prompt edits).
+
+This ADR documents the decision to split configuration into operator-managed and user-owned layers using OpenClaw's native `$include` mechanism, combined with conditional seeding for workspace files.
+
+## Design Principles
+
+- **Operator owns infrastructure; users own application config** — gateway settings, CORS, proxy routing, and provider wiring are operator concerns. Model preferences, agent definitions, and system prompts are user concerns.
+- **Leverage upstream `$include`** — OpenClaw natively supports `$include` directives with `deepMerge` semantics. Using this avoids custom merge logic entirely.
+- **Seed-once for user files; always-overwrite for operator files** — user-owned files are copied to the PVC only if they don't already exist. Operator-owned files are overwritten every pod start.
+- **No runtime merge scripts** — the init container uses simple shell conditionals (`[ -f ... ] || cp`), not JSON merge tools or Node.js scripts.
+
+---
+
+## Decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| Q1 | Config separation strategy | Split into `operator.json` (operator-managed) and `openclaw.json` (user-owned with `$include`) | OpenClaw's `$include` + `deepMerge` handles composition natively. Write-back logic preserves `$include` directives (doesn't flatten). Rejected: custom JSON merge in init container (fragile, upstream `mergeMode: merge` requires Node.js), split ConfigMaps (OpenClaw expects a single config file), SSA partial ownership (can't own fields inside a JSON string value) |
+| Q2 | Where agent defaults live | User-owned `openclaw.json` seed | Model aliases, primary model, agent list, and workspace paths are user preferences. The operator should not overwrite these on every reconcile. The seed provides sensible defaults that users can customize freely |
+| Q3 | `AGENTS.md` handling | Conditional seed (copy only if missing on PVC) | Users and the OpenClaw application modify the system prompt at runtime. The operator provides initial content but must not clobber edits. Rejected: always-overwrite (destroys user edits), append-only (accumulates duplicates across reconciliations) |
+| Q4 | Kubernetes context delivery | Separate `KUBERNETES.md` file, always overwritten | Kubernetes context info (clusters, contexts, namespaces) is derived from the CR's credentials and must stay in sync. A separate file avoids conflicting with user edits to `AGENTS.md`. Always-overwritten because the content is purely operator-derived |
+| Q5 | Model remapping and filtering removal | Removed `remapVertexProviderModels` and `filterAgentDefaultsForProviders` | These functions modified the `agents.defaults` section (model aliases, primary model) which is now user-owned in `openclaw.json`. The operator no longer has access to or responsibility for this section. Users control their own model preferences via the seed or Control UI |
+| Q6 | Init container seeding logic | Shell conditionals in busybox, no merge tools | `[ -f target ] || cp source target` is the simplest correct approach. No dependencies beyond a POSIX shell. The upstream community operator's `mergeMode: merge` uses a Node.js script — unnecessary complexity when `$include` handles composition at the application layer |
+
+---
+
+## Architecture
+
+### File Ownership Model
+
+```
+claw-config ConfigMap (rebuilt every reconcile via SSA)
+├── operator.json          ← operator-managed: gateway, providers, CORS, cron
+├── openclaw.json          ← seed: user-owned config with $include directive
+├── AGENTS.md              ← seed: initial system prompt
+└── KUBERNETES.md          ← operator-managed (only when kubernetes credentials exist)
+```
+
+```
+claw-home-pvc (persistent across pod restarts)
+├── operator.json          ← always overwritten from ConfigMap
+├── openclaw.json          ← seeded once, then user-owned
+└── workspace/
+    ├── AGENTS.md           ← seeded once, then user-owned
+    └── KUBERNETES.md       ← always overwritten from ConfigMap (when present)
+```
+
+### Config Composition via $include
+
+OpenClaw loads `openclaw.json` at startup. The `$include` directive pulls in `operator.json` and merges using `deepMerge`:
+
+```
+openclaw.json (user-owned)          operator.json (operator-managed)
+┌──────────────────────────┐         ┌──────────────────────────────┐
+│ "$include": "./operator" │────────▶│ gateway: { mode, bind, ... } │
+│ agents:                  │         │ models.providers: { ... }    │
+│   defaults:              │         │ cron: { enabled: false }     │
+│     model: { primary }   │         └──────────────────────────────┘
+│     models: { aliases }  │
+│   list: [ ... ]          │              deepMerge semantics:
+└──────────────────────────┘              - objects merge recursively
+                                         - arrays concatenate
+         Result: merged config           - sibling keys (openclaw.json)
+         with both operator                win for primitive conflicts
+         and user settings
+```
+
+The operator dynamically injects values into `operator.json` before it reaches the ConfigMap:
+
+1. **Route host** — `OPENCLAW_ROUTE_HOST` placeholder replaced with the actual Route URL (or `http://localhost:18789` on vanilla Kubernetes)
+2. **Providers** — `models.providers` populated from `spec.credentials[]` entries that have `provider` set
+
+### Init Container Behavior
+
+The `init-config` container runs on every pod start and implements the two-tier copy strategy:
+
+```sh
+# Always overwrite operator-managed files
+cp /config/operator.json /home/node/.openclaw/operator.json
+
+# Seed user-owned files only if missing
+mkdir -p /home/node/.openclaw/workspace
+[ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+[ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+
+# Conditionally copy operator-managed workspace files
+if [ -f /config/KUBERNETES.md ]; then
+  cp /config/KUBERNETES.md /home/node/.openclaw/workspace/KUBERNETES.md
+fi
+```
+
+### Reconciliation Flow (Config-Related Steps)
+
+```
+Reconcile
+ ↓
+buildKustomizedObjects()
+ ├─ Kustomize builds all manifests (ConfigMap contains operator.json, openclaw.json seed, AGENTS.md seed)
+ ↓
+injectRouteHostIntoConfigMap(objects, routeHost)
+ ├─ Replaces OPENCLAW_ROUTE_HOST in operator.json with actual Route URL
+ ↓
+injectProvidersIntoConfigMap(objects, credentials)
+ ├─ Populates models.providers in operator.json from spec.credentials[]
+ ├─ Only credentials with provider set generate entries
+ ├─ Does NOT touch agents.defaults (lives in user-owned openclaw.json)
+ ↓
+injectKubernetesContextFile(objects, resolvedCreds)
+ ├─ Adds KUBERNETES.md key to ConfigMap (if kubernetes credentials exist)
+ ├─ No-op when no kubernetes credentials
+ ↓
+applyResources()
+ ├─ Server-side apply ConfigMap (and all other resources)
+ ↓
+Pod starts → init-config runs → files land on PVC → OpenClaw loads openclaw.json with $include
+```
+
+### Alternatives Considered
+
+**Upstream `mergeMode: merge`** — The community `openclaw-operator` implements a Node.js-based merge script that runs in the init container and performs structural JSON merging of `openclaw.json`. While functional, this adds a runtime dependency on Node.js in the init container and custom merge logic that must be maintained separately from OpenClaw's own config loading. The `$include` approach delegates composition entirely to OpenClaw.
+
+**Server-Side Apply partial ownership** — SSA tracks field ownership at the Kubernetes API level, but a ConfigMap `data` key containing a JSON string is a single atomic field. SSA cannot own individual JSON keys within that string. Two controllers writing to the same `data["openclaw.json"]` key would conflict.
+
+**Annotation-based merge hints** — Embedding merge directives in ConfigMap annotations (e.g., `claw.sandbox.redhat.com/merge-strategy: deep`) would require custom merge logic in the controller and would not survive a `kubectl apply` from a GitOps tool.
+
+**Split ConfigMaps** — Using separate ConfigMaps for operator and user config would require changes to how OpenClaw discovers its configuration file, as it expects a single `openclaw.json` path.
+
+---
+
+## Future Considerations
+
+- **User reset mechanism** — Users who want to restore the default `openclaw.json` or `AGENTS.md` seed can delete the file from the PVC; the next pod restart will re-seed it from the ConfigMap.
+- **Config schema evolution** — If `operator.json` gains new top-level keys, `deepMerge` adds them transparently. If keys are removed, stale copies on the PVC will contain unused fields that OpenClaw ignores.
+- **Conflict on `$include` removal** — If a user removes the `$include` directive from their `openclaw.json`, they lose operator-managed settings (gateway, providers). This is by design: the user has full ownership of their config file. Re-seeding (delete + restart) restores the `$include`.
+
+---
+
+## Out of Scope
+
+- **Runtime conflict detection** — No optimistic concurrency or `baseHash` checking for user edits vs operator updates. The file ownership boundary (`operator.json` vs `openclaw.json`) eliminates the conflict surface.
+- **Custom merge scripts in init containers** — Explicitly rejected in favor of `$include`.
+- **Multi-instance config inheritance** — Only one Claw instance (`"instance"`) is supported per namespace.
+- **Bidirectional sync** — The operator does not read back user changes from the PVC. Config flows one direction: operator → ConfigMap → PVC → OpenClaw.

--- a/internal/assets/manifests/configmap.yaml
+++ b/internal/assets/manifests/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: claw
 data:
-  openclaw.json: |
+  operator.json: |
     {
       "gateway": {
         "mode": "local",
@@ -23,6 +23,11 @@ data:
       "models": {
         "providers": {}
       },
+      "cron": { "enabled": false }
+    }
+  openclaw.json: |
+    {
+      "$include": "./operator.json",
       "agents": {
         "defaults": {
           "model": { "primary": "google/gemini-3-flash-preview" },
@@ -41,8 +46,7 @@ data:
             "workspace": "~/.openclaw/workspace"
           }
         ]
-      },
-      "cron": { "enabled": false }
+      }
     }
   AGENTS.md: |
     # OpenClaw Assistant

--- a/internal/assets/manifests/deployment.yaml
+++ b/internal/assets/manifests/deployment.yaml
@@ -72,9 +72,13 @@ spec:
             - sh
             - -c
             - |
-              cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+              cp /config/operator.json /home/node/.openclaw/operator.json
               mkdir -p /home/node/.openclaw/workspace
-              cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+              [ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+              [ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+              if [ -f /config/KUBERNETES.md ]; then
+                cp /config/KUBERNETES.md /home/node/.openclaw/workspace/KUBERNETES.md
+              fi
           resources:
             requests:
               memory: 32Mi

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -165,14 +165,14 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(ClawConfigMapName)
 		cm.Object["data"] = map[string]any{
-			"openclaw.json": jsonContent,
+			"operator.json": jsonContent,
 		}
 		return []*unstructured.Unstructured{cm}
 	}
 
 	getConfig := func(t *testing.T, objects []*unstructured.Unstructured) map[string]any {
 		t.Helper()
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "openclaw.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
@@ -212,102 +212,6 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		assert.Equal(t, "https://us-east5-aiplatform.googleapis.com", av["baseUrl"])
 		assert.Equal(t, "gcp-vertex-credentials", av["apiKey"])
 		assert.Equal(t, "anthropic-messages", av["api"])
-	})
-
-	t.Run("should remap model entries from anthropic to anthropic-vertex", func(t *testing.T) {
-		configJSON := `{
-			"models": {"providers": {}},
-			"agents": {
-				"defaults": {
-					"model": {"primary": "anthropic/claude-sonnet-4-6"},
-					"models": {
-						"anthropic/claude-sonnet-4-6": {"alias": "Claude Sonnet"},
-						"anthropic/claude-haiku-4-5": {"alias": "Claude Haiku"},
-						"google/gemini-flash": {"alias": "Gemini Flash"}
-					}
-				}
-			}
-		}`
-		objects := makeConfigMap(configJSON)
-		credentials := []clawv1alpha1.CredentialSpec{
-			{
-				Name:     "gemini",
-				Type:     clawv1alpha1.CredentialTypeAPIKey,
-				Provider: "google",
-				Domain:   "generativelanguage.googleapis.com",
-			},
-			{
-				Name:     "anthropic-vertex",
-				Type:     clawv1alpha1.CredentialTypeGCP,
-				Provider: "anthropic",
-				Domain:   ".googleapis.com",
-				GCP: &clawv1alpha1.GCPConfig{
-					Project:  "my-project",
-					Location: "us-east5",
-				},
-			},
-		}
-
-		require.NoError(t, injectProvidersIntoConfigMap(objects, credentials))
-
-		config := getConfig(t, objects)
-		agents := config["agents"].(map[string]any)
-		defaults := agents["defaults"].(map[string]any)
-		modelAliases := defaults["models"].(map[string]any)
-
-		assert.NotContains(t, modelAliases, "anthropic/claude-sonnet-4-6", "original anthropic key should be removed")
-		assert.NotContains(t, modelAliases, "anthropic/claude-haiku-4-5", "original anthropic key should be removed")
-		assert.Contains(t, modelAliases, "anthropic-vertex/claude-sonnet-4-6", "remapped key should exist")
-		assert.Contains(t, modelAliases, "anthropic-vertex/claude-haiku-4-5", "remapped key should exist")
-		assert.Contains(t, modelAliases, "google/gemini-flash", "google key should be preserved")
-
-		primary := defaults["model"].(map[string]any)
-		assert.Equal(t, "anthropic-vertex/claude-sonnet-4-6", primary["primary"], "primary should be remapped")
-	})
-
-	t.Run("should not remap when both base and vertex providers exist", func(t *testing.T) {
-		configJSON := `{
-			"models": {"providers": {}},
-			"agents": {
-				"defaults": {
-					"model": {"primary": "anthropic/direct-model"},
-					"models": {
-						"anthropic/direct-model": {"alias": "Direct"}
-					}
-				}
-			}
-		}`
-		objects := makeConfigMap(configJSON)
-		credentials := []clawv1alpha1.CredentialSpec{
-			{
-				Name:     "claude-direct",
-				Type:     clawv1alpha1.CredentialTypeBearer,
-				Provider: "anthropic",
-				Domain:   "api.anthropic.com",
-			},
-			{
-				Name:     "claude-vertex",
-				Type:     clawv1alpha1.CredentialTypeGCP,
-				Provider: "anthropic",
-				Domain:   ".googleapis.com",
-				GCP: &clawv1alpha1.GCPConfig{
-					Project:  "my-project",
-					Location: "us-east5",
-				},
-			},
-		}
-
-		require.NoError(t, injectProvidersIntoConfigMap(objects, credentials))
-
-		config := getConfig(t, objects)
-		agents := config["agents"].(map[string]any)
-		defaults := agents["defaults"].(map[string]any)
-		modelAliases := defaults["models"].(map[string]any)
-
-		assert.Contains(t, modelAliases, "anthropic/direct-model", "should keep base provider models when both exist")
-
-		primary := defaults["model"].(map[string]any)
-		assert.Equal(t, "anthropic/direct-model", primary["primary"], "primary should not be remapped")
 	})
 
 	t.Run("should reject duplicate vertex providers", func(t *testing.T) {

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -685,21 +684,19 @@ func TestInjectKubePortsIntoNetworkPolicy(t *testing.T) {
 	})
 }
 
-// --- injectKubernetesIntoAgentsMd tests ---
+// --- injectKubernetesContextFile tests ---
 
-func TestInjectKubernetesIntoAgentsMd(t *testing.T) {
-	makeCM := func(agentsMd string) []*unstructured.Unstructured {
+func TestInjectKubernetesContextFile(t *testing.T) {
+	makeCM := func() []*unstructured.Unstructured {
 		cm := &unstructured.Unstructured{}
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(ClawConfigMapName)
-		cm.Object["data"] = map[string]any{
-			"AGENTS.md": agentsMd,
-		}
+		cm.Object["data"] = map[string]any{}
 		return []*unstructured.Unstructured{cm}
 	}
 
-	t.Run("should append kubernetes section to AGENTS.md", func(t *testing.T) {
-		objects := makeCM("# Existing content\n")
+	t.Run("should write KUBERNETES.md key into ConfigMap", func(t *testing.T) {
+		objects := makeCM()
 		creds := []resolvedCredential{
 			{
 				CredentialSpec: clawv1alpha1.CredentialSpec{
@@ -715,18 +712,18 @@ func TestInjectKubernetesIntoAgentsMd(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, injectKubernetesIntoAgentsMd(objects, creds))
+		require.NoError(t, injectKubernetesContextFile(objects, creds))
 
-		agentsMd, _, _ := unstructured.NestedString(objects[0].Object, "data", "AGENTS.md")
-		assert.Contains(t, agentsMd, "# Existing content")
-		assert.Contains(t, agentsMd, "## Kubernetes Access")
-		assert.Contains(t, agentsMd, "`prod-ctx`")
-		assert.Contains(t, agentsMd, "[current]")
-		assert.Contains(t, agentsMd, "namespace: staging")
+		kubeMd, found, _ := unstructured.NestedString(objects[0].Object, "data", "KUBERNETES.md")
+		assert.True(t, found, "KUBERNETES.md should exist in ConfigMap data")
+		assert.Contains(t, kubeMd, "# Kubernetes Access")
+		assert.Contains(t, kubeMd, "`prod-ctx`")
+		assert.Contains(t, kubeMd, "[current]")
+		assert.Contains(t, kubeMd, "namespace: staging")
 	})
 
 	t.Run("should be no-op with no kubernetes credentials", func(t *testing.T) {
-		objects := makeCM("# Original\n")
+		objects := makeCM()
 		creds := []resolvedCredential{
 			{
 				CredentialSpec: clawv1alpha1.CredentialSpec{
@@ -736,10 +733,10 @@ func TestInjectKubernetesIntoAgentsMd(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, injectKubernetesIntoAgentsMd(objects, creds))
+		require.NoError(t, injectKubernetesContextFile(objects, creds))
 
-		agentsMd, _, _ := unstructured.NestedString(objects[0].Object, "data", "AGENTS.md")
-		assert.Equal(t, "# Original\n", agentsMd)
+		_, found, _ := unstructured.NestedString(objects[0].Object, "data", "KUBERNETES.md")
+		assert.False(t, found, "KUBERNETES.md should not exist when no kubernetes credentials")
 	})
 }
 
@@ -813,7 +810,7 @@ func TestKubernetesCredentialReconciliation(t *testing.T) {
 		assert.Contains(t, sanitizedConfig, "api.prod.example.com", "cluster info should be preserved")
 	})
 
-	t.Run("should inject AGENTS.md with kubernetes context info", func(t *testing.T) {
+	t.Run("should inject KUBERNETES.md with context info", func(t *testing.T) {
 		t.Cleanup(func() {
 			_ = deleteAndWait(&corev1.Secret{}, client.ObjectKey{Name: testKubeSecretName, Namespace: namespace})
 			_ = deleteAndWait(&corev1.ConfigMap{}, client.ObjectKey{Name: ClawKubeConfigMapName, Namespace: namespace})
@@ -856,10 +853,10 @@ func TestKubernetesCredentialReconciliation(t *testing.T) {
 			}, cm) == nil
 		}, "ConfigMap should be created")
 
-		agentsMd := cm.Data["AGENTS.md"]
-		assert.True(t, strings.Contains(agentsMd, "Kubernetes Access"),
-			"AGENTS.md should contain Kubernetes Access section, got: %s", agentsMd)
-		assert.Contains(t, agentsMd, "prod-ctx")
+		kubeMd, ok := cm.Data["KUBERNETES.md"]
+		assert.True(t, ok, "KUBERNETES.md should exist in ConfigMap")
+		assert.Contains(t, kubeMd, "Kubernetes Access")
+		assert.Contains(t, kubeMd, "prod-ctx")
 	})
 
 	t.Run("should configure proxy deployment with kubernetes volume mount", func(t *testing.T) {

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -669,7 +669,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(ClawConfigMapName)
 		cm.Object["data"] = map[string]any{
-			"openclaw.json": jsonContent,
+			"operator.json": jsonContent,
 		}
 		return []*unstructured.Unstructured{cm}
 	}
@@ -678,7 +678,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 
 	getProviders := func(t *testing.T, objects []*unstructured.Unstructured) map[string]any {
 		t.Helper()
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "openclaw.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
@@ -775,7 +775,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		objects := makeConfigMap(baseJSON)
 		require.NoError(t, injectProvidersIntoConfigMap(objects, nil))
 
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "openclaw.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
@@ -816,46 +816,6 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		assert.Contains(t, err.Error(), "google")
 	})
 
-	t.Run("should filter model aliases and pick deterministic fallback primary", func(t *testing.T) {
-		configJSON := `{
-			"models": {"providers": {}},
-			"agents": {
-				"defaults": {
-					"model": {"primary": "missing/model-a"},
-					"models": {
-						"anthropic/claude-sonnet": {"alias": "Sonnet"},
-						"google/gemini-flash": {"alias": "Flash"},
-						"missing/model-a": {"alias": "Missing A"},
-						"anthropic/claude-haiku": {"alias": "Haiku"}
-					}
-				}
-			}
-		}`
-		objects := makeConfigMap(configJSON)
-		credentials := []clawv1alpha1.CredentialSpec{
-			{Name: "gemini", Type: clawv1alpha1.CredentialTypeAPIKey, Provider: "google", Domain: "generativelanguage.googleapis.com"},
-			{Name: "claude", Type: clawv1alpha1.CredentialTypeBearer, Provider: "anthropic", Domain: "api.anthropic.com"},
-		}
-
-		require.NoError(t, injectProvidersIntoConfigMap(objects, credentials))
-
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "openclaw.json")
-		require.NoError(t, err)
-		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(raw), &config))
-
-		agents := config["agents"].(map[string]any)
-		defaults := agents["defaults"].(map[string]any)
-		modelAliases := defaults["models"].(map[string]any)
-
-		assert.NotContains(t, modelAliases, "missing/model-a", "missing provider model should be removed")
-		assert.Contains(t, modelAliases, "google/gemini-flash")
-		assert.Contains(t, modelAliases, "anthropic/claude-sonnet")
-		assert.Contains(t, modelAliases, "anthropic/claude-haiku")
-
-		primary := defaults["model"].(map[string]any)
-		assert.Equal(t, "anthropic/claude-haiku", primary["primary"], "fallback should be lexicographically first available model")
-	})
 }
 
 func TestCredEnvVarName(t *testing.T) {
@@ -941,11 +901,11 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 			}, cm) == nil
 		}, "ConfigMap should be created")
 
-		openclawJSON, ok := cm.Data["openclaw.json"]
-		require.True(t, ok, "openclaw.json should exist")
+		operatorJSON, ok := cm.Data["operator.json"]
+		require.True(t, ok, "operator.json should exist")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(openclawJSON), &config))
+		require.NoError(t, json.Unmarshal([]byte(operatorJSON), &config))
 
 		models, ok := config["models"].(map[string]any)
 		require.True(t, ok, "models section should exist")
@@ -986,14 +946,14 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 		}, "ConfigMap should be created")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(cm.Data["openclaw.json"]), &config))
+		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator.json"]), &config))
 
 		models := config["models"].(map[string]any)
 		providers := models["providers"].(map[string]any)
 		assert.Empty(t, providers, "providers should be empty when no credentials have provider set")
 	})
 
-	t.Run("should have empty providers and filtered model defaults for MITM-only credentials", func(t *testing.T) {
+	t.Run("should have empty providers for MITM-only credentials", func(t *testing.T) {
 		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
 		createClawInstanceMITMOnly(t, ctx, ClawInstanceName, namespace)
 		reconciler := createClawReconciler()
@@ -1008,15 +968,10 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 		}, "ConfigMap should be created")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(cm.Data["openclaw.json"]), &config))
+		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator.json"]), &config))
 
 		models := config["models"].(map[string]any)
 		providers := models["providers"].(map[string]any)
 		assert.Empty(t, providers, "providers should be empty for MITM-only credentials")
-
-		agents, _ := config["agents"].(map[string]any)
-		defaults, _ := agents["defaults"].(map[string]any)
-		modelAliases, _ := defaults["models"].(map[string]any)
-		assert.Empty(t, modelAliases, "model aliases should be empty when no providers are configured")
 	})
 }

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -202,9 +202,9 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to inject providers into ConfigMap: %w", err)
 	}
 
-	// Inject Kubernetes context info into AGENTS.md
-	if err := injectKubernetesIntoAgentsMd(objects, resolvedCreds); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes info into AGENTS.md: %w", err)
+	// Inject Kubernetes context info as a separate KUBERNETES.md file
+	if err := injectKubernetesContextFile(objects, resolvedCreds); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes context file: %w", err)
 	}
 
 	// Inject non-443 ports from kubernetes credentials into proxy egress NetworkPolicy
@@ -448,34 +448,28 @@ func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*
 	return r.applyResources(ctx, routeObjects)
 }
 
-// injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in ConfigMap with actual Route host
-// If routeHost is empty (vanilla Kubernetes), uses localhost fallback
+// injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator.json with actual Route host.
+// If routeHost is empty (vanilla Kubernetes), uses localhost fallback.
 func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstructured.Unstructured, routeHost string) error {
-	// Determine replacement value
 	replacement := routeHost
 	if replacement == "" {
-		// Vanilla Kubernetes fallback
 		replacement = "http://localhost:18789"
 	}
 
-	// Find ConfigMap in objects
 	for _, obj := range objects {
 		if obj.GetKind() == ConfigMapKind && obj.GetName() == ClawConfigMapName {
-			// Extract openclaw.json data
-			openclawJSON, found, err := unstructured.NestedString(obj.Object, "data", "openclaw.json")
+			operatorJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator.json")
 			if err != nil {
-				return fmt.Errorf("failed to extract openclaw.json from ConfigMap: %w", err)
+				return fmt.Errorf("failed to extract operator.json from ConfigMap: %w", err)
 			}
 			if !found {
-				return fmt.Errorf("openclaw.json not found in ConfigMap data")
+				return fmt.Errorf("operator.json not found in ConfigMap data")
 			}
 
-			// Replace placeholder with Route host
-			updatedJSON := strings.ReplaceAll(openclawJSON, "OPENCLAW_ROUTE_HOST", replacement)
+			updatedJSON := strings.ReplaceAll(operatorJSON, "OPENCLAW_ROUTE_HOST", replacement)
 
-			// Set modified JSON back into ConfigMap
-			if err := unstructured.SetNestedField(obj.Object, updatedJSON, "data", "openclaw.json"); err != nil {
-				return fmt.Errorf("failed to set updated openclaw.json in ConfigMap: %w", err)
+			if err := unstructured.SetNestedField(obj.Object, updatedJSON, "data", "operator.json"); err != nil {
+				return fmt.Errorf("failed to set updated operator.json in ConfigMap: %w", err)
 			}
 
 			return nil
@@ -485,18 +479,18 @@ func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstruc
 	return fmt.Errorf("ConfigMap %s not found in manifests", ClawConfigMapName)
 }
 
-// injectProvidersIntoConfigMap dynamically builds the models.providers section of openclaw.json
+// injectProvidersIntoConfigMap dynamically builds the models.providers section of operator.json
 // from credentials that have Provider set. Gateway-routed providers get a baseUrl pointing to
 // the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since traffic
 // flows through the MITM proxy which injects GCP credentials transparently.
+// Agent defaults (model aliases, primary model) are in the user-owned openclaw.json seed
+// and are not modified here — users control their own model preferences.
 func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, credentials []clawv1alpha1.CredentialSpec) error {
 	providers := map[string]any{}
 	for _, cred := range credentials {
 		if cred.Provider == "" {
 			continue
 		}
-		// PathToken uses PathPrefix for token injection in the URL path (e.g., /bot<TOKEN>/...),
-		// not for gateway routing — skip provider entry to avoid referencing a non-existent gateway route.
 		if cred.Type == clawv1alpha1.CredentialTypePathToken {
 			continue
 		}
@@ -534,17 +528,17 @@ func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, credenti
 			continue
 		}
 
-		openclawJSON, found, err := unstructured.NestedString(obj.Object, "data", "openclaw.json")
+		operatorJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator.json")
 		if err != nil {
-			return fmt.Errorf("failed to extract openclaw.json from ConfigMap: %w", err)
+			return fmt.Errorf("failed to extract operator.json from ConfigMap: %w", err)
 		}
 		if !found {
-			return fmt.Errorf("openclaw.json not found in ConfigMap data")
+			return fmt.Errorf("operator.json not found in ConfigMap data")
 		}
 
 		var config map[string]any
-		if err := json.Unmarshal([]byte(openclawJSON), &config); err != nil {
-			return fmt.Errorf("failed to parse openclaw.json: %w", err)
+		if err := json.Unmarshal([]byte(operatorJSON), &config); err != nil {
+			return fmt.Errorf("failed to parse operator.json: %w", err)
 		}
 
 		models, _ := config["models"].(map[string]any)
@@ -554,106 +548,18 @@ func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, credenti
 		}
 		models["providers"] = providers
 
-		remapVertexProviderModels(config, providers)
-		filterAgentDefaultsForProviders(config, providers)
-
 		updatedJSON, err := json.MarshalIndent(config, "    ", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal openclaw.json: %w", err)
+			return fmt.Errorf("failed to marshal operator.json: %w", err)
 		}
 
-		if err := unstructured.SetNestedField(obj.Object, string(updatedJSON), "data", "openclaw.json"); err != nil {
-			return fmt.Errorf("failed to set updated openclaw.json in ConfigMap: %w", err)
+		if err := unstructured.SetNestedField(obj.Object, string(updatedJSON), "data", "operator.json"); err != nil {
+			return fmt.Errorf("failed to set updated operator.json in ConfigMap: %w", err)
 		}
 		return nil
 	}
 
 	return fmt.Errorf("ConfigMap %s not found in manifests", ClawConfigMapName)
-}
-
-// remapVertexProviderModels renames model entries in agents.defaults from "provider/model"
-// to "provider-vertex/model" when a Vertex variant exists but the base provider does not.
-// For example, "anthropic/claude-sonnet-4-6" becomes "anthropic-vertex/claude-sonnet-4-6"
-// when anthropic-vertex is configured but anthropic is not.
-func remapVertexProviderModels(config map[string]any, providers map[string]any) {
-	agents, _ := config["agents"].(map[string]any)
-	if agents == nil {
-		return
-	}
-	defaults, _ := agents["defaults"].(map[string]any)
-	if defaults == nil {
-		return
-	}
-
-	if modelMap, ok := defaults["models"].(map[string]any); ok {
-		for modelName, val := range modelMap {
-			providerKey, modelID, ok := strings.Cut(modelName, "/")
-			if !ok {
-				continue
-			}
-			vertexKey := providerKey + "-vertex"
-			_, hasBase := providers[providerKey]
-			_, hasVertex := providers[vertexKey]
-			if !hasBase && hasVertex {
-				delete(modelMap, modelName)
-				modelMap[vertexKey+"/"+modelID] = val
-			}
-		}
-	}
-
-	if primary, _ := defaults["model"].(map[string]any); primary != nil {
-		if primaryName, _ := primary["primary"].(string); primaryName != "" {
-			providerKey, modelID, ok := strings.Cut(primaryName, "/")
-			if ok {
-				vertexKey := providerKey + "-vertex"
-				_, hasBase := providers[providerKey]
-				_, hasVertex := providers[vertexKey]
-				if !hasBase && hasVertex {
-					primary["primary"] = vertexKey + "/" + modelID
-				}
-			}
-		}
-	}
-}
-
-// filterAgentDefaultsForProviders removes model entries from agents.defaults whose
-// provider (the part before "/" in the model name) is not in the injected providers map,
-// and clears agents.defaults.model.primary if its provider is not available.
-func filterAgentDefaultsForProviders(config map[string]any, providers map[string]any) {
-	agents, _ := config["agents"].(map[string]any)
-	if agents == nil {
-		return
-	}
-	defaults, _ := agents["defaults"].(map[string]any)
-	if defaults == nil {
-		return
-	}
-
-	if modelMap, ok := defaults["models"].(map[string]any); ok {
-		var available []string
-		for modelName := range modelMap {
-			providerKey, _, _ := strings.Cut(modelName, "/")
-			if _, exists := providers[providerKey]; !exists {
-				delete(modelMap, modelName)
-			} else {
-				available = append(available, modelName)
-			}
-		}
-		sort.Strings(available)
-
-		if primary, _ := defaults["model"].(map[string]any); primary != nil {
-			if primaryName, _ := primary["primary"].(string); primaryName != "" {
-				providerKey, _, _ := strings.Cut(primaryName, "/")
-				if _, exists := providers[providerKey]; !exists {
-					if len(available) > 0 {
-						primary["primary"] = available[0]
-					} else {
-						primary["primary"] = ""
-					}
-				}
-			}
-		}
-	}
 }
 
 // injectKubePortsIntoNetworkPolicy adds non-443 ports from kubernetes credentials to
@@ -725,9 +631,10 @@ func injectKubePortsIntoNetworkPolicy(objects []*unstructured.Unstructured, reso
 	return nil
 }
 
-// injectKubernetesIntoAgentsMd appends a Kubernetes section to AGENTS.md in the
-// claw-config ConfigMap when kubernetes credentials are present.
-func injectKubernetesIntoAgentsMd(objects []*unstructured.Unstructured, resolvedCreds []resolvedCredential) error {
+// injectKubernetesContextFile writes a KUBERNETES.md key into the claw-config ConfigMap
+// when kubernetes credentials are present. This file is always overwritten on the PVC
+// by the init container, while the user-owned AGENTS.md is left untouched.
+func injectKubernetesContextFile(objects []*unstructured.Unstructured, resolvedCreds []resolvedCredential) error {
 	var allContexts []kubeconfigContext
 	for _, rc := range resolvedCreds {
 		if rc.KubeConfig == nil {
@@ -739,44 +646,37 @@ func injectKubernetesIntoAgentsMd(objects []*unstructured.Unstructured, resolved
 		return nil
 	}
 
+	var sb strings.Builder
+	sb.WriteString("# Kubernetes Access\n\n")
+	sb.WriteString("You have access to Kubernetes clusters via `kubectl`. Your KUBECONFIG is\n")
+	sb.WriteString("pre-configured. Available contexts:\n")
+
+	sort.Slice(allContexts, func(i, j int) bool {
+		return allContexts[i].Name < allContexts[j].Name
+	})
+
+	for _, ctx := range allContexts {
+		entry := fmt.Sprintf("- `%s` (cluster: %s", ctx.Name, ctx.Cluster)
+		if ctx.Namespace != "" {
+			entry += ", namespace: " + ctx.Namespace
+		}
+		entry += ")"
+		if ctx.Current {
+			entry += " [current]"
+		}
+		sb.WriteString(entry + "\n")
+	}
+
+	sb.WriteString("\nUse `kubectl` commands to manage resources. The proxy handles authentication\n")
+	sb.WriteString("transparently — do not attempt to manage tokens or kubeconfig yourself.\n")
+
 	for _, obj := range objects {
 		if obj.GetKind() != ConfigMapKind || obj.GetName() != ClawConfigMapName {
 			continue
 		}
 
-		agentsMd, _, err := unstructured.NestedString(obj.Object, "data", "AGENTS.md")
-		if err != nil {
-			return fmt.Errorf("failed to extract AGENTS.md from ConfigMap: %w", err)
-		}
-
-		var sb strings.Builder
-		sb.WriteString(agentsMd)
-		sb.WriteString("\n## Kubernetes Access\n\n")
-		sb.WriteString("You have access to Kubernetes clusters via `kubectl`. Your KUBECONFIG is\n")
-		sb.WriteString("pre-configured. Available contexts:\n")
-
-		// Sort contexts for stable output
-		sort.Slice(allContexts, func(i, j int) bool {
-			return allContexts[i].Name < allContexts[j].Name
-		})
-
-		for _, ctx := range allContexts {
-			entry := fmt.Sprintf("- `%s` (cluster: %s", ctx.Name, ctx.Cluster)
-			if ctx.Namespace != "" {
-				entry += ", namespace: " + ctx.Namespace
-			}
-			entry += ")"
-			if ctx.Current {
-				entry += " [current]"
-			}
-			sb.WriteString(entry + "\n")
-		}
-
-		sb.WriteString("\nUse `kubectl` commands to manage resources. The proxy handles authentication\n")
-		sb.WriteString("transparently — do not attempt to manage tokens or kubeconfig yourself.\n")
-
-		if err := unstructured.SetNestedField(obj.Object, sb.String(), "data", "AGENTS.md"); err != nil {
-			return fmt.Errorf("failed to set AGENTS.md in ConfigMap: %w", err)
+		if err := unstructured.SetNestedField(obj.Object, sb.String(), "data", "KUBERNETES.md"); err != nil {
+			return fmt.Errorf("failed to set KUBERNETES.md in ConfigMap: %w", err)
 		}
 		return nil
 	}

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"regexp"
 	"strings"
 	"testing"
@@ -91,6 +92,120 @@ func TestClawConfigMapController(t *testing.T) {
 					ownerRef.Controller != nil &&
 					*ownerRef.Controller == true
 			}, "ConfigMap should have correct owner reference")
+		})
+
+		t.Run("should have operator.json with gateway config and providers", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			configMap := &corev1.ConfigMap{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{
+					Name:      ClawConfigMapName,
+					Namespace: namespace,
+				}, configMap) == nil
+			}, "ConfigMap should be created")
+
+			operatorJSON, ok := configMap.Data["operator.json"]
+			require.True(t, ok, "operator.json key must exist")
+
+			var config map[string]any
+			require.NoError(t, json.Unmarshal([]byte(operatorJSON), &config))
+
+			_, hasGateway := config["gateway"]
+			assert.True(t, hasGateway, "operator.json should contain gateway section")
+
+			_, hasModels := config["models"]
+			assert.True(t, hasModels, "operator.json should contain models section")
+
+			_, hasAgents := config["agents"]
+			assert.False(t, hasAgents, "operator.json must not contain agents section (user-owned)")
+		})
+
+		t.Run("should have openclaw.json seed with $include directive", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			configMap := &corev1.ConfigMap{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{
+					Name:      ClawConfigMapName,
+					Namespace: namespace,
+				}, configMap) == nil
+			}, "ConfigMap should be created")
+
+			openclawJSON, ok := configMap.Data["openclaw.json"]
+			require.True(t, ok, "openclaw.json key must exist")
+
+			var config map[string]any
+			require.NoError(t, json.Unmarshal([]byte(openclawJSON), &config))
+
+			include, hasInclude := config["$include"]
+			require.True(t, hasInclude, "openclaw.json must contain $include directive")
+			assert.Equal(t, "./operator.json", include, "$include should reference operator.json")
+
+			agents, hasAgents := config["agents"].(map[string]any)
+			require.True(t, hasAgents, "openclaw.json seed should contain agents section")
+
+			defaults, hasDefaults := agents["defaults"].(map[string]any)
+			require.True(t, hasDefaults, "agents should have defaults")
+
+			model, hasModel := defaults["model"].(map[string]any)
+			require.True(t, hasModel, "defaults should have model config")
+			assert.NotEmpty(t, model["primary"], "should have a primary model set")
+		})
+
+		t.Run("should have AGENTS.md seed content", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			configMap := &corev1.ConfigMap{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{
+					Name:      ClawConfigMapName,
+					Namespace: namespace,
+				}, configMap) == nil
+			}, "ConfigMap should be created")
+
+			agentsMd, ok := configMap.Data["AGENTS.md"]
+			assert.True(t, ok, "AGENTS.md key must exist")
+			assert.Contains(t, agentsMd, "OpenClaw Assistant")
+		})
+
+		t.Run("should not have KUBERNETES.md when no kubernetes credentials", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			configMap := &corev1.ConfigMap{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{
+					Name:      ClawConfigMapName,
+					Namespace: namespace,
+				}, configMap) == nil
+			}, "ConfigMap should be created")
+
+			_, hasKubeMd := configMap.Data["KUBERNETES.md"]
+			assert.False(t, hasKubeMd, "KUBERNETES.md should not exist without kubernetes credentials")
 		})
 	})
 
@@ -588,7 +703,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(ClawConfigMapName)
 			configMap.Object["data"] = map[string]any{
-				"openclaw.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -602,11 +717,11 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			openclawJSON, found, err := unstructured.NestedString(configMap.Object, "data", "openclaw.json")
-			require.NoError(t, err, "failed to get openclaw.json")
-			assert.True(t, found, "openclaw.json not found in ConfigMap data")
-			assert.Contains(t, openclawJSON, routeHost)
-			assert.NotContains(t, openclawJSON, "OPENCLAW_ROUTE_HOST")
+			operatorJSON, found, err := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			require.NoError(t, err, "failed to get operator.json")
+			assert.True(t, found, "operator.json not found in ConfigMap data")
+			assert.Contains(t, operatorJSON, routeHost)
+			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
 		})
 
 		t.Run("should replace all occurrences of OPENCLAW_ROUTE_HOST placeholder", func(t *testing.T) {
@@ -614,7 +729,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(ClawConfigMapName)
 			configMap.Object["data"] = map[string]any{
-				"openclaw.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST","OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST","OPENCLAW_ROUTE_HOST"]}}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -628,10 +743,10 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			openclawJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "openclaw.json")
-			hostCount := strings.Count(openclawJSON, routeHost)
+			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			hostCount := strings.Count(operatorJSON, routeHost)
 			assert.Equal(t, 2, hostCount, "expected 2 occurrences of routeHost")
-			assert.NotContains(t, openclawJSON, "OPENCLAW_ROUTE_HOST")
+			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
 		})
 
 		t.Run("should use localhost fallback when routeHost is empty", func(t *testing.T) {
@@ -639,7 +754,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(ClawConfigMapName)
 			configMap.Object["data"] = map[string]any{
-				"openclaw.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -653,9 +768,9 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			openclawJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "openclaw.json")
-			assert.Contains(t, openclawJSON, "http://localhost:18789")
-			assert.NotContains(t, openclawJSON, "OPENCLAW_ROUTE_HOST")
+			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			assert.Contains(t, operatorJSON, "http://localhost:18789")
+			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
 		})
 	})
 
@@ -723,12 +838,12 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				openclawJSON, ok := configMap.Data["openclaw.json"]
+				operatorJSON, ok := configMap.Data["operator.json"]
 				if !ok {
 					return false
 				}
-				return strings.Contains(openclawJSON, "http://localhost:18789")
-			}, "ConfigMap should contain localhost fallback")
+				return strings.Contains(operatorJSON, "http://localhost:18789")
+			}, "ConfigMap should contain localhost fallback in operator.json")
 		})
 	})
 
@@ -763,6 +878,48 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			require.NoError(t, err, "failed to get containers")
 			assert.True(t, found, "containers not found in proxy deployment")
 			assert.NotEmpty(t, containers, "expected at least one container in proxy deployment")
+		})
+	})
+
+	t.Run("Init container config seeding", func(t *testing.T) {
+		t.Run("should always copy operator.json and conditionally seed user files", func(t *testing.T) {
+			reconciler := createClawReconciler()
+			objects, err := reconciler.buildKustomizedObjects()
+			require.NoError(t, err)
+
+			var deployment *unstructured.Unstructured
+			for _, obj := range objects {
+				if obj.GetKind() == DeploymentKind && obj.GetName() == ClawDeploymentName {
+					deployment = obj
+					break
+				}
+			}
+			require.NotNil(t, deployment)
+
+			initContainers, _, err := unstructured.NestedSlice(
+				deployment.Object, "spec", "template", "spec", "initContainers",
+			)
+			require.NoError(t, err)
+
+			var initConfigScript string
+			for _, ic := range initContainers {
+				container := ic.(map[string]any)
+				if container["name"] == "init-config" {
+					cmds := container["command"].([]any)
+					initConfigScript = cmds[len(cmds)-1].(string)
+					break
+				}
+			}
+			require.NotEmpty(t, initConfigScript, "init-config container should exist")
+
+			assert.Contains(t, initConfigScript, "cp /config/operator.json /home/node/.openclaw/operator.json",
+				"operator.json should always be copied unconditionally")
+			assert.Contains(t, initConfigScript, "[ -f /home/node/.openclaw/openclaw.json ] || cp",
+				"openclaw.json should only be seeded if missing")
+			assert.Contains(t, initConfigScript, "[ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp",
+				"AGENTS.md should only be seeded if missing")
+			assert.Contains(t, initConfigScript, "if [ -f /config/KUBERNETES.md ]",
+				"KUBERNETES.md should be copied only when present in ConfigMap")
 		})
 	})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -429,6 +429,94 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				`controller_runtime_reconcile_total{controller="claw",result="success"}`)
 		})
 
+		t.Run("should create claw-config ConfigMap with split config layering", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create Secret")
+
+			t.Log("applying the Claw CR")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				"config/samples/claw_v1alpha1_claw.yaml", "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw ProxyConfigured did not become True")
+
+			t.Log("verifying operator.json has gateway config and providers")
+			cmd = exec.Command("kubectl", "get", "configmap", "claw-config",
+				"-o", "jsonpath={.data.operator\\.json}",
+				"-n", userNamespace)
+			operatorJSON, err := utils.Run(t, cmd)
+			require.NoError(t, err, "claw-config ConfigMap should exist with operator.json")
+			assert.Contains(t, operatorJSON, `"gateway"`,
+				"operator.json should contain gateway config")
+			assert.Contains(t, operatorJSON, `"providers"`,
+				"operator.json should contain providers section")
+			assert.NotContains(t, operatorJSON, `"agents"`,
+				"operator.json must not contain agents section (user-owned)")
+
+			var operatorConfig map[string]any
+			require.NoError(t, json.Unmarshal([]byte(operatorJSON), &operatorConfig),
+				"operator.json should be valid JSON")
+			models := operatorConfig["models"].(map[string]any)
+			providers := models["providers"].(map[string]any)
+			assert.NotEmpty(t, providers, "should have injected provider from credential")
+
+			t.Log("verifying openclaw.json seed has $include directive")
+			cmd = exec.Command("kubectl", "get", "configmap", "claw-config",
+				"-o", "jsonpath={.data.openclaw\\.json}",
+				"-n", userNamespace)
+			openclawJSON, err := utils.Run(t, cmd)
+			require.NoError(t, err, "claw-config ConfigMap should have openclaw.json")
+			assert.Contains(t, openclawJSON, `"$include"`,
+				"openclaw.json should contain $include directive")
+			assert.Contains(t, openclawJSON, `./operator.json`,
+				"$include should reference operator.json")
+			assert.Contains(t, openclawJSON, `"agents"`,
+				"openclaw.json seed should contain agents section")
+
+			t.Log("verifying AGENTS.md seed is present")
+			cmd = exec.Command("kubectl", "get", "configmap", "claw-config",
+				"-o", "jsonpath={.data.AGENTS\\.md}",
+				"-n", userNamespace)
+			agentsMd, err := utils.Run(t, cmd)
+			require.NoError(t, err, "claw-config ConfigMap should have AGENTS.md")
+			assert.Contains(t, agentsMd, "OpenClaw Assistant",
+				"AGENTS.md should contain seed content")
+
+			t.Log("verifying KUBERNETES.md is absent (no kubernetes credentials)")
+			cmd = exec.Command("kubectl", "get", "configmap", "claw-config",
+				"-o", "jsonpath={.data.KUBERNETES\\.md}",
+				"-n", userNamespace)
+			kubeMd, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, kubeMd, "KUBERNETES.md should not exist without kubernetes credentials")
+		})
+
 		t.Run("should wire credential env var with correct Secret reference", func(t *testing.T) {
 			t.Cleanup(func() {
 				collectDebugInfo(t)


### PR DESCRIPTION
- Split configmap.yaml into operator.json (operator-managed) and openclaw.json (user-owned seed with $include directive)
- Init container seeds openclaw.json and AGENTS.md only if missing, always overwrites operator.json and KUBERNETES.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration now splits into operator-managed and user-owned files, preserving your modifications across reconciliations.
  * Kubernetes context information is stored in a dedicated configuration file.
  * Configuration composition now supports include directives for modular setup.

* **Documentation**
  * Added Architecture Decision Record documenting configuration preservation and layering strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->