### PR TITLE
feat: add clawhub.ai as builtin proxy passthrough domain

### DIFF
--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -72,6 +72,17 @@ data:
     network access without credential injection, the proxy can allowlist domains using
     `type: none` credential entries.
 
+    ## Pre-allowed domains
+
+    The following domains are always allowed without any user configuration:
+    - `clawhub.ai` — ClawHub plugin registry (plugin installs, skill downloads)
+    - `openrouter.ai` — model pricing API for cost estimation
+    - `raw.githubusercontent.com` — LiteLLM pricing data and Baileys defaults (path-restricted)
+    - `registry.npmjs.org` — npm package downloads for plugin dependencies
+
+    You do NOT need to ask the user to allowlist these. If a plugin install or skill
+    download from ClawHub fails, the issue is likely something else (network, auth token).
+
     ## When the user wants to integrate with an external service
 
     If a service is not working or the user asks to enable a new integration, the most

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -182,10 +182,12 @@ type builtinPassthrough struct {
 
 // builtinPassthroughDomains are domains the proxy always allows without credential
 // injection. These support core gateway functionality:
+//   - clawhub.ai: ClawHub plugin registry for plugin installs and skill downloads
 //   - openrouter.ai: model pricing API for cost estimation in the UI
 //   - raw.githubusercontent.com: LiteLLM model pricing data and WhatsApp Baileys library defaults (path-restricted)
 //   - registry.npmjs.org: npm packages for plugin runtime dependencies
 var builtinPassthroughDomains = []builtinPassthrough{
+	{Domain: "clawhub.ai"},
 	{Domain: "openrouter.ai"},
 	{Domain: "raw.githubusercontent.com", AllowedPaths: []string{"/BerriAI/litellm/", "/WhiskeySockets/Baileys/"}},
 	{Domain: "registry.npmjs.org"},

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -297,17 +297,16 @@ func TestGenerateProxyConfig(t *testing.T) {
 		require.NoError(t, json.Unmarshal(data, &cfg))
 		expectedDomains := []string{
 			"api.example.com",
+			"clawhub.ai",
 			"openrouter.ai",
 			"raw.githubusercontent.com",
 			"registry.npmjs.org",
 			".example.com",
 		}
 		require.Len(t, cfg.Routes, len(expectedDomains))
-		assert.Equal(t, expectedDomains[0], cfg.Routes[0].Domain, "exact match should come first")
-		assert.Equal(t, expectedDomains[1], cfg.Routes[1].Domain, "builtin exact should come before suffix")
-		assert.Equal(t, expectedDomains[2], cfg.Routes[2].Domain, "builtin exact should come before suffix")
-		assert.Equal(t, expectedDomains[3], cfg.Routes[3].Domain, "builtin exact should come before suffix")
-		assert.Equal(t, expectedDomains[4], cfg.Routes[4].Domain, "suffix match should come last")
+		for i, want := range expectedDomains {
+			assert.Equal(t, want, cfg.Routes[i].Domain, "route %d should be %s", i, want)
+		}
 	})
 
 	t.Run("should generate config with none route", func(t *testing.T) {
@@ -500,6 +499,17 @@ func TestGenerateProxyConfig(t *testing.T) {
 }
 
 func TestBuiltinPassthroughDomains(t *testing.T) {
+	t.Run("should include clawhub.ai as none route with no credentials", func(t *testing.T) {
+		data, err := generateProxyConfig(nil) //nolint:staticcheck
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+		route := findRouteByDomain(t, cfg.Routes, "clawhub.ai")
+		assert.Equal(t, "none", route.Injector)
+		assert.Empty(t, route.AllowedPaths)
+	})
+
 	t.Run("should include openrouter.ai as none route with no credentials", func(t *testing.T) {
 		data, err := generateProxyConfig(nil) //nolint:staticcheck
 		require.NoError(t, err)


### PR DESCRIPTION
- Add clawhub.ai to builtinPassthroughDomains so plugin installs and skill downloads work without manual CR configuration
- Document pre-allowed domains in PROXY_SETUP.md skill so the agent doesn't incorrectly ask users to allowlist them
- Update ordering test and add dedicated clawhub.ai builtin test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ClawHub to pre-allowed domains for direct access without additional configuration.

* **Documentation**
  * Updated documentation clarifying which external domains are pre-allowed and troubleshooting guidance for plugin/skill download issues.

* **Tests**
  * Enhanced test coverage for proxy configuration and domain routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->