### PR TITLE
chore: update OpenClaw to 2026.5.3-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.4.29-slim
+    newTag: 2026.5.3-slim


### PR DESCRIPTION
- Bump gateway image tag from 2026.4.29-slim to 2026.5.3-slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->