### PR TITLE
feat(claw): enforce v2026.4.23-slim

### DIFF
--- a/internal/assets/manifests/kustomization.yaml
+++ b/internal/assets/manifests/kustomization.yaml
@@ -16,3 +16,8 @@ resources:
   - proxy-service.yaml
   - networkpolicy.yaml
   - ingress-networkpolicy.yaml
+
+images:
+  - name: ghcr.io/openclaw/openclaw
+    newName: ghcr.io/openclaw/openclaw
+    newTag: 2026.4.23-slim


### PR DESCRIPTION
Latest image has changes that result in the following error in the `proxy-patch` init-container:
```
ERROR: no files contain SSRF guard conditional — upstream may have changed
```

and v2026.4.24-slim has a [bug that prevents the gateway from working](https://github.com/openclaw/openclaw/issues/71759)
on an OpenShift cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container deployment image version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->