### PR TITLE
test(proxy): add assertions for npm registry route matching

### DIFF
--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -78,6 +78,8 @@ func TestMatchRoute(t *testing.T) {
 	}{
 		{name: "exact match", host: "api.example.com", wantDom: "api.example.com"},
 		{name: "exact match with port", host: "api.example.com:443", wantDom: "api.example.com"},
+		{name: "npm registry exact match", host: "registry.npmjs.org", wantDom: "registry.npmjs.org"},
+		{name: "npm registry exact match with port", host: "registry.npmjs.org:443", wantDom: "registry.npmjs.org"},
 		{name: "suffix match", host: "generativelanguage.googleapis.com", wantDom: ".googleapis.com"},
 		{name: "suffix match bare domain", host: "googleapis.com", wantDom: ".googleapis.com"},
 		{name: "no match", host: "unknown.example.org", wantNil: true},


### PR DESCRIPTION
- Cover registry.npmjs.org exact match (bare and with :443 port)
- Prevents silent regression of the route added in #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for route-matching logic, adding validation for exact domain matching scenarios and port handling to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->