### PR TITLE
fix: split operator config to unblock OpenClaw config writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Kubernetes operator (Go, Kubebuilder/Operator SDK) that manages OpenClaw instanc
   - `gcp` (GCPConfig, optional): Required when type is `gcp`. Fields: `project` (GCP project ID, minLength=1), `location` (GCP region, minLength=1)
   - `pathToken` (PathTokenConfig, optional): Required when type is `pathToken`. Fields: `prefix` (URL path prefix, minLength=1)
   - `oauth2` (OAuth2Config, optional): Required when type is `oauth2`. Fields: `clientID` (minLength=1), `tokenURL` (minLength=1), `scopes` ([]string, optional)
-  - `provider` (string, optional): Maps this credential to an OpenClaw LLM provider (e.g., "google", "anthropic", "openai", "openrouter"). When set, the controller configures gateway routing and dynamically generates the provider entry in `operator.json` (included by the user-owned `openclaw.json` via `$include`). When omitted, the credential is used for MITM forward proxy only. For `provider: "google"` with `type: apiKey`, the controller uses the Gemini REST API upstream (`generativelanguage.googleapis.com/v1beta`). For `provider: "google"` with `type: gcp`, it uses Vertex AI upstream (`{location}-aiplatform.googleapis.com`).
+  - `provider` (string, optional): Maps this credential to an OpenClaw LLM provider (e.g., "google", "anthropic", "openai", "openrouter"). When set, the controller configures gateway routing and dynamically generates the provider entry in `operator-models.json` (included by the user-owned `openclaw.json` via nested `$include` in the `models` subtree). When omitted, the credential is used for MITM forward proxy only. For `provider: "google"` with `type: apiKey`, the controller uses the Gemini REST API upstream (`generativelanguage.googleapis.com/v1beta`). For `provider: "google"` with `type: gcp`, it uses Vertex AI upstream (`{location}-aiplatform.googleapis.com`).
   - `allowedPaths` ([]string, optional): Restricts which URL paths the proxy permits for this domain. Each entry is a path prefix (e.g., "/v1/api/"). If empty, all paths are allowed. Used by builtin passthrough domains (e.g., `raw.githubusercontent.com` is restricted to `/BerriAI/litellm/` and `/WhiskeySockets/Baileys/`) and available for user-defined credentials.
 
 **Status Fields:**
@@ -142,12 +142,13 @@ The operator uses a **single unified controller** that manages all resources usi
 The `claw-config` ConfigMap uses a **split config** approach to preserve user and application changes across reconciles:
 
 **Operator-managed files** (always overwritten on PVC by init container):
-- `operator.json` — Gateway settings, CORS origins, providers, proxy config. Rewritten every reconcile.
+- `operator-gateway.json` — Gateway settings (port, auth, CORS origins, trusted proxies). Rewritten every reconcile.
+- `operator-models.json` — Model providers configuration. Rewritten every reconcile.
 - `PROXY_SETUP.md` — Proxy architecture skill file (always present). Explains the proxy security model and how to configure access to external services (WhatsApp, custom domains). Init container copies to `skills/proxy/SKILL.md` for OpenClaw auto-discovery.
 - `KUBERNETES.md` — Kubernetes skill file (only when k8s credentials present). Always overwritten. Init container copies to `skills/kubernetes/SKILL.md` for OpenClaw auto-discovery.
 
 **User-owned files** (seeded once, then owned by user/OpenClaw):
-- `openclaw.json` — Contains `"$include": "./operator.json"` plus agent defaults (model aliases, primary model, agent list). Seeded only if file doesn't exist on PVC. User and OpenClaw Control UI changes survive pod restarts.
+- `openclaw.json` — Uses nested `$include` directives (`gateway.$include: ./operator-gateway.json`, `models.$include: ./operator-models.json`) plus agent defaults (model aliases, primary model, agent list), cron settings. Seeded only if file doesn't exist on PVC. User and OpenClaw Control UI changes survive pod restarts. The `$include` directives are at subtree level (not root), which allows OpenClaw's config write-back (plugin installs, UI changes) to modify sibling paths like `plugins.installs` without triggering the include-flatten protection.
 - `AGENTS.md` — System prompt. Seeded only if file doesn't exist on PVC.
 
 OpenClaw's `$include` mechanism deep-merges the included file with sibling keys at config load time. Sibling keys (user's root file) win over included values for primitives, objects merge recursively, arrays concatenate. The write-back logic avoids pulling included values into the root file on save.
@@ -242,7 +243,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
   ↓
 7. injectRouteHostIntoConfigMap(objects, routeHost)
    ├─ Find claw-config ConfigMap in objects
-   ├─ Extract data["operator.json"] string
+   ├─ Extract data["operator-gateway.json"] string
    ├─ Replace "OPENCLAW_ROUTE_HOST" placeholder with routeHost (https://...)
    ├─ If routeHost is empty (vanilla Kubernetes): use "http://localhost:18789" fallback
    └─ Set modified JSON back into ConfigMap
@@ -251,7 +252,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    ├─ Filter credentials with Provider set
    ├─ For gateway-routed providers: resolveProviderInfo(cred) → upstream + basePath as baseUrl (MITM proxy injects credentials transparently)
    ├─ For Vertex SDK providers (GCP + non-Google, e.g., anthropic): map to "{provider}-vertex" key with real Vertex AI URL, api mapping, and "gcp-vertex-credentials" apiKey
-   ├─ Write providers into data["operator.json"] (agent defaults are user-owned in openclaw.json seed)
+   ├─ Write providers into data["operator-models.json"] (agent defaults are user-owned in openclaw.json seed)
    └─ Credentials without Provider are MITM-only (no provider entry)
   ↓
 7c. injectKubernetesSkill(objects, resolvedCreds)
@@ -266,7 +267,7 @@ PHASE 3: ConfigMap Injection and Remaining Resources
    └─ No-op when all ports are 443 or no kubernetes credentials present
   ↓
 7e. stampGatewayConfigHash(objects, instanceName)
-   ├─ Hash entire ConfigMap data (operator.json, openclaw.json, etc.)
+   ├─ Hash entire ConfigMap data (operator-gateway.json, operator-models.json, openclaw.json, etc.)
    ├─ Stamp SHA-256 hash as annotation on gateway pod template
    └─ Triggers gateway pod rollout when ConfigMap content changes (e.g., after operator upgrade)
   ↓
@@ -307,8 +308,8 @@ PHASE 3: ConfigMap Injection and Remaining Resources
 - `applyRouteOnly()` — applies only Route resource from Kustomize manifests (Phase 2)
 - `getRouteURL()` — fetches Route and extracts `.status.ingress[0].host`, returns empty string if status not populated
 - `buildKustomizedObjects()` — builds Kustomize manifests, configures proxy deployment, stamps Secret version, returns parsed objects
-- `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in `operator.json` with Route host (or localhost fallback)
-- `injectProvidersIntoConfigMap()` — dynamically builds `models.providers` in `operator.json`. Provider baseUrl points to real upstream URLs (e.g., `https://generativelanguage.googleapis.com/v1beta`); the MITM proxy injects credentials transparently via HTTP_PROXY. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL. Does not touch agent defaults (user-owned in openclaw.json seed)
+- `injectRouteHostIntoConfigMap()` — replaces `OPENCLAW_ROUTE_HOST` placeholder in `operator-gateway.json` with Route host (or localhost fallback)
+- `injectProvidersIntoConfigMap()` — dynamically builds `providers` in `operator-models.json`. Provider baseUrl points to real upstream URLs (e.g., `https://generativelanguage.googleapis.com/v1beta`); the MITM proxy injects credentials transparently via HTTP_PROXY. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL. Does not touch agent defaults (user-owned in openclaw.json seed)
 - `resolveAndApplyCredentials()` — orchestrates credential resolution: resolves provider defaults, validates credentials (returning `[]resolvedCredential`), applies sanitized kubeconfig ConfigMap for kubernetes credentials, and applies proxy CA
 - `resolveCredentials()` — validates all credentials and referenced Secrets. For `kubernetes` type, parses kubeconfig with `client-go/tools/clientcmd`, validates token-only auth, extracts cluster/context metadata. Returns `[]resolvedCredential` (replaces former `validateCredentials`)
 - `parseAndValidateKubeconfig()` — parses kubeconfig bytes, validates all users use token-based auth (rejects client certs, exec, auth provider), validates unique token per server `hostname:port`, returns `kubeconfigData`
@@ -368,7 +369,7 @@ var ManifestsFS embed.FS
 
 The `internal/assets/manifests/` directory contains:
 - **kustomization.yaml** — defines labels and resource list
-- **configmap.yaml** — OpenClaw configuration (operator.json for operator-managed settings, openclaw.json as user-owned seed with `$include`, AGENTS.md seed, PROXY_SETUP.md for proxy architecture skill, KUBERNETES.md for k8s skill)
+- **configmap.yaml** — OpenClaw configuration (operator-gateway.json and operator-models.json for operator-managed settings, openclaw.json as user-owned seed with nested `$include` directives, AGENTS.md seed, PROXY_SETUP.md for proxy architecture skill, KUBERNETES.md for k8s skill)
 - **pvc.yaml** — persistent storage (10Gi ReadWriteOnce)
 - **deployment.yaml** — OpenClaw application pods (init containers with readOnlyRootFilesystem, gateway without; PVC subpath mounts at `~/.local`, `~/.cache`, `~/.config` for persistent tool state; `wait-for-proxy` init container ensures proxy is ready before gateway starts; `OPENCLAW_PROXY_ACTIVE=1` env var enables native managed proxy support)
 - **service.yaml** — ClusterIP service exposing OpenClaw gateway (port 18789)

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -5,32 +5,34 @@ metadata:
   labels:
     app: claw
 data:
-  operator.json: |
+  operator-gateway.json: |
     {
-      "gateway": {
-        "mode": "local",
-        "bind": "lan",
-        "port": 18789,
-        "auth": {
-          "mode": "token"
-        },
-        "controlUi": {
-          "enabled": true,
-          "allowedOrigins": ["OPENCLAW_ROUTE_HOST"]
-        },
-        "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12"]
+      "mode": "local",
+      "bind": "lan",
+      "port": 18789,
+      "auth": {
+        "mode": "token"
       },
-      "models": {
-        "providers": {}
+      "controlUi": {
+        "enabled": true,
+        "allowedOrigins": ["OPENCLAW_ROUTE_HOST"]
       },
-      "cron": { "enabled": false }
+      "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12"]
+    }
+  operator-models.json: |
+    {
+      "providers": {}
     }
   openclaw.json: |
     {
-      "$include": "./operator.json",
       "gateway": {
+        "$include": "./operator-gateway.json",
         "mode": "local"
       },
+      "models": {
+        "$include": "./operator-models.json"
+      },
+      "cron": { "enabled": false },
       "agents": {
         "defaults": {
           "model": { "primary": "google/gemini-3-flash-preview" },

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -34,7 +34,8 @@ spec:
             - sh
             - -c
             - |
-              cp /config/operator.json /home/node/.openclaw/operator.json
+              cp /config/operator-gateway.json /home/node/.openclaw/operator-gateway.json
+              cp /config/operator-models.json /home/node/.openclaw/operator-models.json
               mkdir -p /home/node/.openclaw/workspace /home/node/.openclaw/.local /home/node/.openclaw/.cache /home/node/.openclaw/.config/codex
               [ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
               [ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -201,14 +201,14 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(getConfigMapName(testInstanceName))
 		cm.Object["data"] = map[string]any{
-			"operator.json": jsonContent,
+			"operator-models.json": jsonContent,
 		}
 		return []*unstructured.Unstructured{cm}
 	}
 
 	getConfig := func(t *testing.T, objects []*unstructured.Unstructured) map[string]any {
 		t.Helper()
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator-models.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
@@ -217,12 +217,11 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 
 	getProviders := func(t *testing.T, config map[string]any) map[string]any {
 		t.Helper()
-		models := config["models"].(map[string]any)
-		return models["providers"].(map[string]any)
+		return config["providers"].(map[string]any)
 	}
 
 	t.Run("should map GCP anthropic to anthropic-vertex provider key", func(t *testing.T) {
-		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		objects := makeConfigMap(`{"providers":{}}`)
 		credentials := []clawv1alpha1.CredentialSpec{
 			{
 				Name:     "anthropic-vertex",
@@ -251,7 +250,7 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 	})
 
 	t.Run("should use plain hostname for global location", func(t *testing.T) {
-		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		objects := makeConfigMap(`{"providers":{}}`)
 		credentials := []clawv1alpha1.CredentialSpec{
 			{
 				Name:     "anthropic-vertex",
@@ -274,7 +273,7 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 	})
 
 	t.Run("should set maxTokens and no api for non-anthropic vertex provider", func(t *testing.T) {
-		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		objects := makeConfigMap(`{"providers":{}}`)
 		credentials := []clawv1alpha1.CredentialSpec{
 			{
 				Name:     "meta-vertex",
@@ -302,7 +301,7 @@ func TestInjectProvidersVertexSDK(t *testing.T) {
 	})
 
 	t.Run("should reject duplicate vertex providers", func(t *testing.T) {
-		objects := makeConfigMap(`{"models":{"providers":{}}}`)
+		objects := makeConfigMap(`{"providers":{}}`)
 		credentials := []clawv1alpha1.CredentialSpec{
 			{
 				Name: "claude-vertex-1", Type: clawv1alpha1.CredentialTypeGCP, Provider: "anthropic",

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -202,8 +202,8 @@ func TestStampGatewayConfigHash(t *testing.T) {
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(getConfigMapName(testInstanceName))
 		cm.Object["data"] = map[string]any{
-			"operator.json": operatorJSON,
-			"openclaw.json": `{"$include":"./operator.json"}`,
+			"operator-gateway.json": operatorJSON,
+			"openclaw.json":         `{"gateway":{"$include":"./operator-gateway.json"}}`,
 		}
 
 		dep := &unstructured.Unstructured{}
@@ -275,7 +275,7 @@ func TestStampGatewayConfigHash(t *testing.T) {
 		cm := &unstructured.Unstructured{}
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(getConfigMapName(testInstanceName))
-		cm.Object["data"] = map[string]any{"operator.json": "{}"}
+		cm.Object["data"] = map[string]any{"operator-gateway.json": "{}"}
 
 		err := stampGatewayConfigHash([]*unstructured.Unstructured{cm}, testInstanceName)
 		assert.Error(t, err)

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -823,8 +823,8 @@ func stampProxyConfigHash(objects []*unstructured.Unstructured, instance *clawv1
 }
 
 // stampGatewayConfigHash computes a SHA-256 hash of the gateway ConfigMap data and
-// stamps it on the gateway pod template. This triggers a rollout when operator.json
-// or other operator-managed config files change (e.g., after an operator upgrade).
+// stamps it on the gateway pod template. This triggers a rollout when operator-managed
+// config files change (e.g., after an operator upgrade).
 func stampGatewayConfigHash(objects []*unstructured.Unstructured, instanceName string) error {
 	configMapName := getConfigMapName(instanceName)
 	var configData map[string]any

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -765,21 +765,20 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		cm.SetKind(ConfigMapKind)
 		cm.SetName(getConfigMapName(testInstanceName))
 		cm.Object["data"] = map[string]any{
-			"operator.json": jsonContent,
+			"operator-models.json": jsonContent,
 		}
 		return []*unstructured.Unstructured{cm}
 	}
 
-	baseJSON := `{"models":{"providers":{}},"gateway":{"port":18789}}`
+	baseJSON := `{"providers":{}}`
 
 	getProviders := func(t *testing.T, objects []*unstructured.Unstructured) map[string]any {
 		t.Helper()
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator-models.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
-		models := config["models"].(map[string]any)
-		return models["providers"].(map[string]any)
+		return config["providers"].(map[string]any)
 	}
 
 	t.Run("should inject google provider with correct baseUrl", func(t *testing.T) {
@@ -867,16 +866,16 @@ func TestInjectProvidersIntoConfigMap(t *testing.T) {
 		assert.Equal(t, "https://europe-west1-aiplatform.googleapis.com/v1/projects/my-proj/locations/europe-west1/publishers/google", google["baseUrl"])
 	})
 
-	t.Run("should preserve other config sections", func(t *testing.T) {
+	t.Run("should preserve providers key structure after injection", func(t *testing.T) {
 		objects := makeConfigMap(baseJSON)
 		require.NoError(t, injectProvidersIntoConfigMap(objects, testClawWithCredentials(nil)))
 
-		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator.json")
+		raw, _, err := unstructured.NestedString(objects[0].Object, "data", "operator-models.json")
 		require.NoError(t, err)
 		var config map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &config))
-		gateway := config["gateway"].(map[string]any)
-		assert.Equal(t, float64(18789), gateway["port"])
+		_, hasProviders := config["providers"]
+		assert.True(t, hasProviders, "providers key should exist after injection")
 	})
 
 	t.Run("should skip pathToken credentials even with provider set", func(t *testing.T) {
@@ -1018,15 +1017,13 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 			}, cm) == nil
 		}, "ConfigMap should be created")
 
-		operatorJSON, ok := cm.Data["operator.json"]
-		require.True(t, ok, "operator.json should exist")
+		modelsJSON, ok := cm.Data["operator-models.json"]
+		require.True(t, ok, "operator-models.json should exist")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(operatorJSON), &config))
+		require.NoError(t, json.Unmarshal([]byte(modelsJSON), &config))
 
-		models, ok := config["models"].(map[string]any)
-		require.True(t, ok, "models section should exist")
-		providers, ok := models["providers"].(map[string]any)
+		providers, ok := config["providers"].(map[string]any)
 		require.True(t, ok, "providers section should exist")
 		require.Contains(t, providers, "google", "google provider should be injected")
 
@@ -1063,10 +1060,9 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 		}, "ConfigMap should be created")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator.json"]), &config))
+		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator-models.json"]), &config))
 
-		models := config["models"].(map[string]any)
-		providers := models["providers"].(map[string]any)
+		providers := config["providers"].(map[string]any)
 		assert.Empty(t, providers, "providers should be empty when no credentials have provider set")
 	})
 
@@ -1085,10 +1081,9 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 		}, "ConfigMap should be created")
 
 		var config map[string]any
-		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator.json"]), &config))
+		require.NoError(t, json.Unmarshal([]byte(cm.Data["operator-models.json"]), &config))
 
-		models := config["models"].(map[string]any)
-		providers := models["providers"].(map[string]any)
+		providers := config["providers"].(map[string]any)
 		assert.Empty(t, providers, "providers should be empty for MITM-only credentials")
 	})
 }

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -755,7 +755,7 @@ func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*
 	return r.applyResources(ctx, routeObjects)
 }
 
-// injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator.json with actual Route host.
+// injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator-gateway.json with actual Route host.
 // If routeHost is empty (vanilla Kubernetes), uses localhost fallback.
 func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstructured.Unstructured, routeHost, instanceName string) error {
 	replacement := routeHost
@@ -766,18 +766,18 @@ func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstruc
 	configMapName := getConfigMapName(instanceName)
 	for _, obj := range objects {
 		if obj.GetKind() == ConfigMapKind && obj.GetName() == configMapName {
-			operatorJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator.json")
+			gatewayJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator-gateway.json")
 			if err != nil {
-				return fmt.Errorf("failed to extract operator.json from ConfigMap: %w", err)
+				return fmt.Errorf("failed to extract operator-gateway.json from ConfigMap: %w", err)
 			}
 			if !found {
-				return fmt.Errorf("operator.json not found in ConfigMap data")
+				return fmt.Errorf("operator-gateway.json not found in ConfigMap data")
 			}
 
-			updatedJSON := strings.ReplaceAll(operatorJSON, "OPENCLAW_ROUTE_HOST", replacement)
+			updatedJSON := strings.ReplaceAll(gatewayJSON, "OPENCLAW_ROUTE_HOST", replacement)
 
-			if err := unstructured.SetNestedField(obj.Object, updatedJSON, "data", "operator.json"); err != nil {
-				return fmt.Errorf("failed to set updated operator.json in ConfigMap: %w", err)
+			if err := unstructured.SetNestedField(obj.Object, updatedJSON, "data", "operator-gateway.json"); err != nil {
+				return fmt.Errorf("failed to set updated operator-gateway.json in ConfigMap: %w", err)
 			}
 
 			return nil
@@ -787,7 +787,7 @@ func (r *ClawResourceReconciler) injectRouteHostIntoConfigMap(objects []*unstruc
 	return fmt.Errorf("ConfigMap %q not found in manifests", configMapName)
 }
 
-// injectProvidersIntoConfigMap dynamically builds the models.providers section of operator.json
+// injectProvidersIntoConfigMap dynamically builds the providers section of operator-models.json
 // from credentials that have Provider set. Gateway-routed providers get a baseUrl pointing to
 // the proxy. Vertex SDK providers (GCP + non-Google) get the real Vertex AI URL since traffic
 // flows through the MITM proxy which injects GCP credentials transparently.
@@ -839,33 +839,28 @@ func injectProvidersIntoConfigMap(objects []*unstructured.Unstructured, instance
 			continue
 		}
 
-		operatorJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator.json")
+		modelsJSON, found, err := unstructured.NestedString(obj.Object, "data", "operator-models.json")
 		if err != nil {
-			return fmt.Errorf("failed to extract operator.json from ConfigMap: %w", err)
+			return fmt.Errorf("failed to extract operator-models.json from ConfigMap: %w", err)
 		}
 		if !found {
-			return fmt.Errorf("operator.json not found in ConfigMap data")
+			return fmt.Errorf("operator-models.json not found in ConfigMap data")
 		}
 
 		var config map[string]any
-		if err := json.Unmarshal([]byte(operatorJSON), &config); err != nil {
-			return fmt.Errorf("failed to parse operator.json: %w", err)
+		if err := json.Unmarshal([]byte(modelsJSON), &config); err != nil {
+			return fmt.Errorf("failed to parse operator-models.json: %w", err)
 		}
 
-		models, _ := config["models"].(map[string]any)
-		if models == nil {
-			models = map[string]any{}
-			config["models"] = models
-		}
-		models["providers"] = providers
+		config["providers"] = providers
 
 		updatedJSON, err := json.MarshalIndent(config, "    ", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal operator.json: %w", err)
+			return fmt.Errorf("failed to marshal operator-models.json: %w", err)
 		}
 
-		if err := unstructured.SetNestedField(obj.Object, string(updatedJSON), "data", "operator.json"); err != nil {
-			return fmt.Errorf("failed to set updated operator.json in ConfigMap: %w", err)
+		if err := unstructured.SetNestedField(obj.Object, string(updatedJSON), "data", "operator-models.json"); err != nil {
+			return fmt.Errorf("failed to set updated operator-models.json in ConfigMap: %w", err)
 		}
 		return nil
 	}

--- a/internal/controller/claw_resource_controller_test.go
+++ b/internal/controller/claw_resource_controller_test.go
@@ -92,7 +92,7 @@ func TestClawConfigMapController(t *testing.T) {
 			}, "ConfigMap should have correct owner reference")
 		})
 
-		t.Run("should have operator.json with gateway config and providers", func(t *testing.T) {
+		t.Run("should have operator-gateway.json and operator-models.json", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
 			})
@@ -109,23 +109,29 @@ func TestClawConfigMapController(t *testing.T) {
 				}, configMap) == nil
 			}, "ConfigMap should be created")
 
-			operatorJSON, ok := configMap.Data["operator.json"]
-			require.True(t, ok, "operator.json key must exist")
+			gatewayJSON, ok := configMap.Data["operator-gateway.json"]
+			require.True(t, ok, "operator-gateway.json key must exist")
 
-			var config map[string]any
-			require.NoError(t, json.Unmarshal([]byte(operatorJSON), &config))
+			var gatewayConfig map[string]any
+			require.NoError(t, json.Unmarshal([]byte(gatewayJSON), &gatewayConfig))
 
-			_, hasGateway := config["gateway"]
-			assert.True(t, hasGateway, "operator.json should contain gateway section")
+			_, hasAuth := gatewayConfig["auth"]
+			assert.True(t, hasAuth, "operator-gateway.json should contain auth section")
 
-			_, hasModels := config["models"]
-			assert.True(t, hasModels, "operator.json should contain models section")
+			_, hasControlUi := gatewayConfig["controlUi"]
+			assert.True(t, hasControlUi, "operator-gateway.json should contain controlUi section")
 
-			_, hasAgents := config["agents"]
-			assert.False(t, hasAgents, "operator.json must not contain agents section (user-owned)")
+			modelsJSON, ok := configMap.Data["operator-models.json"]
+			require.True(t, ok, "operator-models.json key must exist")
+
+			var modelsConfig map[string]any
+			require.NoError(t, json.Unmarshal([]byte(modelsJSON), &modelsConfig))
+
+			_, hasProviders := modelsConfig["providers"]
+			assert.True(t, hasProviders, "operator-models.json should contain providers section")
 		})
 
-		t.Run("should have openclaw.json seed with $include directive", func(t *testing.T) {
+		t.Run("should have openclaw.json seed with nested $include directives", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
 			})
@@ -148,13 +154,17 @@ func TestClawConfigMapController(t *testing.T) {
 			var config map[string]any
 			require.NoError(t, json.Unmarshal([]byte(openclawJSON), &config))
 
-			include, hasInclude := config["$include"]
-			require.True(t, hasInclude, "openclaw.json must contain $include directive")
-			assert.Equal(t, "./operator.json", include, "$include should reference operator.json")
+			_, hasRootInclude := config["$include"]
+			assert.False(t, hasRootInclude, "openclaw.json must NOT have root-level $include (blocks config writes)")
 
 			gateway, hasGateway := config["gateway"].(map[string]any)
-			require.True(t, hasGateway, "openclaw.json seed must contain gateway section for config safety check")
+			require.True(t, hasGateway, "openclaw.json seed must contain gateway section")
+			assert.Equal(t, "./operator-gateway.json", gateway["$include"], "$include should reference operator-gateway.json")
 			assert.Equal(t, "local", gateway["mode"], "gateway.mode must be present to survive OpenClaw write-back")
+
+			models, hasModels := config["models"].(map[string]any)
+			require.True(t, hasModels, "openclaw.json seed must contain models section")
+			assert.Equal(t, "./operator-models.json", models["$include"], "$include should reference operator-models.json")
 
 			agents, hasAgents := config["agents"].(map[string]any)
 			require.True(t, hasAgents, "openclaw.json seed should contain agents section")
@@ -705,7 +715,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(getConfigMapName(testInstanceName))
 			configMap.Object["data"] = map[string]any{
-				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator-gateway.json": `{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -719,11 +729,11 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			operatorJSON, found, err := unstructured.NestedString(configMap.Object, "data", "operator.json")
-			require.NoError(t, err, "failed to get operator.json")
-			assert.True(t, found, "operator.json not found in ConfigMap data")
-			assert.Contains(t, operatorJSON, routeHost)
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+			gatewayJSON, found, err := unstructured.NestedString(configMap.Object, "data", "operator-gateway.json")
+			require.NoError(t, err, "failed to get operator-gateway.json")
+			assert.True(t, found, "operator-gateway.json not found in ConfigMap data")
+			assert.Contains(t, gatewayJSON, routeHost)
+			assert.NotContains(t, gatewayJSON, "OPENCLAW_ROUTE_HOST")
 		})
 
 		t.Run("should replace all occurrences of OPENCLAW_ROUTE_HOST placeholder", func(t *testing.T) {
@@ -731,7 +741,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(getConfigMapName(testInstanceName))
 			configMap.Object["data"] = map[string]any{
-				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST","OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator-gateway.json": `{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST","OPENCLAW_ROUTE_HOST"]}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -745,10 +755,10 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
-			hostCount := strings.Count(operatorJSON, routeHost)
+			gatewayJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator-gateway.json")
+			hostCount := strings.Count(gatewayJSON, routeHost)
 			assert.Equal(t, 2, hostCount, "expected 2 occurrences of routeHost")
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+			assert.NotContains(t, gatewayJSON, "OPENCLAW_ROUTE_HOST")
 		})
 
 		t.Run("should use localhost fallback when routeHost is empty", func(t *testing.T) {
@@ -756,7 +766,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			configMap.SetKind(ConfigMapKind)
 			configMap.SetName(getConfigMapName(testInstanceName))
 			configMap.Object["data"] = map[string]any{
-				"operator.json": `{"gateway":{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}}`,
+				"operator-gateway.json": `{"controlUi":{"allowedOrigins":["OPENCLAW_ROUTE_HOST"]}}`,
 			}
 
 			objects := []*unstructured.Unstructured{configMap}
@@ -770,9 +780,9 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			err := reconciler.injectRouteHostIntoConfigMap(objects, routeHost, testInstanceName)
 			require.NoError(t, err, "injectRouteHostIntoConfigMap failed")
 
-			operatorJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator.json")
-			assert.Contains(t, operatorJSON, "http://localhost:18789")
-			assert.NotContains(t, operatorJSON, "OPENCLAW_ROUTE_HOST")
+			gatewayJSON, _, _ := unstructured.NestedString(configMap.Object, "data", "operator-gateway.json")
+			assert.Contains(t, gatewayJSON, "http://localhost:18789")
+			assert.NotContains(t, gatewayJSON, "OPENCLAW_ROUTE_HOST")
 		})
 	})
 
@@ -840,12 +850,12 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				operatorJSON, ok := configMap.Data["operator.json"]
+				gatewayJSON, ok := configMap.Data["operator-gateway.json"]
 				if !ok {
 					return false
 				}
-				return strings.Contains(operatorJSON, "http://localhost:18789")
-			}, "ConfigMap should contain localhost fallback in operator.json")
+				return strings.Contains(gatewayJSON, "http://localhost:18789")
+			}, "ConfigMap should contain localhost fallback in operator-gateway.json")
 		})
 	})
 
@@ -887,7 +897,7 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 	})
 
 	t.Run("Init container config seeding", func(t *testing.T) {
-		t.Run("should always copy operator.json and conditionally seed user files", func(t *testing.T) {
+		t.Run("should always copy operator config files and conditionally seed user files", func(t *testing.T) {
 			reconciler := createClawReconciler()
 			instance := &clawv1alpha1.Claw{}
 			instance.Name = testInstanceName
@@ -920,8 +930,10 @@ func TestOpenClawRouteConfiguration(t *testing.T) {
 			}
 			require.NotEmpty(t, initConfigScript, "init-config container should exist")
 
-			assert.Contains(t, initConfigScript, "cp /config/operator.json /home/node/.openclaw/operator.json",
-				"operator.json should always be copied unconditionally")
+			assert.Contains(t, initConfigScript, "cp /config/operator-gateway.json /home/node/.openclaw/operator-gateway.json",
+				"operator-gateway.json should always be copied unconditionally")
+			assert.Contains(t, initConfigScript, "cp /config/operator-models.json /home/node/.openclaw/operator-models.json",
+				"operator-models.json should always be copied unconditionally")
 			assert.Contains(t, initConfigScript, "[ -f /home/node/.openclaw/openclaw.json ] || cp",
 				"openclaw.json should only be seeded if missing")
 			assert.Contains(t, initConfigScript, "[ -f /home/node/.openclaw/workspace/AGENTS.md ] || cp",


### PR DESCRIPTION
OpenClaw's config write-back refuses to modify openclaw.json when it has a root-level $include directive — any mutation triggers the "would flatten $include-owned config at <root>" safety check. This blocked plugin installs (e.g. WhatsApp), UI config changes, and any programmatic config writes.

- Split operator.json into operator-gateway.json (gateway settings) and operator-models.json (provider configuration)
- Restructure openclaw.json to use nested $include at subtree level (gateway.$include, models.$include) instead of root-level $include
- Update injectRouteHostIntoConfigMap to target operator-gateway.json
- Update injectProvidersIntoConfigMap to target operator-models.json
- Update init container to copy both new operator config files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to reflect new operator configuration file structure.

* **Refactor**
  * Reorganized operator configuration into separate gateway and model configuration files for improved modularity.
  * Updated deployment initialization to handle the restructured configuration files.
  * Adjusted configuration injection and management to accommodate the new file organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->