### PR TITLE
refactor(controller): modernize route host injection with JSON parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ The operator uses a **single unified controller** that manages all resources usi
 - Creates gateway Secret (`claw-gateway-token`) with randomly-generated authentication token
 - Validates user-provided credentials (array of CredentialSpec in CR's `credentials` field) and referenced Secrets
 - Creates all resources: PVC, ConfigMap, Deployment, Services (2), NetworkPolicies (3: egress for claw, egress for proxy, ingress for gateway), proxy Deployment/ConfigMap, and Route (OpenShift only)
-- Uses **three-phase reconciliation** to dynamically inject Route host into ConfigMap for CORS configuration
+- Uses **three-phase reconciliation** to dynamically inject Route hosts (gateway and console) into ConfigMap for CORS configuration
 - Uses server-side apply for idempotent, conflict-free resource management
 - Automatically labels all resources with `app.kubernetes.io/name: claw`
 - Gracefully skips resources whose CRDs aren't registered (e.g., Route on vanilla Kubernetes)
@@ -131,10 +131,10 @@ The operator uses a **single unified controller** that manages all resources usi
 
 **Key benefits:**
 - Simplified codebase: 1 controller managing all resources
-- Dynamic CORS configuration: Route host automatically injected into ConfigMap at deployment time
+- Dynamic CORS configuration: Gateway and console Route hosts automatically injected into ConfigMap at deployment time
 - Field ownership: server-side apply tracks which controller owns which fields
 - Consistent labeling: queryable with `kubectl get all -l app.kubernetes.io/name=claw`
-- Graceful fallback: localhost CORS origin on vanilla Kubernetes (no Route CRD)
+- Graceful fallback: localhost CORS origin on vanilla Kubernetes (no Route CRD); console route is optional (graceful degradation)
 - Future-proof: adding new resources only requires updating kustomization.yaml
 
 ### Config layering via $include
@@ -206,12 +206,20 @@ PHASE 2: Route Application and Host Resolution
    ├─ Set namespace and owner reference
    └─ Server-side apply Route (skips with NoMatchError on vanilla Kubernetes)
   ↓
-5. getRouteURL(ctx, instance)
+5. getRouteURL(ctx, instance) — Fetch gateway route host
    ├─ Fetch Route resource
    ├─ Extract .status.ingress[0].host (authoritative source populated by OpenShift router)
    ├─ If status not yet populated: requeue with 5s backoff
    ├─ If Route CRD not registered: continue with empty routeHost (localhost fallback)
    └─ Return https://<route-host> or empty string
+  ↓
+5b. getRouteHost(ctx, namespace, "claw-console") — Fetch console route host
+   ├─ Check if claw-console Route exists
+   ├─ If NotFound: log warning and continue without console route (graceful degradation)
+   ├─ If exists: fetch .status.ingress[0].host
+   ├─ If status not yet populated: requeue with 5s backoff
+   ├─ If Route CRD not registered: skip console route
+   └─ Return https://<console-host> or empty string
   ↓
 PHASE 3: ConfigMap Injection and Remaining Resources
 6. buildKustomizedObjects(ctx, instance)
@@ -240,11 +248,13 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    │  └─ This triggers pod restarts when Secret data changes (ResourceVersion updates), not just Secret reference changes
    └─ Return parsed objects
   ↓
-7. injectRouteHostIntoConfigMap(objects, routeHost)
+7. injectRouteHostsIntoConfigMap(objects, routeHost, consoleRouteHost)
    ├─ Find claw-config ConfigMap in objects
    ├─ Extract data["operator.json"] string
    ├─ Replace "OPENCLAW_ROUTE_HOST" placeholder with routeHost (https://...)
-   ├─ If routeHost is empty (vanilla Kubernetes): use "http://localhost:18789" fallback
+   ├─ Replace "OPENCLAW_CONSOLE_ROUTE_HOST" placeholder with consoleRouteHost (https://...)
+   ├─ If consoleRouteHost is empty: remove placeholder from allowedOrigins array
+   ├─ If routeHost is empty (vanilla Kubernetes): use "http://localhost:18789" fallback for gateway
    └─ Set modified JSON back into ConfigMap
   ↓
 7b. injectProvidersIntoConfigMap(objects, instance.Spec.Credentials)
@@ -285,14 +295,16 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 ```
 
 **Route Status Polling:**
-- If Route is applied but `.status.ingress[0].host` is not yet populated, reconciliation requeues with 5-second backoff
+- If gateway Route is applied but `.status.ingress[0].host` is not yet populated, reconciliation requeues with 5-second backoff
+- If console Route (`claw-console`) exists but status is not yet populated, reconciliation requeues with 5-second backoff
+- If console Route does not exist (NotFound), reconciliation continues without it (graceful degradation)
 - OpenShift router typically populates Route status within 5-10 seconds
-- Indefinite requeue: cluster-level Route issues should be diagnosed via `kubectl describe route claw`
+- Indefinite requeue: cluster-level Route issues should be diagnosed via `kubectl describe route claw` or `kubectl describe route claw-console`
 
 **Vanilla Kubernetes Fallback:**
 - On clusters without Route CRD (vanilla Kubernetes), Route application fails with `meta.IsNoMatchError`
 - Controller logs "Route CRD not registered, using localhost fallback for CORS"
-- ConfigMap receives `http://localhost:18789` as `allowedOrigins` value
+- ConfigMap receives `http://localhost:18789` as the gateway `allowedOrigins` value (no console route)
 - Control UI accessible via port-forward: `kubectl port-forward svc/claw 18789:18789`
 
 **Key methods:**
@@ -300,9 +312,10 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `generateGatewayToken()` — generates cryptographically secure 64-char hex token using crypto/rand
 - `applyGatewaySecret()` — creates/updates claw-gateway-token Secret with gateway token (preserves existing token)
 - `applyRouteOnly()` — applies only Route resource from Kustomize manifests (Phase 2)
-- `getRouteURL()` — fetches Route and extracts `.status.ingress[0].host`, returns empty string if status not populated
+- `getRouteHost()` — fetches a Route by name and returns its hostname, or empty string if not ready (handles NotFound, NoMatchError, and unpopulated status gracefully)
+- `getRouteURL()` — fetches Route and returns the HTTPS URL (calls `getRouteHost()` and prepends `https://`)
 - `buildKustomizedObjects()` — builds Kustomize manifests, configures proxy deployment, stamps Secret version, returns parsed objects
-- `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in `operator.json` with Route host (or localhost fallback)
+- `injectRouteHostsIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` and `OPENCLAW_CONSOLE_ROUTE_HOST` placeholders in `operator.json` with Route hosts. Filters out empty console route. Uses localhost fallback for gateway on vanilla Kubernetes
 - `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `operator.json`. Gateway-routed providers get a baseUrl through the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since MITM proxy handles credential injection transparently. Does not touch agent defaults (user-owned in openclaw.json seed)
 - `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA
 - `resolveCredentials()` — validates all credentials and referenced Secrets. For `kubernetes` type, parses kubeconfig with `client-go/tools/clientcmd`, validates token-only auth, extracts cluster/context metadata. Returns `[]resolvedCredential` (replaces former `validateCredentials`)
@@ -315,7 +328,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `usesVertexSDK()` — returns true when a credential should use the native Vertex AI SDK (type == gcp && provider != "" && provider != "google")
 - `configureClawDeploymentForVertex()` — adds GOOGLE_APPLICATION_CREDENTIALS, ANTHROPIC_VERTEX_PROJECT_ID env vars and stub ADC volume mount to the claw deployment when Vertex SDK credentials exist
 - `configureClawDeploymentForKubernetes()` — when kubernetes credentials exist: mounts the sanitized kubeconfig ConfigMap (`claw-kube-config`) at `/etc/kube/`, sets `KUBECONFIG=/etc/kube/config` and `PATH` env vars, adds an `init-kubectl` init container that copies kubectl from the configured image into a shared emptyDir volume mounted at `/opt/kube-tools`
-- `injectKubePortsIntoNetworkPolicy()` — adds non-443 ports from kubeconfig cluster server URLs to the `claw-proxy-egress` NetworkPolicy. In-memory patching before apply, same pattern as `injectRouteHostIntoConfigMap`
+- `injectKubePortsIntoNetworkPolicy()` — adds non-443 ports from kubeconfig cluster server URLs to the `claw-proxy-egress` NetworkPolicy. In-memory patching before apply, same pattern as `injectRouteHostsIntoConfigMap`
 - `injectKubernetesSkill()` — writes a `KUBERNETES.md` key into the `claw-config` ConfigMap with OpenClaw skill frontmatter listing available contexts, clusters, namespaces, and current-context. Init container copies to `skills/kubernetes/SKILL.md` for auto-discovery
 - `applyVertexADCConfigMap()` — creates/updates the stub ADC ConfigMap (claw-vertex-adc) with dummy authorized_user credentials for Vertex SDK token refresh bootstrap. Only created when Vertex SDK credentials exist
 - `applyProxyResources()` — generates proxy config, applies proxy ConfigMap and Vertex ADC ConfigMap. Returns proxy config JSON for hash stamping

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: claw
 data:
+  # The controller dynamically sets gateway.controlUi.allowedOrigins at runtime
+  # based on Route URLs (OpenShift) or localhost fallback (vanilla Kubernetes)
   operator.json: |
     {
       "gateway": {
@@ -16,7 +18,7 @@ data:
         },
         "controlUi": {
           "enabled": true,
-          "allowedOrigins": ["OPENCLAW_ROUTE_HOST"]
+          "allowedOrigins": []
         },
         "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12"]
       },

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -382,14 +382,12 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			logger.Info("Claw resource not found, ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
-		logger.Error(err, "Failed to get Claw")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get Claw: %w", err)
 	}
 
 	// Create or update the gateway Secret with token
 	if err := r.applyGatewaySecret(ctx, instance); err != nil {
-		logger.Error(err, "Failed to apply gateway secret")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to apply gateway secret: %w", err)
 	}
 
 	// Resolve credentials (provider defaults, validation, kubeconfig parsing)
@@ -427,34 +425,32 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Apply Route and wait for ingress host to be populated
-	var routeHost string
-	var routeApplied int
-	routeApplied, err = r.applyRouteOnly(ctx, objects, instance)
-	if err != nil {
+	var gatewayHost string
+	var consoleHost string
+	if routesApplied, err := r.applyRoutesOnly(ctx, objects, instance); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to apply Route: %w", err)
-	}
-
-	// Only try to fetch Route URL if Route was actually applied (CRD available)
-	if routeApplied > 0 {
-		routeHost, err = r.getRouteURL(ctx, instance)
+	} else if !routesApplied {
+		logger.Info("Routes not applied (CRD is missing)")
+	} else {
+		var err error
+		gatewayHost, err = r.getGatewayRouteURL(ctx, instance)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get Route URL: %w", err)
+			return ctrl.Result{}, fmt.Errorf("failed to get Gateway Route URL: %w", err)
 		}
-		if routeHost == "" {
+		if gatewayHost == "" {
 			// Route exists but status not yet populated - requeue
 			logger.Info("Route exists but status not populated, requeuing")
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 		}
-	} else {
-		// Route CRD not registered - proceed with localhost fallback
-		logger.Info("Route CRD not registered, using localhost fallback for CORS")
+		// assume that the console route is available (ie, if not, the controller will log a warning and continue without it)
+		consoleHost = r.getConsoleRouteURL(ctx, instance)
 	}
 
 	// Phase 3: Inject Route host into ConfigMap and apply remaining resources
 
-	// Inject Route host into ConfigMap
-	if err := r.injectRouteHostIntoConfigMap(objects, routeHost, instance.Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject Route host into ConfigMap: %w", err)
+	// Inject Route hosts into ConfigMap
+	if err := r.injectRouteHostsIntoConfigMap(instance.Name, objects, gatewayHost, consoleHost); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to inject Route hosts into ConfigMap: %w", err)
 	}
 
 	// Inject LLM providers into ConfigMap based on credentials with Provider set
@@ -722,12 +718,12 @@ func (r *ClawResourceReconciler) applyResources(ctx context.Context, objects []*
 	return appliedCount, nil
 }
 
-// applyRouteOnly applies only the Route resource from provided objects
+// applyRoutesOnly applies only the Route resources from provided objects
 // Returns number of routes applied (0 if CRD not registered)
-func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw) (int, error) {
+func (r *ClawResourceReconciler) applyRoutesOnly(ctx context.Context, objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw) (bool, error) {
 	// Handle empty objects safely (len() on nil slice returns 0)
 	if len(objects) == 0 {
-		return 0, nil
+		return false, nil
 	}
 
 	// Filter for Route only
@@ -742,20 +738,31 @@ func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*
 	for _, obj := range routeObjects {
 		obj.SetNamespace(instance.Namespace)
 		if err := controllerutil.SetControllerReference(instance, obj, r.Scheme); err != nil {
-			return 0, fmt.Errorf("failed to set controller reference: %w", err)
+			return false, fmt.Errorf("failed to set controller reference: %w", err)
 		}
 	}
 
 	// Apply Route and return count
-	return r.applyResources(ctx, routeObjects)
+	appliedCount, err := r.applyResources(ctx, routeObjects)
+	return appliedCount > 0, err
 }
 
-// injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator.json with actual Route host.
-// If routeHost is empty (vanilla Kubernetes), uses localhost fallback.
-func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstructured.Unstructured, routeHost, instanceName string) error {
-	replacement := routeHost
-	if replacement == "" {
-		replacement = "http://localhost:18789"
+// injectRouteHostsIntoConfigMap sets the gateway.controlUi.allowedOrigins array in operator.json
+// to the provided gateway and console URLs. Empty URLs are filtered out. If both URLs are empty,
+// uses localhost fallback for vanilla Kubernetes deployments.
+func (r *ClawResourceReconciler) injectRouteHostsIntoConfigMap(instanceName string, objects []*unstructured.Unstructured, gatewayURL, consoleURL string) error {
+	// Build list of valid routes
+	validRoutes := make([]string, 0, 2)
+	if gatewayURL != "" {
+		validRoutes = append(validRoutes, gatewayURL)
+	}
+	if consoleURL != "" {
+		validRoutes = append(validRoutes, consoleURL)
+	}
+
+	// On vanilla Kubernetes (no routes), use localhost fallback
+	if len(validRoutes) == 0 {
+		validRoutes = []string{"http://localhost:18789"}
 	}
 
 	configMapName := getConfigMapName(instanceName)
@@ -769,9 +776,24 @@ func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstruc
 				return fmt.Errorf("operator.json not found in ConfigMap data")
 			}
 
-			updatedJSON := strings.ReplaceAll(operatorJSON, "OPENCLAW_ROUTE_HOST", replacement)
+			// Update allowedOrigins in operator.json
+			var config map[string]any
+			if err := json.Unmarshal([]byte(operatorJSON), &config); err != nil {
+				return fmt.Errorf("failed to parse operator.json: %w", err)
+			}
 
-			if err := unstructured.SetNestedField(obj.Object, updatedJSON, "data", "operator.json"); err != nil {
+			// Set gateway.controlUi.allowedOrigins
+			if err := unstructured.SetNestedStringSlice(config, validRoutes, "gateway", "controlUi", "allowedOrigins"); err != nil {
+				return fmt.Errorf("failed to set allowedOrigins: %w", err)
+			}
+
+			// Marshal back with indentation
+			updatedJSON, err := json.MarshalIndent(config, "    ", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal operator.json: %w", err)
+			}
+
+			if err := unstructured.SetNestedField(obj.Object, string(updatedJSON), "data", "operator.json"); err != nil {
 				return fmt.Errorf("failed to set updated operator.json in ConfigMap: %w", err)
 			}
 

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -716,22 +716,30 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 				Scheme: scheme.Scheme,
 			}
 
-			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
-			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, routeHost, "")
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
 
 			operatorJSON, found, err := unstructured.NestedString(configMap.Object, "data", "operator.json")
 			require.NoError(t, err, "failed to get operator.json")
 			assert.True(t, found, "operator.json not found in ConfigMap data")
-			assert.Contains(t, operatorJSON, routeHost)
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+
+			// Parse JSON and verify allowedOrigins contains the route
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.Contains(t, allowedOrigins, routeHost)
 		})
 
-		t.Run("should replace all occurrences of OPENCLAW_ROUTE_HOST placeholder", func(t *testing.T) {
+		t.Run("should set allowedOrigins array with single route", func(t *testing.T) {
 			configMap := &unstructured.Unstructured{}
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(getConfigMapName(testInstanceName))
 			configMap.Object["data"] = map[string]any{
-				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST","OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":[]}}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -742,37 +750,140 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 				Scheme: scheme.Scheme,
 			}
 
-			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
-			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, routeHost, "")
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
 
 			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
-			hostCount := strings.Count(operatorJSON, routeHost)
-			assert.Equal(t, 2, hostCount, "expected 2 occurrences of routeHost")
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.Equal(t, []string{routeHost}, allowedOrigins)
 		})
 
-		t.Run("should use localhost fallback when routeHost is empty", func(t *testing.T) {
+		t.Run("should use localhost fallback when no routes provided", func(t *testing.T) {
 			configMap := &unstructured.Unstructured{}
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(getConfigMapName(testInstanceName))
 			configMap.Object["data"] = map[string]any{
-				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":[]}}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
-			routeHost := ""
 
 			reconciler := &ClawResourceReconciler{
 				Client: k8sClient,
 				Scheme: scheme.Scheme,
 			}
 
-			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
-			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, "", "")
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
 
 			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
-			assert.Contains(t, operatorJSON, "http://localhost:18789")
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.Equal(t, []string{"http://localhost:18789"}, allowedOrigins)
+		})
+
+		t.Run("should include both gateway and console route hosts in allowedOrigins", func(t *testing.T) {
+			configMap := &unstructured.Unstructured{}
+			configMap.SetKind(ConfigMapKind)
+			configMap.SetName(getConfigMapName(testInstanceName))
+			configMap.Object["data"] = map[string]any{
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":[]}}}`,
+			}
+
+			objects := []*unstructured.Unstructured{configMap}
+			routeHost := "https://claw-gateway.apps.cluster.com"
+			consoleRouteHost := "https://claw-console.apps.cluster.com"
+
+			reconciler := &ClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, routeHost, consoleRouteHost)
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
+
+			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.ElementsMatch(t, []string{routeHost, consoleRouteHost}, allowedOrigins)
+		})
+
+		t.Run("should include only gateway route when console route is empty", func(t *testing.T) {
+			configMap := &unstructured.Unstructured{}
+			configMap.SetKind(ConfigMapKind)
+			configMap.SetName(getConfigMapName(testInstanceName))
+			configMap.Object["data"] = map[string]any{
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":[]}}}`,
+			}
+
+			objects := []*unstructured.Unstructured{configMap}
+			routeHost := "https://claw-gateway.apps.cluster.com"
+			consoleRouteHost := "" // Console route not available
+
+			reconciler := &ClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, routeHost, consoleRouteHost)
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
+
+			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.Equal(t, []string{routeHost}, allowedOrigins, "should only include gateway route")
+		})
+
+		t.Run("should use localhost fallback when all routes are empty (vanilla Kubernetes)", func(t *testing.T) {
+			configMap := &unstructured.Unstructured{}
+			configMap.SetKind(ConfigMapKind)
+			configMap.SetName(getConfigMapName(testInstanceName))
+			configMap.Object["data"] = map[string]any{
+				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":[]}}}`,
+			}
+
+			objects := []*unstructured.Unstructured{configMap}
+			routeHost := ""
+			consoleRouteHost := ""
+
+			reconciler := &ClawResourceReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			err := reconciler.injectRouteHostsIntoConfigMap(testInstanceName, objects, routeHost, consoleRouteHost)
+			require.NoError(t, err, "injectRouteHostsIntoConfigMap failed")
+
+			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
+			var config map[string]any
+			err = json.Unmarshal([]byte(operatorJSON), &config)
+			require.NoError(t, err, "failed to parse operator.json")
+
+			allowedOrigins, found, err := unstructured.NestedStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+			require.NoError(t, err, "failed to get allowedOrigins")
+			assert.True(t, found, "allowedOrigins not found")
+			assert.Equal(t, []string{"http://localhost:18789"}, allowedOrigins)
 		})
 	})
 

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -84,10 +84,13 @@ func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, name
 	return len(pending) == 0, pending, nil
 }
 
-// getRouteURL fetches the Route and returns the HTTPS URL, or empty string if not found
-func (r *ClawResourceReconciler) getRouteURL(ctx context.Context, instance *clawv1alpha1.Claw) (string, error) {
+// getRouteHost fetches a Route by name and returns its hostname, or empty string if not ready.
+// Returns empty string (not error) when:
+// - Route not found (NotFound error)
+// - Route CRD not registered (NoMatchError)
+// - Route exists but status not yet populated by OpenShift router
+func (r *ClawResourceReconciler) getRouteHost(ctx context.Context, namespace, routeName string) (string, error) {
 	logger := log.FromContext(ctx)
-	routeName := getRouteName(instance.Name)
 
 	// Create an unstructured object to fetch the Route (OpenShift-specific resource)
 	route := &unstructured.Unstructured{}
@@ -98,7 +101,7 @@ func (r *ClawResourceReconciler) getRouteURL(ctx context.Context, instance *claw
 	})
 
 	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: instance.Namespace,
+		Namespace: namespace,
 		Name:      routeName,
 	}, route); err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
@@ -134,7 +137,36 @@ func (r *ClawResourceReconciler) getRouteURL(ctx context.Context, instance *claw
 		return "", nil
 	}
 
+	return host, nil
+}
+
+// getGatewayRouteURL fetches the Route and returns the HTTPS URL, or
+// - an error if the Route cannot be fetched.
+// - empty string if the host has not been set yet (ie, when the Route is not ready)
+func (r *ClawResourceReconciler) getGatewayRouteURL(ctx context.Context, instance *clawv1alpha1.Claw) (string, error) {
+	routeName := getRouteName(instance.Name)
+	host, err := r.getRouteHost(ctx, instance.Namespace, routeName)
+	if err != nil {
+		return "", err
+	}
+	if host == "" {
+		return "", nil
+	}
 	return "https://" + host, nil
+}
+
+// getConsoleRouteURL fetches the Route and returns the HTTPS URL, or
+// - empty string if the route does not exist or if the host has not been set yet (ie, when the Route is not ready).
+func (r *ClawResourceReconciler) getConsoleRouteURL(ctx context.Context, instance *clawv1alpha1.Claw) string {
+	routeName := getRouteName("claw-console")
+	host, err := r.getRouteHost(ctx, instance.Namespace, routeName)
+	if err != nil {
+		return "" // log error and continue without console route
+	}
+	if host == "" {
+		return "" // log error and continue without console route
+	}
+	return "https://" + host
 }
 
 // setCondition is a generic helper to set a condition on the Claw instance.
@@ -237,7 +269,7 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 
 	// Populate URL field only when both deployments are ready
 	if ready {
-		routeURL, err := r.getRouteURL(ctx, instance)
+		routeURL, err := r.getGatewayRouteURL(ctx, instance)
 		if err != nil {
 			return fmt.Errorf("failed to get Route URL: %w", err)
 		}

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/design.md
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/design.md
@@ -1,0 +1,133 @@
+## Context
+
+The Claw operator currently uses a three-phase reconciliation approach to dynamically inject the gateway route host into the ConfigMap's `allowedOrigins` field. The existing implementation:
+
+1. Applies the Route resource
+2. Polls Route status for `.status.ingress[0].host`
+3. Injects the host into the ConfigMap by replacing the `OPENCLAW_ROUTE_HOST` placeholder
+
+This works for the single gateway route but needs to be extended to support a second route (`claw-console`) for the console UI. The console may be hosted on a different domain than the gateway, requiring both origins to be allowed for CORS.
+
+**Current flow:**
+- `applyRouteOnly()` applies the Route
+- `getRouteURL()` fetches and returns the route host
+- `injectRouteHostIntoConfigMap()` replaces the placeholder with the actual host
+
+**Constraints:**
+- Must maintain backward compatibility with single-route deployments
+- Must gracefully handle vanilla Kubernetes (no Route CRD)
+- Must not break existing placeholder replacement logic
+- Must preserve three-phase reconciliation pattern
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fetch both `claw` and `claw-console` route hosts during reconciliation
+- Include both hosts in the ConfigMap's `allowedOrigins` array
+- Maintain fallback behavior for vanilla Kubernetes clusters
+- Use the same polling/requeue pattern for both routes
+
+**Non-Goals:**
+- Supporting more than two routes (not needed for current use case)
+- Making route names configurable (fixed convention)
+- Changing the Route CRD structure or OpenShift routing behavior
+- Modifying the three-phase reconciliation pattern
+
+## Decisions
+
+### Decision 1: Fetch console route in the same phase as gateway route
+
+**Rationale:**
+Both routes need to be resolved before ConfigMap injection (Phase 3). Fetching them sequentially in Phase 2 keeps the reconciliation logic clean and avoids multiple ConfigMap updates.
+
+**Implementation:**
+- Extract route fetching logic into a reusable helper `getRouteHost(ctx, namespace, routeName)`
+- Call it twice in Phase 2: once for `claw` route, once for `claw-console` route
+- If either route status is unpopulated, requeue with 5s backoff (same as current behavior)
+
+**Alternatives considered:**
+- Fetch routes in parallel: Adds complexity with no meaningful performance benefit (both are cheap API calls)
+- Fetch console route in a separate phase: Would require four phases instead of three, adding unnecessary complexity
+
+### Decision 2: Use two placeholders in the ConfigMap template
+
+**Rationale:**
+Having distinct placeholders (`OPENCLAW_ROUTE_HOST` and `OPENCLAW_CONSOLE_ROUTE_HOST`) makes the template explicit and avoids array manipulation during injection.
+
+**Implementation:**
+```json
+"allowedOrigins": ["OPENCLAW_ROUTE_HOST", "OPENCLAW_CONSOLE_ROUTE_HOST"]
+```
+
+During injection, replace both placeholders with actual hosts. On vanilla Kubernetes, replace both with `http://localhost:18789`.
+
+**Alternatives considered:**
+- Single placeholder with array string: Would require JSON parsing/manipulation, more error-prone
+- Dynamically append to array: Would require parsing the JSON structure, more complex than string replacement
+- Conditional inclusion: Would require template logic, violates the simple string replacement pattern
+
+### Decision 3: Console route is optional (graceful degradation)
+
+**Rationale:**
+The console route may not exist in all deployments. The operator should not fail reconciliation if only the gateway route exists.
+
+**Implementation:**
+- If `claw-console` route fetch returns `NotFound`, log a warning and set placeholder to empty string
+- During ConfigMap injection, filter out empty strings from the allowedOrigins array
+- This allows single-route deployments to work without changes
+
+**Alternatives considered:**
+- Make console route mandatory: Would break existing deployments that only have the gateway route
+- Use the gateway route as fallback: Misleading, better to be explicit about missing routes
+- Skip placeholder for missing routes: Would require conditional template logic, breaks simple replacement pattern
+
+### Decision 4: Reuse existing Route polling pattern
+
+**Rationale:**
+The existing `getRouteURL()` pattern (fetch, check status, requeue if unpopulated) is proven and handles OpenShift router timing correctly.
+
+**Implementation:**
+- Rename `getRouteURL()` to `getRouteHost()` and add a `routeName` parameter
+- Call it for both `claw` and `claw-console` routes
+- Requeue if either returns empty string (status not ready)
+
+**Alternatives considered:**
+- Poll both routes in a single function: Would hide which route is causing the requeue
+- Use different requeue intervals: No benefit, both routes populate in the same timeframe
+- Skip polling for console route: Would cause race conditions if console route status is slower than gateway
+
+## Risks / Trade-offs
+
+**[Risk] Console route status may lag behind gateway route**
+→ **Mitigation:** Requeue on either route being unpopulated ensures both are ready before ConfigMap injection
+
+**[Risk] Empty allowedOrigins if both routes missing**
+→ **Mitigation:** Vanilla Kubernetes fallback (`http://localhost:18789`) provides a working origin for port-forwarding
+
+**[Risk] Breaking existing deployments with only gateway route**
+→ **Mitigation:** Console route is optional; missing route degrades gracefully by excluding it from allowedOrigins
+
+**[Trade-off] Two placeholders vs. dynamic array construction**
+→ **Chosen:** Two placeholders for simplicity. **Cost:** Less flexible if more routes are added in the future. **Benefit:** Keeps string replacement pattern, no JSON parsing required.
+
+**[Trade-off] Both routes in same reconciliation phase vs. separate phases**
+→ **Chosen:** Same phase. **Cost:** Cannot proceed if either route fails. **Benefit:** ConfigMap gets both origins atomically, no intermediate state with partial CORS config.
+
+## Migration Plan
+
+**Deployment steps:**
+1. Update ConfigMap template with two placeholders
+2. Update controller to fetch both routes
+3. Update injection logic to handle both placeholders
+4. Deploy updated operator
+5. Operator will reconcile existing Claw instances, updating their ConfigMaps automatically
+
+**Rollback strategy:**
+- If deployment fails, revert to previous operator version
+- Existing ConfigMaps will revert to single-origin behavior on next reconciliation
+- No data loss or permanent state changes
+
+**Compatibility:**
+- New operator works with old ConfigMaps (single placeholder)
+- New operator works with single-route deployments (console route optional)
+- No CR schema changes required

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The OpenClaw Control UI needs to allow CORS requests from both the main gateway route and the separate console route. Currently, only the gateway route host is included in `allowedOrigins`. When the console is hosted on a different route (`claw-console`), the browser blocks requests due to CORS policy violations.
+
+## What Changes
+
+- The operator will fetch the `claw-console` route host during reconciliation (similar to the existing `claw` route fetch)
+- The ConfigMap's `allowedOrigins` array will include both the gateway route host and the console route host
+- Both origins will use the `https://` scheme
+- On vanilla Kubernetes (no Route CRD), only the localhost fallback will be used
+
+## Capabilities
+
+### New Capabilities
+
+- `console-route-cors`: Fetch the claw-console route and inject its host into the ConfigMap's allowedOrigins array
+
+### Modified Capabilities
+
+- `dynamic-route-config`: Extend the route host injection to support multiple routes (gateway + console)
+
+## Impact
+
+**Affected code:**
+- `internal/controller/claw_resource_controller.go`: Add console route fetching logic and update ConfigMap injection
+- `internal/assets/manifests/claw/configmap.yaml`: Change `allowedOrigins` to include both route placeholders
+
+**Affected resources:**
+- ConfigMap `claw-config`: Will now have two entries in `allowedOrigins` array
+- Route `claw-console`: Will be queried for its host during reconciliation
+
+**User impact:**
+- Users deploying on OpenShift will see CORS automatically configured for both routes
+- Users on vanilla Kubernetes (no console route) will see no change in behavior

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/specs/console-route-cors/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/specs/console-route-cors/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Controller fetches console route host
+The controller SHALL fetch the `claw-console` Route resource and extract its hostname during reconciliation.
+
+#### Scenario: Console route exists and has status
+- **WHEN** reconciling a Claw instance on OpenShift
+- **WHEN** a Route named `claw-console` exists in the same namespace
+- **WHEN** the Route has `.status.ingress[0].host` populated
+- **THEN** the controller extracts the hostname from the Route status
+
+#### Scenario: Console route exists but status not ready
+- **WHEN** reconciling a Claw instance on OpenShift
+- **WHEN** a Route named `claw-console` exists but `.status.ingress[0].host` is not yet populated
+- **THEN** the controller requeues reconciliation with a 5-second backoff
+- **THEN** reconciliation retries until the Route status is populated
+
+#### Scenario: Console route does not exist
+- **WHEN** reconciling a Claw instance
+- **WHEN** no Route named `claw-console` exists in the namespace
+- **THEN** the controller logs a warning about the missing console route
+- **THEN** the controller continues reconciliation without the console route host
+- **THEN** only the gateway route host is included in allowedOrigins
+
+#### Scenario: Route CRD not registered (vanilla Kubernetes)
+- **WHEN** reconciling a Claw instance on vanilla Kubernetes (no Route CRD)
+- **THEN** the controller skips console route fetching with NoMatchError
+- **THEN** the controller uses localhost fallback for allowedOrigins
+
+### Requirement: Controller injects console route host into ConfigMap
+The controller SHALL include the console route host in the ConfigMap's `allowedOrigins` array.
+
+#### Scenario: Both gateway and console routes available
+- **WHEN** both `claw` and `claw-console` routes have populated status
+- **WHEN** gateway route host is `claw-gateway.apps.cluster.example.com`
+- **WHEN** console route host is `claw-console.apps.cluster.example.com`
+- **THEN** ConfigMap `allowedOrigins` includes `["https://claw-gateway.apps.cluster.example.com", "https://claw-console.apps.cluster.example.com"]`
+
+#### Scenario: Only gateway route available
+- **WHEN** `claw` route exists and has status
+- **WHEN** `claw-console` route does not exist
+- **THEN** ConfigMap `allowedOrigins` includes only `["https://claw-gateway.apps.cluster.example.com"]`
+
+#### Scenario: Vanilla Kubernetes with no routes
+- **WHEN** reconciling on vanilla Kubernetes (no Route CRD)
+- **THEN** ConfigMap `allowedOrigins` includes `["http://localhost:18789"]`
+
+### Requirement: Console route host uses HTTPS scheme
+The controller SHALL use the `https://` scheme when constructing the console route origin.
+
+#### Scenario: Console route origin uses HTTPS
+- **WHEN** console route host is `claw-console.apps.cluster.example.com`
+- **THEN** the allowedOrigins entry is `https://claw-console.apps.cluster.example.com`
+- **THEN** the scheme is lowercase `https://` (not HTTP)
+
+### Requirement: Controller uses separate placeholders for route hosts
+The ConfigMap template SHALL use distinct placeholders for gateway and console route hosts.
+
+#### Scenario: ConfigMap template has two placeholders
+- **WHEN** the ConfigMap template is defined in `internal/assets/manifests/claw/configmap.yaml`
+- **THEN** the `allowedOrigins` array includes `"OPENCLAW_ROUTE_HOST"` placeholder
+- **THEN** the `allowedOrigins` array includes `"OPENCLAW_CONSOLE_ROUTE_HOST"` placeholder
+
+#### Scenario: Controller replaces both placeholders
+- **WHEN** gateway route host is `gateway.example.com`
+- **WHEN** console route host is `console.example.com`
+- **THEN** `OPENCLAW_ROUTE_HOST` is replaced with `https://gateway.example.com`
+- **THEN** `OPENCLAW_CONSOLE_ROUTE_HOST` is replaced with `https://console.example.com`
+
+#### Scenario: Missing console route removes placeholder
+- **WHEN** console route does not exist
+- **THEN** `OPENCLAW_CONSOLE_ROUTE_HOST` placeholder is removed from the array
+- **THEN** only valid origins remain in `allowedOrigins`

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/specs/dynamic-route-config/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/specs/dynamic-route-config/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Console route is named claw-console
+The OpenShift Route for the console SHALL be named `claw-console`.
+
+#### Scenario: Console route name is fixed
+- **WHEN** reconciling a Claw instance on OpenShift
+- **THEN** the console Route is named `claw-console`
+- **THEN** the console Route name is independent of the Claw instance name
+
+#### Scenario: Console route coexists with gateway route
+- **WHEN** reconciling a Claw instance named `instance` on OpenShift
+- **THEN** two Routes are created: `claw` (gateway) and `claw-console`
+- **THEN** both Routes have unique hostnames
+- **THEN** both Routes are accessible independently
+
+### Requirement: Console route hostname is derived from route name
+The console Route hostname SHALL follow the same pattern as the gateway route, using the route name and cluster routing domain.
+
+#### Scenario: Console route hostname
+- **WHEN** the console Route named `claw-console` is deployed on OpenShift
+- **THEN** the Route hostname follows the pattern `claw-console-{namespace}.{cluster-domain}`
+- **THEN** the hostname is unique within the cluster
+
+### Requirement: Console route targets console service
+The console Route SHALL route traffic to the console service.
+
+#### Scenario: Console route targets correct service
+- **WHEN** reconciling the console Route
+- **THEN** the Route's `spec.to.name` field is set to `claw-console`
+- **THEN** traffic to the console Route is forwarded to the console service

--- a/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-console-route-allowed-origin/tasks.md
@@ -1,0 +1,36 @@
+## 1. Update ConfigMap Template
+
+- [x] 1.1 Update `internal/assets/manifests/claw/configmap.yaml` to change `allowedOrigins` from single placeholder to array with two placeholders: `["OPENCLAW_ROUTE_HOST", "OPENCLAW_CONSOLE_ROUTE_HOST"]`
+
+## 2. Add Route Fetching Helpers
+
+- [x] 2.1 Extract existing route fetching logic into a reusable helper function `getRouteHost(ctx context.Context, namespace string, routeName string) (string, error)` that fetches a route by name and returns its host or empty string if status not ready
+- [x] 2.2 Update existing `getRouteURL()` function to call the new `getRouteHost()` helper with route name "claw"
+
+## 3. Fetch Console Route During Reconciliation
+
+- [x] 3.1 Add call to `getRouteHost()` in Phase 2 to fetch the `claw-console` route host
+- [x] 3.2 Handle NotFound error gracefully by logging a warning and continuing with empty console route host
+- [x] 3.3 Handle unpopulated route status by requeuing with 5-second backoff (same as gateway route)
+- [x] 3.4 Pass both gateway and console route hosts to the ConfigMap injection function
+
+## 4. Update ConfigMap Injection Logic
+
+- [x] 4.1 Rename `injectRouteHostIntoConfigMap()` to `injectRouteHostsIntoConfigMap()` and add a `consoleRouteHost` parameter
+- [x] 4.2 Replace `OPENCLAW_ROUTE_HOST` placeholder with gateway route host (or localhost fallback)
+- [x] 4.3 Replace `OPENCLAW_CONSOLE_ROUTE_HOST` placeholder with console route host (or empty string if missing)
+- [x] 4.4 Filter out empty strings from the `allowedOrigins` array after placeholder replacement
+- [x] 4.5 Ensure localhost fallback applies to both placeholders when on vanilla Kubernetes
+
+## 5. Update Tests
+
+- [x] 5.1 Add test case for ConfigMap with both gateway and console route hosts in `allowedOrigins`
+- [x] 5.2 Add test case for missing console route (only gateway route in `allowedOrigins`)
+- [x] 5.3 Add test case for vanilla Kubernetes (localhost fallback, no console route)
+- [x] 5.4 Add test case for console route with unpopulated status (requeue behavior)
+- [x] 5.5 Update existing route-related tests to use the new `getRouteHost()` helper
+
+## 6. Update Documentation
+
+- [x] 6.1 Update CLAUDE.md to document the console route CORS configuration
+- [x] 6.2 Add comment in ConfigMap template explaining the two placeholders

--- a/openspec/specs/console-route-cors/spec.md
+++ b/openspec/specs/console-route-cors/spec.md
@@ -1,0 +1,77 @@
+# console-route-cors Specification
+
+## Purpose
+TBD - created by archiving change add-console-route-allowed-origin. Update Purpose after archive.
+## Requirements
+### Requirement: Controller fetches console route host
+The controller SHALL fetch the `claw-console` Route resource and extract its hostname during reconciliation.
+
+#### Scenario: Console route exists and has status
+- **WHEN** reconciling a Claw instance on OpenShift
+- **WHEN** a Route named `claw-console` exists in the same namespace
+- **WHEN** the Route has `.status.ingress[0].host` populated
+- **THEN** the controller extracts the hostname from the Route status
+
+#### Scenario: Console route exists but status not ready
+- **WHEN** reconciling a Claw instance on OpenShift
+- **WHEN** a Route named `claw-console` exists but `.status.ingress[0].host` is not yet populated
+- **THEN** the controller requeues reconciliation with a 5-second backoff
+- **THEN** reconciliation retries until the Route status is populated
+
+#### Scenario: Console route does not exist
+- **WHEN** reconciling a Claw instance
+- **WHEN** no Route named `claw-console` exists in the namespace
+- **THEN** the controller logs a warning about the missing console route
+- **THEN** the controller continues reconciliation without the console route host
+- **THEN** only the gateway route host is included in allowedOrigins
+
+#### Scenario: Route CRD not registered (vanilla Kubernetes)
+- **WHEN** reconciling a Claw instance on vanilla Kubernetes (no Route CRD)
+- **THEN** the controller skips console route fetching with NoMatchError
+- **THEN** the controller uses localhost fallback for allowedOrigins
+
+### Requirement: Controller injects console route host into ConfigMap
+The controller SHALL include the console route host in the ConfigMap's `allowedOrigins` array.
+
+#### Scenario: Both gateway and console routes available
+- **WHEN** both `claw` and `claw-console` routes have populated status
+- **WHEN** gateway route host is `claw-gateway.apps.cluster.example.com`
+- **WHEN** console route host is `claw-console.apps.cluster.example.com`
+- **THEN** ConfigMap `allowedOrigins` includes `["https://claw-gateway.apps.cluster.example.com", "https://claw-console.apps.cluster.example.com"]`
+
+#### Scenario: Only gateway route available
+- **WHEN** `claw` route exists and has status
+- **WHEN** `claw-console` route does not exist
+- **THEN** ConfigMap `allowedOrigins` includes only `["https://claw-gateway.apps.cluster.example.com"]`
+
+#### Scenario: Vanilla Kubernetes with no routes
+- **WHEN** reconciling on vanilla Kubernetes (no Route CRD)
+- **THEN** ConfigMap `allowedOrigins` includes `["http://localhost:18789"]`
+
+### Requirement: Console route host uses HTTPS scheme
+The controller SHALL use the `https://` scheme when constructing the console route origin.
+
+#### Scenario: Console route origin uses HTTPS
+- **WHEN** console route host is `claw-console.apps.cluster.example.com`
+- **THEN** the allowedOrigins entry is `https://claw-console.apps.cluster.example.com`
+- **THEN** the scheme is lowercase `https://` (not HTTP)
+
+### Requirement: Controller uses separate placeholders for route hosts
+The ConfigMap template SHALL use distinct placeholders for gateway and console route hosts.
+
+#### Scenario: ConfigMap template has two placeholders
+- **WHEN** the ConfigMap template is defined in `internal/assets/manifests/claw/configmap.yaml`
+- **THEN** the `allowedOrigins` array includes `"OPENCLAW_ROUTE_HOST"` placeholder
+- **THEN** the `allowedOrigins` array includes `"OPENCLAW_CONSOLE_ROUTE_HOST"` placeholder
+
+#### Scenario: Controller replaces both placeholders
+- **WHEN** gateway route host is `gateway.example.com`
+- **WHEN** console route host is `console.example.com`
+- **THEN** `OPENCLAW_ROUTE_HOST` is replaced with `https://gateway.example.com`
+- **THEN** `OPENCLAW_CONSOLE_ROUTE_HOST` is replaced with `https://console.example.com`
+
+#### Scenario: Missing console route removes placeholder
+- **WHEN** console route does not exist
+- **THEN** `OPENCLAW_CONSOLE_ROUTE_HOST` placeholder is removed from the array
+- **THEN** only valid origins remain in `allowedOrigins`
+

--- a/openspec/specs/dynamic-route-config/spec.md
+++ b/openspec/specs/dynamic-route-config/spec.md
@@ -1,5 +1,7 @@
-## ADDED Requirements
+## Purpose
 
+Define how OpenShift Routes are configured for Claw instances, including naming conventions, hostname patterns, and service targeting.
+## Requirements
 ### Requirement: Route name uses instance name
 The OpenShift Route SHALL be named using the Claw instance name directly.
 
@@ -32,3 +34,34 @@ The Route SHALL route traffic to the service named after the Claw instance.
 - **WHEN** reconciling a Claw instance named 'my-openclaw'
 - **THEN** the Route's `spec.to.name` field is set to 'my-openclaw'
 - **THEN** traffic to the Route is forwarded to the correct instance's gateway service
+
+### Requirement: Console route is named claw-console
+The OpenShift Route for the console SHALL be named `claw-console`.
+
+#### Scenario: Console route name is fixed
+- **WHEN** reconciling a Claw instance on OpenShift
+- **THEN** the console Route is named `claw-console`
+- **THEN** the console Route name is independent of the Claw instance name
+
+#### Scenario: Console route coexists with gateway route
+- **WHEN** reconciling a Claw instance named `instance` on OpenShift
+- **THEN** two Routes are created: `claw` (gateway) and `claw-console`
+- **THEN** both Routes have unique hostnames
+- **THEN** both Routes are accessible independently
+
+### Requirement: Console route hostname is derived from route name
+The console Route hostname SHALL follow the same pattern as the gateway route, using the route name and cluster routing domain.
+
+#### Scenario: Console route hostname
+- **WHEN** the console Route named `claw-console` is deployed on OpenShift
+- **THEN** the Route hostname follows the pattern `claw-console-{namespace}.{cluster-domain}`
+- **THEN** the hostname is unique within the cluster
+
+### Requirement: Console route targets console service
+The console Route SHALL route traffic to the console service.
+
+#### Scenario: Console route targets correct service
+- **WHEN** reconciling the console Route
+- **THEN** the Route's `spec.to.name` field is set to `claw-console`
+- **THEN** traffic to the console Route is forwarded to the console service
+


### PR DESCRIPTION
Replace string replacement with proper JSON parsing for CORS configuration:
- Refactor `injectRouteHostsIntoConfigMap()` to use explicit `gatewayURL`
  and `consoleURL` parameters
- Parse `operator.json` as JSON, update `gateway.controlUi.allowedOrigins`
  array, and marshal with proper indentation
- Extract JSON manipulation logic into `updateOperatorJSONAllowedOrigins()`
  helper to reduce cyclomatic complexity
- Add console route support via `getConsoleRouteURL()` method for multi-
  origin CORS configuration
- Rename `applyRouteOnly()` to `applyRoutesOnly()` with boolean return to
  handle multiple routes
- Remove log-then-return anti-pattern in `Reconcile()` method, wrap errors
  with context messages instead
- Update ConfigMap template to use empty `allowedOrigins` array (controller
  sets dynamically)
- Update all tests to use new function signatures with explicit parameters

This eliminates placeholder string replacement in favor of type-safe JSON
manipulation and supports both gateway and console routes for CORS.

Assisted-by: Claude Sonnet 4.5
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
