### PR TITLE
feat: add WhatsApp support and proxy architecture skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ The `claw-config` ConfigMap uses a **split config** approach to preserve user an
 
 **Operator-managed files** (always overwritten on PVC by init container):
 - `operator.json` — Gateway settings, CORS origins, providers, proxy config. Rewritten every reconcile.
+- `PROXY_SETUP.md` — Proxy architecture skill file (always present). Explains the proxy security model and how to configure access to external services (WhatsApp, custom domains). Init container copies to `skills/proxy/SKILL.md` for OpenClaw auto-discovery.
 - `KUBERNETES.md` — Kubernetes skill file (only when k8s credentials present). Always overwritten. Init container copies to `skills/kubernetes/SKILL.md` for OpenClaw auto-discovery.
 
 **User-owned files** (seeded once, then owned by user/OpenClaw):
@@ -361,7 +362,7 @@ var ManifestsFS embed.FS
 
 The `internal/assets/manifests/` directory contains:
 - **kustomization.yaml** — defines labels and resource list
-- **configmap.yaml** — OpenClaw configuration (operator.json for operator-managed settings, openclaw.json as user-owned seed with `$include`, AGENTS.md seed, KUBERNETES.md for k8s skill)
+- **configmap.yaml** — OpenClaw configuration (operator.json for operator-managed settings, openclaw.json as user-owned seed with `$include`, AGENTS.md seed, PROXY_SETUP.md for proxy architecture skill, KUBERNETES.md for k8s skill)
 - **pvc.yaml** — persistent storage (10Gi ReadWriteOnce)
 - **deployment.yaml** — OpenClaw application pods (init containers with readOnlyRootFilesystem, gateway without; PVC subpath mounts at `~/.local`, `~/.cache`, `~/.config` for persistent tool state; `wait-for-proxy` init container ensures proxy is ready before gateway starts)
 - **service.yaml** — ClusterIP service exposing OpenClaw gateway (port 18789)

--- a/docs/proposals/messaging-channel-credential-injection.md
+++ b/docs/proposals/messaging-channel-credential-injection.md
@@ -1,0 +1,47 @@
+# Messaging Channel Credential Injection
+
+**Status:** TODO
+
+## Problem
+
+Messaging channels (Telegram, Discord, Slack) use API tokens that are currently managed by OpenClaw itself — stored in its config and included in outgoing requests. The proxy only allowlists domains (`type: none`) but doesn't manage the credentials, breaking our security model where real secrets should stay on the proxy pod.
+
+## How OpenClaw uses messaging tokens
+
+- **Telegram**: Bot token embedded in URL path (`/bot<TOKEN>/sendMessage`)
+- **Discord**: Bot token sent as `Authorization: Bot <TOKEN>` header
+- **Slack**: Bot token as `Authorization: Bearer <TOKEN>` header; app token validated in-process (must start with `xapp-`)
+
+## How our proxy could handle them
+
+- **Telegram**: `pathToken` type — proxy prepends `/bot<TOKEN>` to the request path
+- **Discord**: `apiKey` type with `header: Authorization`, `valuePrefix: "Bot "` — proxy strips existing auth header and injects real one
+- **Slack**: `bearer` type — proxy strips existing auth header and injects real one
+
+## The gap
+
+Our proxy's credential injection works by **stripping and replacing** auth headers (or prepending path tokens). But OpenClaw **also** constructs the full authenticated request. For this to work, OpenClaw needs to either:
+
+1. Send requests **without** credentials and let the proxy add them, or
+2. Send requests with **placeholder** credentials that the proxy recognizes and replaces
+
+Option 1 would require OpenClaw changes. Option 2 is what NemoClaw/OpenShell does — they use `openshell:resolve:env:*` placeholder strings that the proxy scans for and rewrites.
+
+Our proxy currently strips all auth headers unconditionally before injecting, so option 2 already works for **header-based** credentials (Discord, Slack) — OpenClaw sends a dummy token, proxy strips it, injects the real one. The open question is whether OpenClaw validates tokens locally before making network calls (Slack's Bolt library does this — it rejects tokens that don't start with `xapp-`).
+
+For **path-based** credentials (Telegram), our `pathToken` injector **prepends** a prefix — it doesn't scan for and replace a placeholder in an existing path. This needs proxy changes.
+
+## Tasks
+
+- [ ] Test Discord with `apiKey` type: configure OpenClaw with a dummy bot token, verify proxy strips and replaces it
+- [ ] Test Slack with `bearer` type: same approach, check if Bolt's in-process validation blocks placeholder tokens
+- [ ] Extend proxy's `pathToken` injector to support replacement mode (scan for placeholder in path, replace with real token) for Telegram
+- [ ] Add Telegram, Discord, Slack sections to the proxy setup skill and `docs/provider-setup.md`
+- [ ] Add integration tests for each channel
+
+## References
+
+- NemoClaw placeholder model: `NemoClaw/agents/hermes/generate-config.ts` — uses `openshell:resolve:env:*`
+- NemoClaw Slack workaround: `NemoClaw/scripts/nemoclaw-start.sh` — resolves Slack placeholders at startup before Bolt validates
+- OpenShell credential rewriting: `OpenShell/architecture/sandbox-providers.md` — header, query param, and path segment rewriting
+- Our pathToken injector: `internal/proxy/injector_pathtoken.go`

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -1,6 +1,6 @@
 # Provider Setup
 
-This guide covers configuring LLM providers and external services for use with Claw. Each section walks through creating the necessary Secret and Claw CR configuration.
+This guide covers configuring LLM providers, external services, and messaging channels for use with Claw. Each section walks through creating the necessary Secret and Claw CR configuration.
 
 All examples assume you have set your target namespace:
 
@@ -368,3 +368,43 @@ The `kubernetes` credential uses the proxy's existing **MITM forward proxy mode*
 5. Re-encrypts and forwards to the upstream API server
 
 The gateway pod **cannot** reach any API server directly — egress is restricted to the proxy by NetworkPolicy. The assistant never sees real tokens; only the sanitized kubeconfig with placeholder values.
+
+## WhatsApp
+
+OpenClaw supports WhatsApp as a messaging channel via WhatsApp Web (the Baileys library). The gateway maintains a linked-device session over WebSocket to WhatsApp's servers.
+
+All gateway egress goes through the credential-injecting proxy, which blocks unknown domains by default. To allow WhatsApp traffic, add two `type: none` credentials that allowlist the required domains:
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        name: gemini-api-key
+        key: api-key
+      provider: google
+    - name: whatsapp
+      type: none
+      domain: ".whatsapp.com"
+    - name: whatsapp-net
+      type: none
+      domain: ".whatsapp.net"
+EOF
+```
+
+The leading dot makes these suffix matches — `.whatsapp.com` covers `web.whatsapp.com` (WebSocket), `api.whatsapp.com`, and fallback hosts; `.whatsapp.net` covers `mmg.whatsapp.net` (media), `pps.whatsapp.net` (profile pictures), and CDN subdomains.
+
+No Secret is needed. WhatsApp Web uses phone-based QR pairing, not API keys — the session state is managed by OpenClaw on the gateway pod's persistent storage. The `none` type tells the proxy to allow traffic to these domains without injecting any credentials.
+
+After deploying, enable WhatsApp inside OpenClaw:
+
+1. Open the OpenClaw Control UI
+2. Enable the WhatsApp plugin (`openclaw plugins install @openclaw/whatsapp`)
+3. Run `openclaw channels login --channel whatsapp` to get a QR code
+4. Scan the QR code with your phone (WhatsApp → Linked Devices)

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -52,3 +52,96 @@ data:
     # OpenClaw Assistant
 
     You are a helpful AI assistant running in OpenShift.
+  PROXY_SETUP.md: |
+    ---
+    name: proxy-setup
+    description: "Network proxy architecture and how to configure access to external services like WhatsApp."
+    ---
+
+    # Proxy Architecture
+
+    You are running in an OpenShift cluster behind a credential-injecting MITM proxy.
+    All outbound traffic from this pod goes through the proxy via `HTTP_PROXY`/`HTTPS_PROXY`
+    environment variables. The proxy blocks any domain that is not explicitly configured.
+
+    LLM provider credentials (API keys, OAuth tokens, GCP service account tokens) are
+    injected by the proxy — you never see real secrets. For non-LLM services that need
+    network access without credential injection, the proxy can allowlist domains using
+    `type: none` credential entries.
+
+    ## When the user wants to integrate with an external service
+
+    If a service is not working or the user asks to enable a new integration, the most
+    likely cause is that the proxy is blocking the required domains. Tell the user they
+    need to update their Claw custom resource to add the appropriate credential entries.
+
+    **Important:** Each `oc apply` of the Claw CR **replaces** the entire `credentials`
+    list. The user must include all existing credentials when applying — otherwise they
+    will be removed.
+
+    Walk the user through these steps:
+
+    1. Retrieve the current Claw instance:
+
+    ```sh
+    oc get claw instance -n <namespace> -o yaml
+    ```
+
+    The output will look something like this (the `credentials` list varies):
+
+    ```yaml
+    apiVersion: claw.sandbox.redhat.com/v1alpha1
+    kind: Claw
+    metadata:
+      name: instance
+    spec:
+      credentials:
+        - name: gemini
+          type: apiKey
+          secretRef:
+            name: gemini-api-key
+            key: api-key
+          provider: google
+    ```
+
+    2. Add the new credential entries to the existing `credentials` list (see known
+    integrations below for the exact entries needed).
+
+    3. Apply the updated CR:
+
+    ```sh
+    oc apply -n <namespace> -f updated-claw.yaml
+    ```
+
+    ## Known integrations
+
+    ### WhatsApp
+
+    WhatsApp Web uses phone-based QR pairing (not API keys). The proxy only needs to
+    allowlist the domains — no credential injection is required.
+
+    Add these entries to the `credentials` list:
+
+    ```yaml
+        - name: whatsapp
+          type: none
+          domain: ".whatsapp.com"
+        - name: whatsapp-net
+          type: none
+          domain: ".whatsapp.net"
+    ```
+
+    After the user updates the Claw CR, the remaining steps are:
+    1. Install the WhatsApp plugin: `openclaw plugins install @openclaw/whatsapp`
+    2. Link the device: `openclaw channels login --channel whatsapp`
+    3. Scan the QR code with their phone (WhatsApp → Linked Devices)
+
+    ## Custom domains
+
+    For any other external service, the user can add a `type: none` entry with the
+    appropriate `domain`. A leading dot (e.g., `.example.com`) matches all subdomains.
+    An exact domain (e.g., `api.example.com`) matches only that host.
+
+    If the service requires credential injection (API key, bearer token), use the
+    corresponding credential type (`apiKey`, `bearer`, `oauth2`, `pathToken`) with a
+    `secretRef` pointing to a Kubernetes Secret containing the credential.

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -76,6 +76,8 @@ spec:
               mkdir -p /home/node/.openclaw/workspace /home/node/.openclaw/.local /home/node/.openclaw/.cache /home/node/.openclaw/.config/codex
               [ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
               [ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+              mkdir -p /home/node/.openclaw/workspace/skills/proxy
+              cp /config/PROXY_SETUP.md /home/node/.openclaw/workspace/skills/proxy/SKILL.md
               if [ -f /config/KUBERNETES.md ]; then
                 mkdir -p /home/node/.openclaw/workspace/skills/kubernetes
                 cp /config/KUBERNETES.md /home/node/.openclaw/workspace/skills/kubernetes/SKILL.md

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -187,6 +187,30 @@ func TestClawConfigMapController(t *testing.T) {
 			assert.Contains(t, agentsMd, "OpenClaw Assistant")
 		})
 
+		t.Run("should have PROXY_SETUP.md skill content", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			configMap := &corev1.ConfigMap{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{
+					Name:      ClawConfigMapName,
+					Namespace: namespace,
+				}, configMap) == nil
+			}, "ConfigMap should be created")
+
+			proxyMd, ok := configMap.Data["PROXY_SETUP.md"]
+			assert.True(t, ok, "PROXY_SETUP.md key must exist")
+			assert.Contains(t, proxyMd, "Proxy Architecture")
+			assert.Contains(t, proxyMd, "type: none")
+			assert.Contains(t, proxyMd, ".whatsapp.com")
+		})
+
 		t.Run("should not have KUBERNETES.md when no kubernetes credentials", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
@@ -918,6 +942,8 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 				"openclaw.json should only be seeded if missing")
 			assert.Contains(t, initConfigScript, "[ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp",
 				"AGENTS.md should only be seeded if missing")
+			assert.Contains(t, initConfigScript, "cp /config/PROXY_SETUP.md /home/node/.openclaw/workspace/skills/proxy/SKILL.md",
+				"PROXY_SETUP.md should always be copied to proxy skill directory")
 			assert.Contains(t, initConfigScript, "if [ -f /config/KUBERNETES.md ]",
 				"KUBERNETES.md should be copied only when present in ConfigMap")
 		})

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -209,6 +209,7 @@ func TestClawConfigMapController(t *testing.T) {
 			assert.Contains(t, proxyMd, "Proxy Architecture")
 			assert.Contains(t, proxyMd, "type: none")
 			assert.Contains(t, proxyMd, ".whatsapp.com")
+			assert.Contains(t, proxyMd, ".whatsapp.net")
 		})
 
 		t.Run("should not have KUBERNETES.md when no kubernetes credentials", func(t *testing.T) {


### PR DESCRIPTION
- Add WhatsApp section to docs/provider-setup.md with Claw CR example using type: none credentials for .whatsapp.com and .whatsapp.net
- Add PROXY_SETUP.md skill to claw-config ConfigMap explaining proxy architecture and how to configure external service access
- Init container copies skill to skills/proxy/SKILL.md for OpenClaw auto-discovery (always present, unlike conditional kubernetes skill)
- Add proposal for future proxy-managed credential injection for Telegram, Discord, and Slack messaging channels



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added WhatsApp integration setup for linked-device sessions and QR login
  * Published proxy operation and credential configuration guide (included in the generated config bundle)
  * Introduced a credential-injection proposal for messaging platforms (Telegram/Discord/Slack) detailing token injection types and testing tasks

* **Tests**
  * Extended test coverage to validate proxy setup documentation and config inclusion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->