### PR TITLE
docs: add Meta domains to WhatsApp proxy allowlist guide

### DIFF
--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -118,7 +118,8 @@ data:
     ### WhatsApp
 
     WhatsApp Web uses phone-based QR pairing (not API keys). The proxy only needs to
-    allowlist the domains — no credential injection is required.
+    allowlist the domains — no credential injection is required. Beyond `*.whatsapp.*`,
+    WhatsApp Web also relies on Meta's authentication and CDN infrastructure.
 
     Add these entries to the `credentials` list:
 
@@ -129,6 +130,15 @@ data:
         - name: whatsapp-net
           type: none
           domain: ".whatsapp.net"
+        - name: facebook
+          type: none
+          domain: ".facebook.com"
+        - name: facebook-net
+          type: none
+          domain: ".facebook.net"
+        - name: fbcdn
+          type: none
+          domain: ".fbcdn.net"
     ```
 
     After the user updates the Claw CR, the remaining steps are:


### PR DESCRIPTION
- Include .facebook.com, .facebook.net, .fbcdn.net in example credentials
- Note WhatsApp Web's dependency on Meta auth and CDN infrastructure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WhatsApp integration network configuration documentation with expanded allowlist requirements for Meta-related domains, including authentication and CDN infrastructure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->