### PR TITLE
feat: update OpenClaw to 2026.4.29-slim

### DIFF
--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -146,13 +146,30 @@ spec:
               value: /etc/proxy-ca/ca.crt
             - name: GIT_SSL_CAINFO
               value: /etc/proxy-ca/ca.crt
+            # Rewrite all SSH URL forms to HTTPS — the slim image has no ssh
+            # binary, and some npm packages (e.g. @whiskeysockets/baileys →
+            # libsignal-node) declare git SSH dependencies that fail without it.
+            - name: GIT_CONFIG_COUNT
+              value: "3"
+            - name: GIT_CONFIG_KEY_0
+              value: url.https://github.com/.insteadOf
+            - name: GIT_CONFIG_VALUE_0
+              value: git+ssh://git@github.com/
+            - name: GIT_CONFIG_KEY_1
+              value: url.https://github.com/.insteadOf
+            - name: GIT_CONFIG_VALUE_1
+              value: ssh://git@github.com/
+            - name: GIT_CONFIG_KEY_2
+              value: url.https://github.com/.insteadOf
+            - name: GIT_CONFIG_VALUE_2
+              value: "git@github.com:"
           resources:
             requests:
-              memory: 512Mi
+              memory: 1Gi
               cpu: 250m
             limits:
-              memory: 2Gi
-              cpu: "1"
+              memory: 4Gi
+              cpu: "2"
           startupProbe:
             tcpSocket:
               port: 18789

--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.4.27-slim
+    newTag: 2026.4.29-slim

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -184,11 +184,14 @@ type builtinPassthrough struct {
 // injection. These support core gateway functionality:
 //   - clawhub.ai: ClawHub plugin registry for plugin installs and skill downloads
 //   - openrouter.ai: model pricing API for cost estimation in the UI
+//   - github.com + codeload.github.com: git HTTPS clones and tarball fetches for npm packages with git dependencies (e.g. @whiskeysockets/baileys → libsignal-node)
 //   - raw.githubusercontent.com: LiteLLM model pricing data and WhatsApp Baileys library defaults (path-restricted)
 //   - registry.npmjs.org: npm packages for plugin runtime dependencies
 var builtinPassthroughDomains = []builtinPassthrough{
 	{Domain: "clawhub.ai"},
 	{Domain: "openrouter.ai"},
+	{Domain: "github.com"},
+	{Domain: "codeload.github.com"},
 	{Domain: "raw.githubusercontent.com", AllowedPaths: []string{"/BerriAI/litellm/", "/WhiskeySockets/Baileys/"}},
 	{Domain: "registry.npmjs.org"},
 }

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -298,6 +298,8 @@ func TestGenerateProxyConfig(t *testing.T) {
 		expectedDomains := []string{
 			"api.example.com",
 			"clawhub.ai",
+			"codeload.github.com",
+			"github.com",
 			"openrouter.ai",
 			"raw.githubusercontent.com",
 			"registry.npmjs.org",


### PR DESCRIPTION
- Bump image tag from 2026.4.27-slim to 2026.4.29-slim
- Increase gateway memory limit to 4Gi (OOMKilled during plugin staging)
- Add git SSH→HTTPS rewrite env vars (slim image lacks ssh binary)
- Add github.com and codeload.github.com as proxy passthroughs for npm packages with git dependencies (e.g. @whiskeysockets/baileys)


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct support for GitHub-hosted npm dependencies, enabling git/tarball fetches from GitHub domains without credential injection.

* **Improvements**
  * Increased gateway container resources for improved performance and reliability (memory and CPU limits/request increased).
  * Updated proxy behavior to treat GitHub hosts as passthrough, allowing direct HTTPS retrievals.

* **Chores**
  * Updated container image to a newer tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->