### PR TITLE
fix: allow kubelet health probes through ingress NetworkPolicy

### DIFF
--- a/internal/assets/manifests/claw/network-policy.yaml
+++ b/internal/assets/manifests/claw/network-policy.yaml
@@ -15,6 +15,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               policy-group.network.openshift.io/ingress: ""
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ""
       ports:
         - port: 18789
           protocol: TCP


### PR DESCRIPTION
- Add host-network namespace selector to claw-ingress NetworkPolicy
- On OVN-Kubernetes, kubelet probes originate from openshift-host-network namespace which was not permitted, causing readiness/liveness timeouts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration to allow traffic from additional sources alongside existing permitted paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->