### PR TITLE
chore: update to OpenClaw 2006.04.27 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
   ↓
 7b. injectProvidersIntoConfigMap(objects, instance.Spec.Credentials)
    ├─ Filter credentials with Provider set
-   ├─ For gateway-routed providers: resolveProviderInfo(cred) → upstream + basePath, build baseUrl via proxy
+   ├─ For gateway-routed providers: resolveProviderInfo(cred) → upstream + basePath as baseUrl (MITM proxy injects credentials transparently)
    ├─ For Vertex SDK providers (GCP + non-Google, e.g., anthropic): map to "{provider}-vertex" key with real Vertex AI URL, api mapping, and "gcp-vertex-credentials" apiKey
    ├─ Write providers into data["operator.json"] (agent defaults are user-owned in openclaw.json seed)
    └─ Credentials without Provider are MITM-only (no provider entry)
@@ -303,7 +303,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `getRouteURL()` — fetches Route and extracts `.status.ingress[0].host`, returns empty string if status not populated
 - `buildKustomizedObjects()` — builds Kustomize manifests, configures proxy deployment, stamps Secret version, returns parsed objects
 - `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in `operator.json` with Route host (or localhost fallback)
-- `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `operator.json`. Gateway-routed providers get a baseUrl through the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since MITM proxy handles credential injection transparently. Does not touch agent defaults (user-owned in openclaw.json seed)
+- `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `operator.json`. Provider baseUrl points to real upstream URLs (e.g., `https://generativelanguage.googleapis.com/v1beta`); the MITM proxy injects credentials transparently via HTTP_PROXY. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL. Does not touch agent defaults (user-owned in openclaw.json seed)
 - `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA
 - `resolveCredentials()` — validates all credentials and referenced Secrets. For `kubernetes` type, parses kubeconfig with `client-go/tools/clientcmd`, validates token-only auth, extracts cluster/context metadata. Returns `[]resolvedCredential` (replaces former `validateCredentials`)
 - `parseAndValidateKubeconfig()` — parses kubeconfig bytes, validates all users use token-based auth (rejects client certs, exec, auth provider), validates unique token per server `hostname:port`, returns `kubeconfigData`
@@ -364,11 +364,11 @@ The `internal/assets/manifests/` directory contains:
 - **kustomization.yaml** — defines labels and resource list
 - **configmap.yaml** — OpenClaw configuration (operator.json for operator-managed settings, openclaw.json as user-owned seed with `$include`, AGENTS.md seed, PROXY_SETUP.md for proxy architecture skill, KUBERNETES.md for k8s skill)
 - **pvc.yaml** — persistent storage (10Gi ReadWriteOnce)
-- **deployment.yaml** — OpenClaw application pods (init containers with readOnlyRootFilesystem, gateway without; PVC subpath mounts at `~/.local`, `~/.cache`, `~/.config` for persistent tool state; `wait-for-proxy` init container ensures proxy is ready before gateway starts)
+- **deployment.yaml** — OpenClaw application pods (init containers with readOnlyRootFilesystem, gateway without; PVC subpath mounts at `~/.local`, `~/.cache`, `~/.config` for persistent tool state; `wait-for-proxy` init container ensures proxy is ready before gateway starts; `OPENCLAW_PROXY_ACTIVE=1` env var enables native managed proxy support)
 - **service.yaml** — ClusterIP service exposing OpenClaw gateway (port 18789)
 - **route.yaml** — OpenShift Route for external HTTPS access (skipped on non-OpenShift)
-- **proxy-configmap.yaml** — Nginx configuration for LLM API proxy
-- **proxy-deployment.yaml** — Nginx proxy (env vars reference user-managed Secrets; controller patches GEMINI_API_KEY after applying)
+- **proxy-configmap.yaml** — Proxy configuration for LLM API proxy
+- **proxy-deployment.yaml** — Go MITM proxy (env vars reference user-managed Secrets; controller patches credential env vars after applying)
 - **proxy-service.yaml** — ClusterIP service for proxy (port 8080)
 - **networkpolicy.yaml** — Two NetworkPolicies for egress control (OpenClaw → proxy, proxy → internet)
 - **ingress-networkpolicy.yaml** — Ingress NetworkPolicy restricting gateway access to OpenShift router namespace

--- a/docs/adr/0001-security-hardening.md
+++ b/docs/adr/0001-security-hardening.md
@@ -38,7 +38,7 @@ All questions resolved across sketch (Q1–Q7) and implementation questions (Q1�
 | Q4 | Operator RBAC | Deferred until credential and proxy changes complete | Credential/proxy work alters required permissions; audit after stabilization |
 | Q5 | Container hardening | Init container security context matching main container | Required for Pod Security Admission restricted profile. Deferred: image digest pinning, Route TLS config |
 | Q6 | Application-layer security | Document threat model; investigate assistant RBAC scoping | |
-| Q7 | Proxy architecture | Hybrid Go proxy (gateway + MITM) built on `github.com/elazarl/goproxy` | Pure MITM blocked by Google ADK JS SDK `thought_signature` bug on streamed responses. Gateway mode bypasses the bug; MITM retained for general egress |
+| Q7 | Proxy architecture | MITM forward proxy built on `github.com/elazarl/goproxy` with `OPENCLAW_PROXY_ACTIVE=1` | OpenClaw 2026.4.27+ native managed proxy support enables pure MITM for all traffic. Provider baseUrls point to real upstreams; proxy injects credentials transparently |
 
 | # | Question | Decision | Rationale |
 |---|----------|----------|-----------|
@@ -53,7 +53,7 @@ All questions resolved across sketch (Q1–Q7) and implementation questions (Q1�
 | Q9 | Implementation phasing | Phase 1 (quick wins + CRD rename) → Phase 2 (all 6 credential types + Go proxy) → Phase 3 (kubernetes type, deferred) | GCP requirement merged original Phases 2+3. Kubernetes type deferred due to SA token projection limitations |
 | Q10 | Credential validation | CEL validation rules on `spec.credentials[]` items + controller defense-in-depth | Admission-time feedback, no webhook infrastructure. Requires Kubernetes 1.25+ |
 | Q11 | Phase 2 credential types | `apiKey`, `bearer`, `gcp`, `pathToken`, `oauth2`, `none` (6 types) | Covers all current use cases. `kubernetes` deferred to Phase 3 |
-| Q12 | Proxy traffic routing | Hybrid: gateway mode (path-based, LLM providers) + MITM forward proxy (CONNECT, general egress) | SDK bug necessitated gateway mode for LLM providers; MITM retained for general egress |
+| Q12 | Proxy traffic routing | Pure MITM forward proxy (CONNECT, all traffic) via `HTTP_PROXY` + `OPENCLAW_PROXY_ACTIVE=1` | OpenClaw 2026.4.27+ supports `OPENCLAW_PROXY_ACTIVE` env for managed proxy environments; gateway mode (path-based reverse proxy) retained in proxy code but no longer used for provider routing |
 
 ---
 
@@ -77,7 +77,7 @@ spec:
     - name: gemini
       type: apiKey
       secretRef: { name: llm-keys, key: GEMINI_API_KEY }
-      provider: google     # gateway mode + openclaw.json provider entry
+      provider: google     # generates provider entry in operator.json
     - name: github
       type: bearer
       secretRef: { name: platform-tokens, key: GITHUB_TOKEN }
@@ -104,21 +104,17 @@ spec:
 
 ### Hybrid Go Credential Proxy
 
-A credential-injecting proxy replacing nginx, built on `github.com/elazarl/goproxy`, operating in two modes:
+A credential-injecting MITM forward proxy built on `github.com/elazarl/goproxy`:
 
 ```
-# Gateway mode (LLM providers with provider set):
-Claw Gateway ──HTTP──▶ Go Proxy (strip prefix, inject creds) ──HTTPS──▶ upstream LLM API
-  baseUrl: http://claw-proxy:8080/gemini/v1beta
-
-# MITM forward proxy mode (general egress):
+# MITM forward proxy mode (all traffic):
 Claw Gateway ──CONNECT host:443──▶ Go Proxy (MITM: TLS terminate, inject creds) ──HTTPS──▶ upstream API
   HTTP_PROXY=http://claw-proxy:8080
+  OPENCLAW_PROXY_ACTIVE=1
+  baseUrl: https://generativelanguage.googleapis.com/v1beta  (real upstream, proxy transparent)
 ```
 
-**Gateway mode:** For LLM providers with `provider` set. OpenClaw configured with `baseUrl` pointing to proxy. Proxy strips path prefix, injects credentials, forwards via `httputil.ReverseProxy`. Avoids Google ADK JS SDK `thought_signature` bug.
-
-**MITM mode:** For general egress (web_fetch, npm, OTEL). Proxy intercepts CONNECT tunnels, generates leaf certs from operator-managed CA, TLS-terminates, matches Host header against domain patterns, injects credentials.
+All traffic from the gateway pod flows through the MITM proxy via `HTTP_PROXY`/`HTTPS_PROXY` env vars. OpenClaw's native managed proxy support (`OPENCLAW_PROXY_ACTIVE=1`) enables the SSRF guard to route requests through the env proxy. Provider `baseUrl` values point to real upstream URLs; the proxy intercepts CONNECT tunnels, generates leaf certs from the operator-managed CA, TLS-terminates, matches Host header against domain patterns, and injects credentials transparently.
 
 **Injector types:**
 - `apiKey` — configured header with optional value prefix + default headers
@@ -206,15 +202,14 @@ status:
                     │    └──┬───────┬──┘                               │
                     │       │       │                                  │
                     │  [Gateway]  [MITM]                               │
-                    │   baseUrl    CONNECT                             │
-                    │       │       │                                  │
-                    │       ▼       ▼                                  │
-                    │    Hybrid Go Credential Proxy (goproxy)          │
+                    │      CONNECT (all traffic via HTTP_PROXY)        │
+                    │           │                                      │
+                    │           ▼                                      │
+                    │    MITM Go Credential Proxy (goproxy)            │
                     │    ┌─────────────────────────────────────┐       │
-                    │    │ Gateway mode: path-prefix routing   │       │
-                    │    │ MITM mode: CONNECT + TLS termination│       │
+                    │    │ MITM: CONNECT + TLS termination     │       │
                     │    │ Config from spec.credentials[]      │       │
-                    │    │ Dynamic openclaw.json generation    │       │
+                    │    │ Dynamic operator.json generation    │       │
                     │    │ Strip ALL client auth headers       │       │
                     │    │ Inject real credentials             │       │
                     │    │ Injection failure → 502             │       │

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -37,8 +37,8 @@ data:
           "models": {
             "google/gemini-3.1-pro-preview": { "alias": "Gemini Pro" },
             "google/gemini-3-flash-preview": { "alias": "Gemini Flash" },
-            "anthropic/claude-sonnet-4-6": { "alias": "Claude Sonnet" },
-            "anthropic/claude-haiku-4-5": { "alias": "Claude Haiku" }
+            "anthropic-vertex/claude-sonnet-4-6": { "alias": "Claude Sonnet" },
+            "anthropic-vertex/claude-haiku-4-5": { "alias": "Claude Haiku" }
           },
           "workspace": "~/.openclaw/workspace"
         },

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -21,44 +21,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: patch-proxy
-          image: ghcr.io/openclaw/openclaw:slim
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - sh
-            - -c
-            - |
-              set -e
-              cp -r /app/dist/. /patched-dist/
-              patched=0
-              guard_pattern='mode[[:space:]]*===[[:space:]]*GUARDED_FETCH_MODE\.TRUSTED_ENV_PROXY[[:space:]]*&&[[:space:]]*hasProxyEnvConfigured\(\)'
-              guard_files=$(grep -rEl "$guard_pattern" /patched-dist --include='*.js' 2>/dev/null || true)
-              if [ -z "$guard_files" ]; then
-                echo "[proxy-patch] ERROR: no files contain SSRF guard conditional — upstream may have changed" >&2
-                exit 1
-              fi
-              for file in $guard_files; do
-                sed -Ei "s|$guard_pattern|hasProxyEnvConfigured()|g" "$file"
-                echo "[proxy-patch] Patched SSRF guard: $file"
-                patched=$((patched + 1))
-              done
-              echo "[proxy-patch] Patched $patched file(s)"
-          resources:
-            requests:
-              memory: 128Mi
-              cpu: 100m
-            limits:
-              memory: 256Mi
-              cpu: 500m
-          volumeMounts:
-            - name: patched-dist
-              mountPath: /patched-dist
         - name: init-config
           image: mirror.gcr.io/library/busybox:1.37
           imagePullPolicy: IfNotPresent
@@ -149,6 +111,8 @@ spec:
               value: /home/node/.openclaw
             - name: NODE_ENV
               value: production
+            - name: OPENCLAW_PROXY_ACTIVE
+              value: "1"
             - name: OPENCLAW_GATEWAY_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -208,8 +172,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
           volumeMounts:
-            - name: patched-dist
-              mountPath: /app/dist
             - name: claw-home
               mountPath: /home/node/.openclaw
             - name: claw-home
@@ -232,8 +194,6 @@ spec:
               drop:
                 - ALL
       volumes:
-        - name: patched-dist
-          emptyDir: {}
         - name: claw-home
           persistentVolumeClaim:
             claimName: CLAW_INSTANCE_NAME-home-pvc

--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.4.23-slim
+    newTag: 2026.4.27-slim

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -27,6 +27,42 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
+// --- Vertex AI base URL tests ---
+
+func TestVertexAIBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     string
+	}{
+		{
+			name:     "global uses plain hostname",
+			location: "global",
+			want:     "https://aiplatform.googleapis.com",
+		},
+		{
+			name:     "regional location uses prefix",
+			location: "us-east5",
+			want:     "https://us-east5-aiplatform.googleapis.com",
+		},
+		{
+			name:     "another region uses prefix",
+			location: "europe-west1",
+			want:     "https://europe-west1-aiplatform.googleapis.com",
+		},
+		{
+			name:     "us-central1 uses prefix",
+			location: "us-central1",
+			want:     "https://us-central1-aiplatform.googleapis.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, vertexAIBaseURL(tt.location))
+		})
+	}
+}
+
 // --- Vertex SDK helper tests ---
 
 func TestUsesVertexSDK(t *testing.T) {
@@ -235,6 +271,34 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		providers := getProviders(t, config)
 		av := providers["anthropic-vertex"].(map[string]any)
 		assert.Equal(t, "https://aiplatform.googleapis.com", av["baseUrl"])
+	})
+
+	t.Run("should set maxTokens and no api for non-anthropic vertex provider", func(t *testing.T) {
+		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "meta-vertex",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "meta",
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-project",
+					Location: "us-central1",
+				},
+			},
+		}
+
+		require.NoError(t, injectProvidersIntoConfigMap(objects, testClawWithCredentials(credentials)))
+
+		config := getConfig(t, objects)
+		providers := getProviders(t, config)
+
+		require.Contains(t, providers, "meta-vertex")
+		mv := providers["meta-vertex"].(map[string]any)
+		assert.Equal(t, "https://us-central1-aiplatform.googleapis.com", mv["baseUrl"])
+		assert.Equal(t, "gcp-vertex-credentials", mv["apiKey"])
+		assert.Equal(t, float64(128000), mv["maxTokens"])
+		assert.NotContains(t, mv, "api", "meta has no api mapping in vertexProviderAPIMapping")
 	})
 
 	t.Run("should reject duplicate vertex providers", func(t *testing.T) {

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -185,7 +185,7 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		return models["providers"].(map[string]any)
 	}
 
-	t.Run("should map GCP anthropic to anthropic-vertex provider", func(t *testing.T) {
+	t.Run("should map GCP anthropic to anthropic-vertex provider key", func(t *testing.T) {
 		objects := makeConfigMap(`{"models":{"providers":{}}}`)
 		credentials := []clawv1alpha1.CredentialSpec{
 			{
@@ -205,13 +205,36 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		config := getConfig(t, objects)
 		providers := getProviders(t, config)
 
-		assert.NotContains(t, providers, "anthropic", "should not have base anthropic provider")
 		require.Contains(t, providers, "anthropic-vertex")
 
 		av := providers["anthropic-vertex"].(map[string]any)
 		assert.Equal(t, "https://us-east5-aiplatform.googleapis.com", av["baseUrl"])
 		assert.Equal(t, "gcp-vertex-credentials", av["apiKey"])
 		assert.Equal(t, "anthropic-messages", av["api"])
+		assert.Equal(t, float64(128000), av["maxTokens"])
+	})
+
+	t.Run("should use plain hostname for global location", func(t *testing.T) {
+		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "anthropic-vertex",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "anthropic",
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-project",
+					Location: "global",
+				},
+			},
+		}
+
+		require.NoError(t, injectProvidersIntoConfigMap(objects, testClawWithCredentials(credentials)))
+
+		config := getConfig(t, objects)
+		providers := getProviders(t, config)
+		av := providers["anthropic-vertex"].(map[string]any)
+		assert.Equal(t, "https://aiplatform.googleapis.com", av["baseUrl"])
 	})
 
 	t.Run("should reject duplicate vertex providers", func(t *testing.T) {

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -85,6 +85,15 @@ func usesVertexSDK(cred clawv1alpha1.CredentialSpec) bool {
 	return cred.Type == clawv1alpha1.CredentialTypeGCP && cred.Provider != "" && cred.Provider != "google"
 }
 
+// vertexAIBaseURL returns the Vertex AI REST base URL for the given location.
+// The "global" location uses a plain hostname without a region prefix.
+func vertexAIBaseURL(location string) string {
+	if location == "global" {
+		return "https://aiplatform.googleapis.com"
+	}
+	return "https://" + location + "-aiplatform.googleapis.com"
+}
+
 // vertexProviderAPIMapping maps provider names to their OpenClaw API identifiers for Vertex AI.
 var vertexProviderAPIMapping = map[string]string{
 	"anthropic": "anthropic-messages",

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -158,7 +158,7 @@ type providerInfo struct {
 func resolveProviderInfo(cred clawv1alpha1.CredentialSpec) providerInfo {
 	if cred.Type == clawv1alpha1.CredentialTypeGCP && cred.GCP != nil {
 		return providerInfo{
-			Upstream: "https://" + cred.GCP.Location + "-aiplatform.googleapis.com",
+			Upstream: vertexAIBaseURL(cred.GCP.Location),
 			BasePath: "/v1/projects/" + cred.GCP.Project + "/locations/" + cred.GCP.Location + "/publishers/" + cred.Provider,
 		}
 	}

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -703,6 +703,20 @@ func TestResolveProviderInfo(t *testing.T) {
 			wantBasePath: "/v1/projects/my-project/locations/us-east5/publishers/anthropic",
 		},
 		{
+			name: "gcp global location uses plain hostname",
+			cred: clawv1alpha1.CredentialSpec{
+				Provider: "anthropic",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-project",
+					Location: "global",
+				},
+			},
+			wantUpstream: "https://aiplatform.googleapis.com",
+			wantBasePath: "/v1/projects/my-project/locations/global/publishers/anthropic",
+		},
+		{
 			name: "unknown provider with exact domain",
 			cred: clawv1alpha1.CredentialSpec{
 				Provider: "custom-llm",

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -772,7 +772,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		providers := getProviders(t, objects)
 		require.Contains(t, providers, "google")
 		google := providers["google"].(map[string]any)
-		assert.Equal(t, "http://"+getProxyServiceName(testInstanceName)+":8080/gemini/v1beta", google["baseUrl"])
+		assert.Equal(t, "https://generativelanguage.googleapis.com/v1beta", google["baseUrl"])
 		assert.Equal(t, "ah-ah-ah-you-didnt-say-the-magic-word", google["apiKey"])
 	})
 
@@ -799,7 +799,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		assert.Contains(t, providers, "google")
 		assert.Contains(t, providers, "anthropic")
 		anthropic := providers["anthropic"].(map[string]any)
-		assert.Equal(t, "http://"+getProxyServiceName(testInstanceName)+":8080/claude", anthropic["baseUrl"])
+		assert.Equal(t, "https://api.anthropic.com", anthropic["baseUrl"])
 	})
 
 	t.Run("should leave providers empty when no provider is set", func(t *testing.T) {
@@ -838,7 +838,7 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		providers := getProviders(t, objects)
 		require.Contains(t, providers, "google")
 		google := providers["google"].(map[string]any)
-		assert.Equal(t, "http://"+getProxyServiceName(testInstanceName)+":8080/vertex/v1/projects/my-proj/locations/europe-west1/publishers/google", google["baseUrl"])
+		assert.Equal(t, "https://europe-west1-aiplatform.googleapis.com/v1/projects/my-proj/locations/europe-west1/publishers/google", google["baseUrl"])
 	})
 
 	t.Run("should preserve other config sections", func(t *testing.T) {
@@ -1006,7 +1006,7 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 
 		google, ok := providers["google"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "http://"+getProxyServiceName(testInstanceName)+":8080/gemini/v1beta", google["baseUrl"])
+		assert.Equal(t, "https://generativelanguage.googleapis.com/v1beta", google["baseUrl"])
 		assert.Equal(t, "ah-ah-ah-you-didnt-say-the-magic-word", google["apiKey"])
 	})
 

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -790,7 +790,6 @@ func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstruc
 // and are not modified here — users control their own model preferences.
 func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw) error {
 	credentials := instance.Spec.Credentials
-	proxyServiceName := getProxyServiceName(instance.Name)
 	providers := map[string]any{}
 	for _, cred := range credentials {
 		if cred.Provider == "" {
@@ -805,10 +804,12 @@ func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, instance
 			if _, exists := providers[providerKey]; exists {
 				return fmt.Errorf("duplicate provider %q in credentials", providerKey)
 			}
+			baseURL := vertexAIBaseURL(cred.GCP.Location)
 			entry := map[string]any{
-				"baseUrl": "https://" + cred.GCP.Location + "-aiplatform.googleapis.com",
-				"apiKey":  "gcp-vertex-credentials",
-				"models":  []any{},
+				"baseUrl":   baseURL,
+				"apiKey":    "gcp-vertex-credentials",
+				"maxTokens": 128000,
+				"models":    []any{},
 			}
 			if api, ok := vertexProviderAPIMapping[cred.Provider]; ok {
 				entry["api"] = api
@@ -819,9 +820,8 @@ func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, instance
 				return fmt.Errorf("duplicate provider %q in credentials", cred.Provider)
 			}
 			info := resolveProviderInfo(cred)
-			baseURL := "http://" + proxyServiceName + ":8080/" + strings.ToLower(cred.Name) + info.BasePath
 			providers[cred.Provider] = map[string]any{
-				"baseUrl": baseURL,
+				"baseUrl": info.Upstream + info.BasePath,
 				"apiKey":  "ah-ah-ah-you-didnt-say-the-magic-word",
 				"models":  []any{},
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -733,7 +733,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "new pod did not reach Running phase")
 		})
 
-		t.Run("should patch SSRF guard in claw gateway init container", func(t *testing.T) {
+		t.Run("should set OPENCLAW_PROXY_ACTIVE env for managed proxy support", func(t *testing.T) {
 			t.Cleanup(func() {
 				collectDebugInfo(t)
 				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
@@ -785,17 +785,15 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 				})
 			require.NoError(t, err, "claw pod did not reach Running — init containers may have failed")
 
-			t.Log("verifying patch-proxy init container logs")
-			cmd = exec.Command("kubectl", "logs", podName, "-c", "patch-proxy",
-				"-n", userNamespace)
+			t.Log("verifying OPENCLAW_PROXY_ACTIVE env var is set on gateway container")
+			jsonPath := `{.spec.containers[?(@.name=="gateway")]` +
+				`.env[?(@.name=="OPENCLAW_PROXY_ACTIVE")].value}`
+			cmd = exec.Command("kubectl", "get", "pod", podName,
+				"-n", userNamespace, "-o", "jsonpath="+jsonPath)
 			logOutput, err := utils.Run(t, cmd)
-			require.NoError(t, err, "failed to get patch-proxy logs")
-			t.Logf("patch-proxy logs:\n%s", logOutput)
-
-			assert.Contains(t, logOutput, "[proxy-patch] Patched SSRF guard:",
-				"init container should report patching at least one file")
-			assert.NotContains(t, logOutput, "ERROR",
-				"init container should not report errors")
+			require.NoError(t, err, "failed to get gateway env")
+			assert.Equal(t, "1", logOutput,
+				"OPENCLAW_PROXY_ACTIVE should be set to 1")
 		})
 
 		t.Run("should proxy kubectl requests with kubernetes credential type", func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and config docs to describe a MITM forward-proxy model, direct upstream provider endpoints, and the deployment env var OPENCLAW_PROXY_ACTIVE=1.
* **Chores**
  * Simplified deployment by removing runtime proxy patching and adding the proxy-active env flag.
  * Updated container image tag and provider model mappings (Anthropic → Anthropic-Vertex).
  * Vertex providers now include a larger maxTokens default.
* **Tests**
  * Expanded provider-injection and Vertex URL tests, including global-location coverage; updated proxy-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->