### PR TITLE
feat: add Telegram and Discord credential injection

### DIFF
--- a/docs/proposals/messaging-channel-credential-injection-design.md
+++ b/docs/proposals/messaging-channel-credential-injection-design.md
@@ -207,7 +207,7 @@ Bolt-shaped placeholders (`xoxb-placeholder`, `xapp-placeholder`) pass Bolt's st
 
 ## Implementation Plan
 
-### PR1: Telegram + Discord
+### PR1: Telegram + Discord - DONE
 
 Telegram requires a proxy change (pathToken replacement). Discord uses existing injectors unchanged. Grouped into one PR — small proxy diff, shared documentation scope.
 

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -369,7 +369,104 @@ The `kubernetes` credential uses the proxy's existing **MITM forward proxy mode*
 
 The gateway pod **cannot** reach any API server directly — egress is restricted to the proxy by NetworkPolicy. The assistant never sees real tokens; only the sanitized kubeconfig with placeholder values.
 
-## WhatsApp
+## Messaging Channels
+
+Messaging channels (Telegram, Discord, WhatsApp) use different authentication mechanisms. Unlike LLM providers, messaging channel credentials are injected transparently by the proxy — OpenClaw is configured with placeholder tokens and never sees the real secrets.
+
+### Telegram
+
+The Telegram Bot API embeds the bot token in the URL path (`/bot<TOKEN>/method`). The proxy uses `pathToken` credential injection to replace the placeholder with the real token on every request.
+
+**1. Create a bot** via [@BotFather](https://t.me/BotFather) and copy the bot token.
+
+**2. Create the Secret:**
+
+```sh
+oc create secret generic telegram-bot-secret \
+  --from-literal=token=YOUR_BOT_TOKEN \
+  -n $NS
+```
+
+**3. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: telegram
+      type: pathToken
+      secretRef:
+        name: telegram-bot-secret
+        key: token
+      domain: "api.telegram.org"
+      pathToken:
+        prefix: "/bot"
+EOF
+```
+
+**4. Configure OpenClaw** with a placeholder token:
+
+```sh
+openclaw channels add --channel telegram --token placeholder
+```
+
+The proxy intercepts requests like `/botplaceholder/sendMessage` and forwards them as `/bot<REAL_TOKEN>/sendMessage`. The real token never reaches the gateway pod.
+
+### Discord
+
+Discord Bot API uses `Authorization: Bot <TOKEN>` header authentication. The proxy uses `apiKey` credential injection with a `Bot ` value prefix. Discord also requires passthrough domains for its WebSocket gateway and CDN.
+
+**1. Create a bot** in the [Discord Developer Portal](https://discord.com/developers/applications) and copy the bot token.
+
+**2. Create the Secret:**
+
+```sh
+oc create secret generic discord-bot-secret \
+  --from-literal=token=YOUR_BOT_TOKEN \
+  -n $NS
+```
+
+**3. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: discord
+      type: apiKey
+      secretRef:
+        name: discord-bot-secret
+        key: token
+      domain: "discord.com"
+      apiKey:
+        header: Authorization
+        valuePrefix: "Bot "
+    - name: discord-gateway
+      type: none
+      domain: "gateway.discord.gg"
+    - name: discord-cdn
+      type: none
+      domain: "cdn.discordapp.com"
+EOF
+```
+
+**4. Configure OpenClaw** with a placeholder token:
+
+```sh
+openclaw channels add --channel discord --token placeholder
+```
+
+The `discord-gateway` and `discord-cdn` entries allow Discord's WebSocket connection and media/avatar downloads without credential injection.
+
+### WhatsApp
 
 OpenClaw supports WhatsApp as a messaging channel via WhatsApp Web (the Baileys library). The gateway maintains a linked-device session over WebSocket to WhatsApp's servers.
 

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -135,7 +135,7 @@ data:
   PROXY_SETUP.md: |
     ---
     name: proxy-setup
-    description: "Network proxy architecture and how to configure access to external services like WhatsApp."
+    description: "Network proxy architecture and how to configure access to external services like WhatsApp, Telegram, and Discord."
     ---
 
     # Proxy Architecture
@@ -282,6 +282,70 @@ data:
 
     **Step 5.** Tell the user to scan the QR code with their phone
     (WhatsApp → Linked Devices).
+
+    ### Telegram
+
+    Telegram Bot API embeds the bot token in the URL path (`/bot<TOKEN>/method`).
+    The proxy uses `pathToken` credential injection: OpenClaw is configured with a
+    placeholder token, and the proxy replaces it with the real token on every request.
+
+    The user needs to add this credential entry to the Claw CR:
+
+    ```yaml
+        - name: telegram
+          type: pathToken
+          secretRef:
+            name: telegram-bot-secret
+            key: token
+          domain: "api.telegram.org"
+          pathToken:
+            prefix: "/bot"
+    ```
+
+    OpenClaw config: set the bot token to any placeholder value (e.g., `placeholder`).
+    The proxy strips whatever token it finds and injects the real one:
+    ```sh
+    openclaw channels add --channel telegram --token placeholder
+    ```
+
+    The real bot token is stored in the Kubernetes Secret and never reaches the
+    gateway pod. The proxy intercepts `/botplaceholder/sendMessage` and forwards
+    it as `/bot<REAL_TOKEN>/sendMessage`.
+
+    ### Discord
+
+    Discord Bot API uses `Authorization: Bot <TOKEN>` header authentication. The
+    proxy uses `apiKey` credential injection with `valuePrefix: "Bot "` to inject
+    the real token into the Authorization header.
+
+    The user needs to add these credential entries to the Claw CR:
+
+    ```yaml
+        - name: discord
+          type: apiKey
+          secretRef:
+            name: discord-bot-secret
+            key: token
+          domain: "discord.com"
+          apiKey:
+            header: Authorization
+            valuePrefix: "Bot "
+        - name: discord-gateway
+          type: none
+          domain: "gateway.discord.gg"
+        - name: discord-cdn
+          type: none
+          domain: "cdn.discordapp.com"
+    ```
+
+    OpenClaw config: set the bot token to any placeholder value:
+    ```sh
+    openclaw channels add --channel discord --token placeholder
+    ```
+
+    The `discord-gateway` and `discord-cdn` entries are passthrough domains for
+    Discord's WebSocket gateway and CDN (media/avatars). They don't need credential
+    injection.
 
     ## Custom domains
 

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -360,6 +360,35 @@ func TestGenerateProxyConfig(t *testing.T) {
 		assert.Equal(t, "/bot", route.PathPrefix)
 	})
 
+	t.Run("should generate config with Discord apiKey credential", func(t *testing.T) {
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name: "discord",
+				Type: clawv1alpha1.CredentialTypeAPIKey,
+				SecretRef: &clawv1alpha1.SecretRef{
+					Name: "discord-bot-secret",
+					Key:  "token",
+				},
+				Domain: "discord.com",
+				APIKey: &clawv1alpha1.APIKeyConfig{
+					Header:      "Authorization",
+					ValuePrefix: "Bot ",
+				},
+			},
+		}
+
+		data, err := generateProxyConfig(toResolved(credentials))
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+		route := findRouteByDomain(t, cfg.Routes, "discord.com")
+		assert.Equal(t, "api_key", route.Injector)
+		assert.Equal(t, "Authorization", route.Header)
+		assert.Equal(t, "Bot ", route.ValuePrefix)
+		assert.Equal(t, "CRED_DISCORD", route.EnvVar)
+	})
+
 	t.Run("should generate config with oauth2 route", func(t *testing.T) {
 		credentials := []clawv1alpha1.CredentialSpec{
 			{

--- a/internal/proxy/injector_pathtoken.go
+++ b/internal/proxy/injector_pathtoken.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 )
 
-// PathTokenInjector prepends a token into the URL path.
-// For example, Telegram bots use /bot<token>/method — the prefix is "/bot"
-// and the token is read from an env var, yielding /bot<token>/original/path.
+// PathTokenInjector replaces a placeholder token in the URL path with the real
+// credential. The client sends requests with a placeholder already embedded
+// (e.g., /bot<placeholder>/sendMessage). The injector strips the placeholder
+// segment and inserts the real token from an env var.
 type PathTokenInjector struct {
 	envVar         string
 	pathPrefix     string
@@ -50,7 +52,19 @@ func (p *PathTokenInjector) Inject(req *http.Request) error {
 	if token == "" {
 		return fmt.Errorf("credential env var %s is empty", p.envVar)
 	}
-	req.URL.Path = p.pathPrefix + token + req.URL.Path
+
+	path := req.URL.Path
+	if !strings.HasPrefix(path, p.pathPrefix) {
+		return fmt.Errorf("path %q does not start with expected prefix %q", path, p.pathPrefix)
+	}
+
+	remainder := path[len(p.pathPrefix):]
+	if idx := strings.IndexByte(remainder, '/'); idx >= 0 {
+		req.URL.Path = p.pathPrefix + token + remainder[idx:]
+	} else {
+		req.URL.Path = p.pathPrefix + token
+	}
+
 	for k, v := range p.defaultHeaders {
 		req.Header.Set(k, v)
 	}

--- a/internal/proxy/injector_test.go
+++ b/internal/proxy/injector_test.go
@@ -276,11 +276,50 @@ func TestPathTokenInjector(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", nil)
-	require.NoError(t, inj.Inject(req))
+	t.Run("replaces placeholder token in path", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/botplaceholder/sendMessage", nil)
+		require.NoError(t, inj.Inject(req))
 
-	assert.Equal(t, "/bot123456:ABC-DEF/sendMessage", req.URL.Path)
-	assert.Equal(t, "value", req.Header.Get("x-custom"))
+		assert.Equal(t, "/bot123456:ABC-DEF/sendMessage", req.URL.Path)
+		assert.Equal(t, "value", req.Header.Get("x-custom"))
+	})
+
+	t.Run("bare token without method", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/botplaceholder", nil)
+		require.NoError(t, inj.Inject(req))
+
+		assert.Equal(t, "/bot123456:ABC-DEF", req.URL.Path)
+	})
+
+	t.Run("multiple path segments after token", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/botplaceholder/sendMessage/extra", nil)
+		require.NoError(t, inj.Inject(req))
+
+		assert.Equal(t, "/bot123456:ABC-DEF/sendMessage/extra", req.URL.Path)
+	})
+
+	t.Run("prefix only with no token segment", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/bot", nil)
+		require.NoError(t, inj.Inject(req))
+
+		assert.Equal(t, "/bot123456:ABC-DEF", req.URL.Path)
+	})
+
+	t.Run("realistic token with colons preserved", func(t *testing.T) {
+		t.Setenv("CRED_TELEGRAM", "7891011:XYZ_abc-123")
+
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/botdummy/getMe", nil)
+		require.NoError(t, inj.Inject(req))
+
+		assert.Equal(t, "/bot7891011:XYZ_abc-123/getMe", req.URL.Path)
+	})
+
+	t.Run("error when path does not start with prefix", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", nil)
+		err := inj.Inject(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not start with expected prefix")
+	})
 }
 
 func TestPathTokenInjectorEmptyEnvVar(t *testing.T) {
@@ -292,7 +331,7 @@ func TestPathTokenInjectorEmptyEnvVar(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/sendMessage", nil)
+	req, _ := http.NewRequest(http.MethodPost, "https://api.telegram.org/botplaceholder/sendMessage", nil)
 	err = inj.Inject(req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CRED_EMPTY_PATH is empty")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup guides for Telegram and Discord messaging channels with configuration examples and CLI commands
  * Expanded WhatsApp documentation with detailed setup workflows

* **New Features**
  * Added support for Discord APIKey credential injection via the proxy
  * Enhanced path token injection mechanism to support placeholder replacement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->