### PR TITLE
refactor(controller): modernize Go code with slices, maps, and cmp packages

### DIFF
--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -18,11 +18,13 @@ package controller
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -663,13 +665,9 @@ func (r *ClawResourceReconciler) buildKustomizedObjects(instance *clawv1alpha1.C
 	}
 
 	// Write all files to in-memory filesystem
-	allManifests := make(map[string][]byte)
-	for k, v := range clawManifests {
-		allManifests[k] = v
-	}
-	for k, v := range proxyManifests {
-		allManifests[k] = v
-	}
+	allManifests := make(map[string][]byte, len(clawManifests)+len(proxyManifests))
+	maps.Copy(allManifests, clawManifests)
+	maps.Copy(allManifests, proxyManifests)
 
 	for path, content := range allManifests {
 		replaced := bytes.ReplaceAll(content, []byte("CLAW_INSTANCE_NAME"), []byte(instance.Name))
@@ -920,7 +918,7 @@ func injectKubePortsIntoNetworkPolicy(objects []*unstructured.Unstructured, reso
 			}
 			sortedPorts = append(sortedPorts, portInt)
 		}
-		sort.Ints(sortedPorts)
+		slices.Sort(sortedPorts)
 
 		for _, portInt := range sortedPorts {
 			ports = append(ports, map[string]any{
@@ -956,8 +954,8 @@ func injectKubernetesSkill(objects []*unstructured.Unstructured, resolvedCreds [
 		return nil
 	}
 
-	sort.Slice(allContexts, func(i, j int) bool {
-		return allContexts[i].Name < allContexts[j].Name
+	slices.SortFunc(allContexts, func(a, b kubeconfigContext) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	var sb strings.Builder
@@ -1016,8 +1014,7 @@ func readEmbeddedFile(path string) []byte {
 func parseYAMLToObjects(yamlData []byte) ([]*unstructured.Unstructured, error) {
 	var objects []*unstructured.Unstructured
 	// Split YAML documents by separator
-	docs := bytes.Split(yamlData, []byte("\n---\n"))
-	for _, doc := range docs {
+	for doc := range bytes.SplitSeq(yamlData, []byte("\n---\n")) {
 		doc = bytes.TrimSpace(doc)
 		if len(doc) == 0 {
 			continue


### PR DESCRIPTION
Replace legacy `sort` package usage with modern Go 1.21+ alternatives:
- Use `slices.Sort()` instead of `sort.Ints()`
- Use `slices.SortFunc()` with `cmp.Compare()` instead of `sort.Slice()`
- Use `bytes.SplitSeq()` instead of `bytes.Split()` for iterator-based splitting
- Use `maps.Copy()` for merging manifest maps with preallocated capacity

These changes improve type safety, memory efficiency, and code readability
while leveraging modern Go stdlib features available in Go 1.25.

Assisted-by: Claude Sonnet 4.5
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal resource controller with improved algorithms and memory management techniques for enhanced efficiency in operations including manifest processing, port ordering, and YAML parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->