### PR TITLE
docs: add config merge design proposal

### DIFF
--- a/docs/proposals/config-merge-design.md
+++ b/docs/proposals/config-merge-design.md
@@ -26,8 +26,8 @@ deployment tool (openclaw-operator, openclaw-installer, NemoClaw, paude).
    standard config mutations (plugin install, `config.patch`, UI settings) work.
 
 2. **Operator controls what it needs to** — gateway settings, CORS origins,
-   provider definitions, and cron are always overwritten. The operator is the
-   source of truth for infrastructure config.
+   and provider definitions are always overwritten. The operator is the source
+   of truth for infrastructure config.
 
 3. **User changes survive pod restarts** (in `merge` mode) — keys the operator
    doesn't touch (plugins, agent config, model preferences, channels) persist on
@@ -64,7 +64,7 @@ ConfigMap                          PVC (openclaw.json)
 │  agents: {user-owned, preserved}     │
 │  plugins: {user-owned, preserved}    │
 │  channels: {user-owned, preserved}   │
-│  cron: {from operator.json}          │
+│  cron: {user-owned, preserved}       │
 └──────────────────────────────────────┘
          │
   OpenClaw loads ──▶ plain JSON, no includes
@@ -209,7 +209,7 @@ Key changes from current:
 ### Controller changes
 
 Minimal. The controller continues to:
-- Build `operator.json` with gateway settings, CORS, providers, cron
+- Build `operator.json` with gateway settings, CORS, providers
 - Inject Route host, providers, skills into the ConfigMap
 - Stamp config hash for rollout detection
 

--- a/docs/proposals/config-merge-design.md
+++ b/docs/proposals/config-merge-design.md
@@ -1,0 +1,228 @@
+# Drop `$include`, Deep-Merge Config at Init Time
+
+**Status:** Final
+
+## Overview
+
+OpenClaw's `$include` directive at the root of `openclaw.json` blocks all runtime
+config writes — plugin installs, `config.patch` via the gateway tool, and any
+automated mutation. This breaks WhatsApp setup and any other plugin that needs to
+persist config.
+
+The root cause is OpenClaw's flatten guard (`preserveUntouchedIncludes`): a
+root-level `$include` makes `collectIncludeOwnedPaths` record path `[]`, and
+`patchTouchesPath(patch, [])` returns true for **any** non-empty patch. Every
+write is rejected with _"Config write would flatten $include-owned config at
+\<root\>"_.
+
+This design replaces the `$include` approach with init-time deep-merging, where
+the init container merges operator-managed settings into the user's config file
+on every pod start. This is the proven pattern used by every other OpenClaw
+deployment tool (openclaw-operator, openclaw-installer, NemoClaw, paude).
+
+## Design Principles
+
+1. **OpenClaw sees a plain JSON file** — no `$include`, no write barriers. All
+   standard config mutations (plugin install, `config.patch`, UI settings) work.
+
+2. **Operator controls what it needs to** — gateway settings, CORS origins,
+   provider definitions, and cron are always overwritten. The operator is the
+   source of truth for infrastructure config.
+
+3. **User changes survive pod restarts** (in `merge` mode) — keys the operator
+   doesn't touch (plugins, agent config, model preferences, channels) persist on
+   the PVC across restarts.
+
+4. **Lockdown available** — `spec.configMode: overwrite` disables runtime config
+   mutability for managed/shared deployments where user edits are not desired.
+
+5. **Minimal change surface** — the ConfigMap structure, controller injection
+   logic, and Kustomize pipeline remain the same. Only the init container script
+   and `openclaw.json` seed change.
+
+## Architecture / How It Works
+
+### New flow
+
+```
+ConfigMap                          PVC (openclaw.json)
+┌─────────────────────┐
+│ operator.json       │           (read from ConfigMap mount at /config/)
+│ openclaw.json seed  │──if new──▶ seeded to PVC (plain JSON, no $include)
+└─────────────────────┘
+         │
+    init container (gateway image, Node.js)
+    deep-merges /config/operator.json
+    INTO /home/node/.openclaw/openclaw.json
+    (operator keys win, arrays replace)
+         │
+         ▼
+┌──────────────────────────────────────┐
+│ openclaw.json (merged, plain JSON)   │
+│  gateway: {from operator.json}       │
+│  models: {from operator.json}        │
+│  agents: {user-owned, preserved}     │
+│  plugins: {user-owned, preserved}    │
+│  channels: {user-owned, preserved}   │
+│  cron: {from operator.json}          │
+└──────────────────────────────────────┘
+         │
+  OpenClaw loads ──▶ plain JSON, no includes
+         │
+  Plugin install ──▶ WORKS (standard write path)
+  config.patch   ──▶ WORKS
+  WhatsApp setup ──▶ WORKS
+```
+
+### What gets merged and who wins
+
+| Config section | Owner | Behavior on pod restart (merge mode) |
+|---|---|---|
+| `gateway.*` | Operator | **Overwritten** — CORS origins, auth mode, bind, port, trustedProxies |
+| `models.providers` | Operator | **Overwritten** — tracks credentials in Claw CR |
+| `cron` | Operator | **Overwritten** |
+| `agents.*` | User | **Preserved** — model aliases, primary model, agent list, workspace |
+| `plugins.*` | User | **Preserved** — plugin installs, allow/deny lists |
+| `channels.*` | User | **Preserved** — WhatsApp, Telegram, etc. |
+| `tools.*` | User | **Preserved** |
+
+### Deep merge semantics
+
+- **Objects**: merge recursively; operator keys override matching user keys
+- **Arrays**: operator value replaces user value (not concatenated)
+- **Primitives**: operator value wins
+
+### `spec.configMode` CRD field
+
+A top-level enum on `ClawSpec` with values `merge` (default) and `overwrite`:
+
+- **`merge`** (default): init container seeds `openclaw.json` if missing, then
+  deep-merges `operator.json` into it. User-owned keys survive restarts. Plugin
+  installs, channel configs, and agent customizations persist.
+
+- **`overwrite`**: init container fully overwrites `openclaw.json` with the
+  operator-managed config on every pod start. User edits are wiped. Suitable for
+  managed deployments (Dev Sandbox shared instances) where the operator is the
+  sole config authority.
+
+### Init container
+
+Uses the gateway image (`ghcr.io/openclaw/openclaw:slim`) — same image as the
+main container, already cached. Provides Node.js for the merge script. Replaces
+the current busybox-based `init-config` container.
+
+**Merge mode script** (pseudocode):
+```javascript
+const base = JSON.parse(fs.readFileSync("/home/node/.openclaw/openclaw.json"));
+const ops = JSON.parse(fs.readFileSync("/config/operator.json"));
+
+function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])
+        && result[key] && typeof result[key] === "object" && !Array.isArray(result[key])) {
+      result[key] = deepMerge(result[key], source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+fs.writeFileSync("/home/node/.openclaw/openclaw.json",
+  JSON.stringify(deepMerge(base, ops), null, 2));
+```
+
+**Overwrite mode script** (pseudocode):
+```javascript
+const seed = JSON.parse(fs.readFileSync("/config/openclaw.json"));
+const ops = JSON.parse(fs.readFileSync("/config/operator.json"));
+// Always start from seed (ignore PVC state) — user edits don't survive
+fs.writeFileSync("/home/node/.openclaw/openclaw.json",
+  JSON.stringify(deepMerge(seed, ops), null, 2));
+```
+
+The key difference: merge mode reads the **existing PVC file** as the base (preserving
+user changes), while overwrite mode reads the **ConfigMap seed** as the base (resetting
+to operator-defined state every restart).
+
+### Files on PVC
+
+| File | Written by | When |
+|---|---|---|
+| `openclaw.json` | init container | Every pod start (merge or overwrite) |
+| `workspace/AGENTS.md` | init container | Seed if missing |
+| `workspace/skills/proxy/SKILL.md` | init container | Always (operator-managed) |
+| `workspace/skills/kubernetes/SKILL.md` | init container | Always when k8s credentials present |
+
+Note: `operator.json` is **not** written to PVC. It's only read from the
+ConfigMap volume mount at `/config/`.
+
+### ConfigMap structure (updated)
+
+```yaml
+data:
+  operator.json: |
+    {
+      "gateway": { ... },
+      "models": { "providers": { ... } },
+      "cron": { "enabled": false }
+    }
+  openclaw.json: |
+    {
+      "agents": {
+        "defaults": {
+          "model": { "primary": "google/gemini-3-flash-preview" },
+          "models": { ... },
+          "workspace": "~/.openclaw/workspace"
+        },
+        "list": [{ "id": "default", "name": "OpenClaw Assistant", ... }]
+      }
+    }
+  AGENTS.md: |
+    ...
+  PROXY_SETUP.md: |
+    ...
+```
+
+Key changes from current:
+- `openclaw.json` no longer has `$include` or `gateway` section — purely
+  user-owned seed content
+- `operator.json` gains no new fields (structure unchanged)
+
+### Controller changes
+
+Minimal. The controller continues to:
+- Build `operator.json` with gateway settings, CORS, providers, cron
+- Inject Route host, providers, skills into the ConfigMap
+- Stamp config hash for rollout detection
+
+The only controller change is making the init container script conditional on
+`spec.configMode`. The controller injects a `CLAW_CONFIG_MODE` environment
+variable on the init container (same pattern as existing env var injection on
+the proxy deployment via `configureProxyDeployment`).
+
+## Implementation Plan
+
+### Phase 1: Drop `$include` and implement merge
+
+1. Update `configmap.yaml`: remove `$include` and `gateway` section from
+   `openclaw.json` seed
+2. Update `deployment.yaml`: change `init-config` to gateway image, implement
+   merge/overwrite script with mode detection
+3. Update tests: assert no `$include` in `openclaw.json` seed, verify ConfigMap
+   content
+
+### Phase 2: Add `spec.configMode` to CRD
+
+4. Add `ConfigMode` field to `ClawSpec` in `claw_types.go` with enum validation
+5. Run `make manifests && make generate`
+6. Update controller to inject `CLAW_CONFIG_MODE` env var on init container
+   (new function `configureClawDeploymentConfigMode` following existing patterns)
+7. Init script already branches on `$CLAW_CONFIG_MODE` from Phase 1
+8. Add tests for both modes (merge preserves user keys, overwrite resets)
+
+### Phase 3: Update documentation
+
+9. Update `CLAUDE.md` with new config approach
+10. Update `PROXY_SETUP.md` if needed

--- a/docs/proposals/config-merge-design.md
+++ b/docs/proposals/config-merge-design.md
@@ -80,11 +80,11 @@ ConfigMap                          PVC (openclaw.json)
 |---|---|---|
 | `gateway.*` | Operator | **Overwritten** — CORS origins, auth mode, bind, port, trustedProxies |
 | `models.providers` | Operator | **Overwritten** — tracks credentials in Claw CR |
-| `cron` | Operator | **Overwritten** |
 | `agents.*` | User | **Preserved** — model aliases, primary model, agent list, workspace |
 | `plugins.*` | User | **Preserved** — plugin installs, allow/deny lists |
 | `channels.*` | User | **Preserved** — WhatsApp, Telegram, etc. |
 | `tools.*` | User | **Preserved** |
+| `cron.*` | User | **Preserved** — scheduled tasks |
 
 ### Deep merge semantics
 
@@ -102,19 +102,35 @@ A top-level enum on `ClawSpec` with values `merge` (default) and `overwrite`:
 
 - **`overwrite`**: init container fully overwrites `openclaw.json` with the
   operator-managed config on every pod start. User edits are wiped. Suitable for
-  managed deployments (Dev Sandbox shared instances) where the operator is the
-  sole config authority.
+  managed deployments where the operator is the sole config authority.
 
 ### Init container
 
-Uses the gateway image (`ghcr.io/openclaw/openclaw:slim`) — same image as the
-main container, already cached. Provides Node.js for the merge script. Replaces
-the current busybox-based `init-config` container.
+Uses the gateway image (`ghcr.io/openclaw/openclaw`) — same base image reference
+as the main container. Kustomize's `images` transformer pins both to the same
+version tag (e.g., `2026.4.29-slim`), so bumping the tag in `kustomization.yaml`
+updates both containers atomically. Already cached on the node. Provides Node.js
+for the merge script. Replaces the current busybox-based `init-config` container.
 
-**Merge mode script** (pseudocode):
+**Script delivery:** The merge script is stored as a `merge.js` key in the
+`claw-config` ConfigMap (already mounted at `/config`). The init container
+command is simply `node /config/merge.js`. This avoids YAML quoting issues for
+multi-line JavaScript and keeps the deployment manifest clean. The operator
+regenerates the ConfigMap on every reconcile, so script updates deploy
+automatically with operator upgrades.
+
+**Deployment command:**
+```yaml
+command: ["node", "/config/merge.js"]
+env:
+  - name: CLAW_CONFIG_MODE
+    value: "merge"  # or "overwrite"
+```
+
+**merge.js** (pseudocode — stored in ConfigMap):
 ```javascript
-const base = JSON.parse(fs.readFileSync("/home/node/.openclaw/openclaw.json"));
-const ops = JSON.parse(fs.readFileSync("/config/operator.json"));
+const fs = require("fs");
+const mode = process.env.CLAW_CONFIG_MODE || "merge";
 
 function deepMerge(target, source) {
   const result = { ...target };
@@ -129,17 +145,18 @@ function deepMerge(target, source) {
   return result;
 }
 
-fs.writeFileSync("/home/node/.openclaw/openclaw.json",
-  JSON.stringify(deepMerge(base, ops), null, 2));
-```
+const ops = JSON.parse(fs.readFileSync("/config/operator.json", "utf8"));
+const pvcPath = "/home/node/.openclaw/openclaw.json";
 
-**Overwrite mode script** (pseudocode):
-```javascript
-const seed = JSON.parse(fs.readFileSync("/config/openclaw.json"));
-const ops = JSON.parse(fs.readFileSync("/config/operator.json"));
-// Always start from seed (ignore PVC state) — user edits don't survive
-fs.writeFileSync("/home/node/.openclaw/openclaw.json",
-  JSON.stringify(deepMerge(seed, ops), null, 2));
+if (mode === "merge" && fs.existsSync(pvcPath)) {
+  // Merge: operator config wins over existing user config
+  const base = JSON.parse(fs.readFileSync(pvcPath, "utf8"));
+  fs.writeFileSync(pvcPath, JSON.stringify(deepMerge(base, ops), null, 2));
+} else {
+  // Overwrite (or first run): start from seed, merge operator config
+  const seed = JSON.parse(fs.readFileSync("/config/openclaw.json", "utf8"));
+  fs.writeFileSync(pvcPath, JSON.stringify(deepMerge(seed, ops), null, 2));
+}
 ```
 
 The key difference: merge mode reads the **existing PVC file** as the base (preserving
@@ -165,8 +182,7 @@ data:
   operator.json: |
     {
       "gateway": { ... },
-      "models": { "providers": { ... } },
-      "cron": { "enabled": false }
+      "models": { "providers": { ... } }
     }
   openclaw.json: |
     {
@@ -204,25 +220,28 @@ the proxy deployment via `configureProxyDeployment`).
 
 ## Implementation Plan
 
-### Phase 1: Drop `$include` and implement merge
+Single PR — phases below are implementation order within the branch, not
+separate deliverables. The operator is pre-production, so no migration or
+intermediate-state concerns.
+
+### Step 1: ConfigMap and deployment changes
 
 1. Update `configmap.yaml`: remove `$include` and `gateway` section from
-   `openclaw.json` seed
-2. Update `deployment.yaml`: change `init-config` to gateway image, implement
-   merge/overwrite script with mode detection
+   `openclaw.json` seed, add `merge.js` key
+2. Update `deployment.yaml`: change `init-config` to gateway image, set
+   command to `node /config/merge.js`
 3. Update tests: assert no `$include` in `openclaw.json` seed, verify ConfigMap
-   content
+   contains `merge.js` key
 
-### Phase 2: Add `spec.configMode` to CRD
+### Step 2: CRD field and controller wiring
 
 4. Add `ConfigMode` field to `ClawSpec` in `claw_types.go` with enum validation
 5. Run `make manifests && make generate`
 6. Update controller to inject `CLAW_CONFIG_MODE` env var on init container
    (new function `configureClawDeploymentConfigMode` following existing patterns)
-7. Init script already branches on `$CLAW_CONFIG_MODE` from Phase 1
-8. Add tests for both modes (merge preserves user keys, overwrite resets)
+7. Add tests for both modes (merge preserves user keys, overwrite resets)
 
-### Phase 3: Update documentation
+### Step 3: Documentation
 
-9. Update `CLAUDE.md` with new config approach
-10. Update `PROXY_SETUP.md` if needed
+8. Update `CLAUDE.md` with new config approach
+9. Update `PROXY_SETUP.md` if needed

--- a/docs/proposals/config-merge-questions.md
+++ b/docs/proposals/config-merge-questions.md
@@ -1,0 +1,119 @@
+# Config Merge Design — Open Questions
+
+**Status:** Resolved — all decisions made
+**Related:** [Design document](config-merge-design.md)
+
+All questions resolved. Decisions recorded below.
+
+---
+
+## Q1: Init container image for the merge step
+
+The current `init-config` container uses `mirror.gcr.io/library/busybox:1.37`
+which has no JSON processing capability. The deep-merge step needs to parse and
+manipulate JSON. What image should we use?
+
+### Option A: Use the gateway image (`ghcr.io/openclaw/openclaw:slim`)
+
+The same image already used for the main container. Has Node.js, so we can run
+an inline merge script.
+
+- **Pro:** No additional image pull — already cached from the main container
+- **Pro:** Full Node.js available, can handle complex JSON (comments, edge cases)
+- **Pro:** Matches what openclaw-operator does (uses the OpenClaw image for its init merge)
+- **Con:** Much larger image for a simple init task (~500MB vs ~5MB for busybox)
+- **Con:** Slower init container startup on cold pull
+- **Con:** If the gateway image tag changes, init container must also be updated (single source of truth anyway)
+
+**Decision:** Option A — gateway image is already cached, no extra pull cost, and matches the openclaw-operator pattern.
+
+_Considered and rejected: Option B — alpine+jq (jq deep-merge is fragile, extra image to maintain), Option C — split init containers (unnecessary complexity for minimal benefit)._
+
+---
+
+## Q2: CRD field design for locked/immutable config mode
+
+The user wants the ability to disable runtime config edits via the Claw CRD. How
+should this be exposed?
+
+### Option A: `spec.configMode` top-level enum (`merge` / `overwrite`)
+
+Same enum values as the upstream openclaw-operator (`merge` / `overwrite`) but as
+a top-level field on ClawSpec rather than nested under `spec.config`. Default is
+`merge` (user changes survive restarts). `overwrite` makes the operator fully
+overwrite `openclaw.json` on every pod start.
+
+- **Pro:** Matches upstream naming — familiar to openclaw-operator users
+- **Pro:** Top-level field — no unnecessary nesting (we have nothing else under `config`)
+- **Pro:** Extensible enum if needed later
+- **Pro:** Mechanism-descriptive: clear what actually happens
+
+**Decision:** Option A — top-level `spec.configMode` enum with values `merge` (default) and `overwrite`, matching upstream naming but without unnecessary nesting.
+
+_Considered and rejected: Option B — nested `spec.config.mutable` boolean (less extensible, implies other config sub-fields), Option C — nested `spec.config.mergeMode` (matches upstream path exactly but adds unnecessary nesting for our simpler CRD)._
+
+---
+
+## Q3: Migration strategy for existing `$include`-based PVC configs
+
+~~Not applicable — the operator is in development phase and not yet deployed in
+production. No existing PVC data needs migration.~~
+
+**Decision:** Skipped — no migration needed. Operator is pre-release.
+
+---
+
+## Q4: Array merge behavior (replace vs concatenate)
+
+When the operator's `operator.json` has an array value (e.g.,
+`gateway.controlUi.allowedOrigins`) and the user's `openclaw.json` also has that
+key, should arrays replace or concatenate?
+
+### Option A: Operator arrays replace user arrays
+
+Simple override: operator value wins completely for arrays.
+
+- **Pro:** Predictable — operator is authoritative for its keys
+- **Pro:** `allowedOrigins` must be exactly what the operator sets (Route-derived)
+- **Pro:** `providers` must be exactly what the operator sets (credential-derived)
+
+**Decision:** Option A — arrays replace. Operator-managed arrays are authoritative and must reflect current deployment state.
+
+_Considered and rejected: Option B — concatenate (would accumulate stale values, operator can't remove entries)._
+
+---
+
+## Q5: Should `operator.json` still be written to PVC?
+
+Currently the init container always copies `operator.json` to the PVC so OpenClaw
+can resolve `$include`. With `$include` removed, `operator.json` is no longer
+read by OpenClaw at runtime and the merge script reads from the ConfigMap volume
+mount (`/config/operator.json`), not from PVC. No functional purpose remains.
+
+**Decision:** Option B — stop writing `operator.json` to PVC. It serves no
+functional purpose (merge reads from ConfigMap mount, OpenClaw doesn't reference
+it). Cleaner PVC.
+
+_Considered and rejected: Option A — keep writing for debugging (dead file, no functional value)._
+
+---
+
+## Q6: Adopt `models.mode: "merge"` in `operator.json`
+
+OpenClaw supports `"models": {"mode": "merge"}` which deep-merges provider
+definitions from multiple config sources instead of replacing. NemoClaw uses
+this. Should we adopt it?
+
+### Option B: Don't add it — operator providers fully replace
+
+- **Pro:** Operator has complete control over provider definitions
+- **Pro:** User-added providers can't work anyway — the MITM proxy blocks any
+  domain not configured via the Claw CR's `credentials` array. The only path to
+  a working provider is through the CR, which configures both the proxy route
+  AND the provider entry in `operator.json`
+
+**Decision:** Option B — don't add `models.mode: "merge"`. User-added providers
+are non-functional because the proxy blocks unconfigured domains. All providers
+must come through the Claw CR.
+
+_Considered and rejected: Option A — add `models.mode: "merge"` (no practical benefit since proxy blocks user-added provider traffic)._


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design docs for an init-time configuration merge that replaces runtime include behavior.
  * Defined deep-merge semantics (objects merge recursively; arrays and primitives are replaced).
  * Introduced a configMode option with "merge" (preserve user edits) and "overwrite" (reset to operator defaults).
  * Clarified which configuration areas are operator-managed vs user-owned and what content is persisted/seeding on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->