### PR TITLE
docs: add declarative channel configuration design proposal

### DIFF
--- a/docs/proposals/declarative-channels-design.md
+++ b/docs/proposals/declarative-channels-design.md
@@ -171,7 +171,7 @@ The AI skill document is updated to explain:
 
 ## Implementation Plan
 
-### Phase 1: CRD + Channel Injection (Telegram focus)
+### PR 1: Declarative channel injection
 
 1. Update `api/v1alpha1/claw_types.go`:
    - Add `Channel` and `ChannelConfig` fields to `CredentialSpec`
@@ -193,19 +193,12 @@ The AI skill document is updated to explain:
    - Call `injectChannelsIntoConfigMap` after `injectModelCatalogIntoConfigMap`
    - Include companion routes in proxy config generation
 
-4. Tests: `internal/controller/claw_channels_test.go`
-   - Table-driven tests for each channel type
-   - Inference with and without explicit overrides
-   - Companion route generation
-   - channelConfig passthrough
+4. Tests:
+   - Unit: `internal/controller/claw_channels_test.go` — table-driven tests for each channel type, inference with/without overrides, companion route generation, channelConfig passthrough
+   - E2E: channel credential → verify operator.json contains channel config, pod starts with channel active
 
-### Phase 2: Documentation + PLATFORM.md
+### PR 2: Documentation
 
 1. Update `docs/provider-setup.md` — simplify channel examples to use `channel:` field
-2. Update PLATFORM.md template in `configmap.yaml` — new AI instructions
+2. Update PLATFORM.md template in `configmap.yaml` — new AI instructions for operator-managed channels
 3. Update `docs/architecture.md` if needed
-
-### Phase 3: Validation + Polish
-
-1. CEL validation rules for channel-specific constraints (if UX feedback warrants it)
-2. E2E test coverage

--- a/docs/proposals/declarative-channels-design.md
+++ b/docs/proposals/declarative-channels-design.md
@@ -1,0 +1,211 @@
+# Declarative Channel Configuration
+
+**Status:** Final — all decisions resolved in [declarative-channels-questions.md](declarative-channels-questions.md)
+
+## Overview
+
+When a user adds a messaging channel credential (Telegram, Discord, Slack, WhatsApp) to the Claw CR, the operator declaratively configures the corresponding OpenClaw channel — no reliance on the AI assistant to run `openclaw channels add` at runtime.
+
+The `channel` field on a credential entry acts as both:
+1. A declaration that enables the channel in OpenClaw's config
+2. A service-level hint that infers proxy defaults (domain, type, companion routes)
+
+This mirrors the existing `provider` field pattern: `provider: google` infers LLM config, `channel: telegram` infers messaging config. The two are mutually exclusive — a credential cannot have both `provider` and `channel` set (validated by CEL).
+
+## Design Principles
+
+1. **Declarative over imperative** — channel lifecycle is driven by the Claw CR, not runtime CLI commands
+2. **Mirror the `provider` pattern** — `channel` infers service defaults just like `provider` infers LLM defaults
+3. **Explicit > implicit** — user opts into channel management via the `channel` field (no magic detection)
+4. **Placeholder-token architecture** — channels use dummy tokens; the proxy replaces them transparently
+5. **Pod rollout on change** — channel config changes `operator.json` → config hash changes → gateway rolls out fresh
+
+## Architecture
+
+### Flow
+
+```
+User adds credential with channel: telegram
+  → Operator infers proxy config (type, domain, pathToken)
+  → Operator generates companion proxy routes (if needed)
+  → Operator injects channels.telegram into operator.json
+  → Config hash changes → gateway pod rolls out (fresh start)
+  → init-config merges channels into PVC config
+  → Gateway starts with channel pre-configured ✓
+```
+
+### CRD Changes
+
+The `CredentialSpec` gets these changes:
+
+**`Type` becomes optional** — currently required; when `channel` is set, the operator infers `Type` from the channel defaults table. Explicit `type:` still overrides. Validation strategy: only two structural CEL rules at admission (require `type` or `channel`; `provider`/`channel` mutually exclusive). All type-specific config checks (e.g., "apiKey requires apiKey config") move to the controller and report via the `CredentialsResolved` status condition — matching the existing `resolveProviderDefaults` pattern.
+
+**Two new fields:**
+
+```go
+// Channel declares this credential as a messaging channel integration.
+// When set, the operator enables the channel in OpenClaw's config and
+// infers proxy defaults (type, domain, injection config, companion routes).
+// Known values: telegram, discord, slack, whatsapp.
+// +optional
+Channel string `json:"channel,omitempty"`
+
+// ChannelConfig is opaque JSON merged into the channel's config block
+// in operator.json. Use for channel-specific settings (dmPolicy, allowFrom, etc.).
+// +kubebuilder:pruning:PreserveUnknownFields
+// +optional
+ChannelConfig *runtime.RawExtension `json:"channelConfig,omitempty"`
+```
+
+**`SecretRef` changes from `*SecretRef` (single pointer) to `[]SecretRefEntry` (array).**
+This is a breaking API change — existing CRs using `secretRef: {name: ..., key: ...}` must migrate to the array syntax. The controller code (`claw_credentials.go`, `claw_proxy.go`) accesses `cred.SecretRef.Name`/`cred.SecretRef.Key` directly and needs refactoring to iterate or index the array.
+
+New type with an optional `role` discriminator for multi-secret channels:
+
+```go
+// SecretRefEntry references a specific key in a Secret.
+type SecretRefEntry struct {
+    Name string `json:"name"`
+    Key  string `json:"key"`
+    // Role distinguishes multiple secrets for the same credential.
+    // Required when multiple secretRef entries are present (e.g., Slack botToken/appToken).
+    // +optional
+    Role string `json:"role,omitempty"`
+}
+```
+
+### User-Facing Examples
+
+```yaml
+credentials:
+  # Telegram — minimal, everything inferred
+  - name: telegram
+    channel: telegram
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+
+  # Discord — one secret, companion routes auto-generated
+  - name: discord
+    channel: discord
+    secretRef:
+      - name: discord-bot-secret
+        key: token
+
+  # Slack — two secrets with roles
+  - name: slack
+    channel: slack
+    secretRef:
+      - name: slack-secret
+        key: bot-token
+        role: botToken
+      - name: slack-secret
+        key: app-token
+        role: appToken
+
+  # WhatsApp — no secret needed (QR pairing)
+  - name: whatsapp
+    channel: whatsapp
+
+  # Telegram with custom settings
+  - name: telegram
+    channel: telegram
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+    channelConfig:
+      dmPolicy: allowlist
+      allowFrom: [12345]
+
+  # Explicit override — custom domain, still gets channel enablement
+  - name: telegram
+    channel: telegram
+    type: pathToken
+    domain: "telegram.internal.corp.com"
+    pathToken:
+      prefix: "/bot"
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+```
+
+### Channel Defaults
+
+When `channel` is set and no explicit type/domain/config is provided:
+
+| Channel | Inferred Type | Domain(s) | Companion Routes | Placeholder |
+|---------|--------------|-----------|------------------|-------------|
+| telegram | pathToken (prefix: `/bot`) | api.telegram.org | — | `"placeholder"` |
+| discord | apiKey (header: `Authorization`, valuePrefix: `Bot `) | discord.com | gateway.discord.gg, cdn.discordapp.com | `"placeholder"` |
+| slack | bearer | slack.com | .slack.com (WS) | `"xoxb-placeholder"` / `"xapp-placeholder"` |
+| whatsapp | none | — | .whatsapp.com, .whatsapp.net | — |
+
+### Channel Config Injection
+
+The operator injects into `operator.json`:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "botToken": "placeholder"
+    }
+  },
+  "plugins": {
+    "entries": {
+      "telegram": { "enabled": true }
+    }
+  }
+}
+```
+
+For WhatsApp, the plugin entry is added but the AI handles actual npm installation.
+
+### PLATFORM.md Updates
+
+The AI skill document is updated to explain:
+1. Channels with `channel:` field in the CR are **operator-managed** — do NOT run `openclaw channels add/remove`
+2. WhatsApp: AI installs the `@openclaw/whatsapp` plugin; user does QR pairing
+3. Custom/unknown channels not in the CR: AI and user manage them directly via CLI
+
+## Implementation Plan
+
+### Phase 1: CRD + Channel Injection (Telegram focus)
+
+1. Update `api/v1alpha1/claw_types.go`:
+   - Add `Channel` and `ChannelConfig` fields to `CredentialSpec`
+   - Make `Type` optional (add `+optional`, `omitempty`)
+   - Change `SecretRef` from `*SecretRef` to `[]SecretRefEntry`
+   - Add two structural CEL rules: (1) require `type` or `channel`, (2) `provider` and `channel` mutually exclusive
+   - Remove type-specific CEL rules (e.g., `self.type != 'apiKey' || has(self.apiKey)`) — these become controller-side errors reported via `CredentialsResolved` status condition (matches existing `resolveProviderDefaults` pattern)
+   - Run `make manifests && make generate`
+   - Refactor all `cred.SecretRef.Name`/`cred.SecretRef.Key` usages in controller (helper function recommended)
+
+2. New file: `internal/controller/claw_channels.go`
+   - Channel defaults table (domain, type, companions, placeholder tokens)
+   - `resolveChannelDefaults(cred *CredentialSpec)` — populate missing fields from channel
+   - `injectChannelsIntoConfigMap(objects, instance)` — inject channels + plugins into operator.json
+   - `generateCompanionRoutes(cred CredentialSpec)` — return companion proxy routes for multi-domain channels
+
+3. Wire into reconciler (`claw_resource_controller.go`):
+   - Call `resolveChannelDefaults` during credential resolution
+   - Call `injectChannelsIntoConfigMap` after `injectModelCatalogIntoConfigMap`
+   - Include companion routes in proxy config generation
+
+4. Tests: `internal/controller/claw_channels_test.go`
+   - Table-driven tests for each channel type
+   - Inference with and without explicit overrides
+   - Companion route generation
+   - channelConfig passthrough
+
+### Phase 2: Documentation + PLATFORM.md
+
+1. Update `docs/provider-setup.md` — simplify channel examples to use `channel:` field
+2. Update PLATFORM.md template in `configmap.yaml` — new AI instructions
+3. Update `docs/architecture.md` if needed
+
+### Phase 3: Validation + Polish
+
+1. CEL validation rules for channel-specific constraints (if UX feedback warrants it)
+2. E2E test coverage

--- a/docs/proposals/declarative-channels-design.md
+++ b/docs/proposals/declarative-channels-design.md
@@ -50,12 +50,25 @@ The `CredentialSpec` gets these changes:
 // +optional
 Channel string `json:"channel,omitempty"`
 
-// ChannelConfig is opaque JSON merged into the channel's config block
+// ChannelConfig is opaque JSON deep-merged into the channel's config block
 // in operator.json. Use for channel-specific settings (dmPolicy, allowFrom, etc.).
 // +kubebuilder:pruning:PreserveUnknownFields
 // +optional
 ChannelConfig *runtime.RawExtension `json:"channelConfig,omitempty"`
 ```
+
+**ChannelConfig merge semantics:**
+
+The operator builds a base config block per channel (e.g., `{"enabled": true, "botToken": "placeholder"}`), then applies `channelConfig` on top:
+
+- **Objects:** deep-merge (recursive key-level merge)
+- **Arrays:** replaced wholesale (not concatenated)
+- **Scalars:** overwritten by `channelConfig` value
+
+**Protected keys** — the following keys are operator-managed and must not appear in `channelConfig`. Attempts to set them produce a controller-side validation error (reported via `CredentialsResolved` condition):
+
+- `enabled` — always `true` when the channel is declared; removing a channel means removing the credential from the CR
+- Token/secret placeholder fields (`botToken`, `token`, `appToken`) — these are operator-generated placeholders for proxy injection
 
 **`SecretRef` changes from `*SecretRef` (single pointer) to `[]SecretRefEntry` (array).**
 This is a breaking API change — existing CRs using `secretRef: {name: ..., key: ...}` must migrate to the array syntax. The controller code (`claw_credentials.go`, `claw_proxy.go`) accesses `cred.SecretRef.Name`/`cred.SecretRef.Key` directly and needs refactoring to iterate or index the array.

--- a/docs/proposals/declarative-channels-questions.md
+++ b/docs/proposals/declarative-channels-questions.md
@@ -1,0 +1,186 @@
+# Declarative Channel Configuration — Design Questions
+
+**Status:** Resolved — all decisions made
+**Related:** [Design document](declarative-channels-design.md)
+
+## Q1: How should the operator identify which credentials are messaging channels?
+
+The operator needs to know "this credential entry means Telegram" to inject `channels.telegram` into `operator.json`. Two approaches: infer from existing fields, or add a new CRD field.
+
+### Option B (chosen): Add `channel` field to CredentialSpec with service-level inference
+
+Add an optional `channel` field (e.g., `channel: telegram`) to `CredentialSpec`. When present, the operator:
+1. Enables the channel in `operator.json`
+2. Infers proxy defaults (type, domain, pathToken/apiKey config) — same pattern as `provider` for LLMs
+3. Auto-generates companion credentials (e.g., discord-gateway, discord-cdn)
+
+Simple path — everything inferred from `channel`:
+```yaml
+credentials:
+  - name: telegram
+    channel: telegram
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+```
+
+Explicit override — user controls proxy config, still gets channel enablement:
+```yaml
+credentials:
+  - name: telegram
+    channel: telegram
+    type: pathToken
+    domain: "telegram.internal.corp.com"  # custom domain override
+    pathToken:
+      prefix: "/bot"
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+```
+
+Proxy-only — no channel field, explicit low-level control:
+```yaml
+credentials:
+  - name: telegram-custom
+    type: pathToken
+    domain: "api.telegram.org"
+    pathToken:
+      prefix: "/bot"
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+```
+
+- **Pro:** Explicit — no magic, user clearly opts in
+- **Pro:** Mirrors `provider` field design — `provider` infers LLM config, `channel` infers messaging config
+- **Pro:** Dramatically simpler UX (3 fields vs 5+ for Telegram, 3 vs 12+ for Discord)
+- **Pro:** Auto-generates companion entries (Discord gateway/CDN, Slack WS)
+- **Pro:** Escape hatch preserved — can have proxy routing without channel enablement
+- **Pro:** Explicit fields always override inference (full control when needed)
+
+**Decision:** Option B with service-level inference — the `channel` field acts as both "enable this channel" and "infer proxy defaults for this service", mirroring how `provider` already works for LLMs. Backwards compatible: existing CRs without `channel` keep working unchanged.
+
+_Considered and rejected: Option A (implicit pattern matching — fragile, no escape hatch), Option C (separate `spec.channels` array — redundant, breaks "one entry = one integration" model)_
+
+---
+
+## Q2: Should we support channel-specific settings in the CRD?
+
+Channels can have settings beyond just "enabled + token" — for example, Telegram supports `dmPolicy` (allowlist/open), `allowFrom` (user IDs), `requireMention` (in groups). Should the operator expose these?
+
+### Option C (chosen): Opaque channelConfig (raw JSON)
+
+Allow an opaque `channelConfig` field that passes through to the channel's config block in `operator.json`:
+
+```yaml
+channel: telegram
+channelConfig:
+  dmPolicy: allowlist
+  allowFrom: [12345]
+```
+
+- **Pro:** Flexible, no need to model every channel's config in Go types
+- **Pro:** Forward-compatible with new OpenClaw channel features
+- **Pro:** Users get full declarative control from day one without waiting for typed fields
+
+**Decision:** Option C — opaque raw JSON for channel-specific settings. Flexible, forward-compatible, and avoids needing to chase upstream OpenClaw's channel config schema in our Go types.
+
+_Considered and rejected: Option A (minimal, just enable — leaves no declarative path for security settings), Option B (typed fields per channel — ongoing maintenance burden tracking upstream changes)_
+
+---
+
+## Q3: How should multi-credential channels be handled?
+
+Discord requires 3 proxy entries (bot token + gateway WS + CDN), Slack requires 3 (bot + app + WS). With the `channel` field from Q1, the user writes a single credential entry — should the operator auto-generate companion proxy routes?
+
+### Option A (chosen): Auto-generate companion entries
+
+The operator knows that `channel: discord` needs `gateway.discord.gg` and `cdn.discordapp.com` allowlisted. It generates these proxy routes internally — the user never writes them.
+
+For multi-secret channels (Slack), `secretRef` becomes an array with `role` discriminator:
+
+```yaml
+credentials:
+  # Telegram — one secret
+  - name: telegram
+    channel: telegram
+    secretRef:
+      - name: telegram-bot-secret
+        key: token
+
+  # Discord — one secret, companions auto-generated
+  - name: discord
+    channel: discord
+    secretRef:
+      - name: discord-bot-secret
+        key: token
+
+  # Slack — two secrets, roles distinguish them
+  - name: slack
+    channel: slack
+    secretRef:
+      - name: slack-secret
+        key: bot-token
+        role: botToken
+      - name: slack-secret
+        key: app-token
+        role: appToken
+```
+
+`role` is optional when only one secretRef is defined (Telegram, Discord). Required when the channel needs multiple secrets (Slack).
+
+- **Pro:** Dramatically simpler UX — one entry instead of three
+- **Pro:** No risk of forgetting companion domains
+- **Pro:** Uniform structure — no channel-specific nested structs
+- **Pro:** Explicit roles for multi-secret channels, no conventions to remember
+
+**Decision:** Option A — auto-generate companion proxy routes. `secretRef` becomes an array; multi-secret channels use `role` to distinguish entries. The `channel` field gives the operator all it needs to generate proxy routes internally.
+
+_Considered and rejected: Option B (group by name prefix — fragile naming convention)_
+
+---
+
+## Q4: How should WhatsApp be handled?
+
+WhatsApp is fundamentally different from Telegram/Discord/Slack:
+- No API key or bot token — uses phone-based QR pairing (user interaction required)
+- Requires an npm plugin (`@openclaw/whatsapp`) that only loads on a full pod restart
+- Credential entries are just domain allowlisting (`type: none`)
+- Session state lives on the PVC (persistent across restarts)
+
+### Option B (chosen): Partial support — operator enables channel + domains, AI installs plugin, user pairs
+
+`channel: whatsapp` causes the operator to:
+1. Auto-generate domain allowlists (`.whatsapp.com`, `.whatsapp.net`)
+2. Inject `channels.whatsapp: { enabled: true }` and plugin enablement into `operator.json`
+
+The AI handles plugin installation (`@openclaw/whatsapp` via npm). The user completes QR pairing manually when prompted.
+
+```yaml
+- name: whatsapp
+  channel: whatsapp
+  # No secretRef needed — WhatsApp uses QR pairing, not API keys
+```
+
+- **Pro:** Consistent — all channels with `channel:` field get operator management
+- **Pro:** Domain allowlisting and channel/plugin enabling are automated
+- **Pro:** Division of labor: operator (infra), AI (plugin install), user (QR pairing)
+
+**Decision:** Option B — partial declarative support. Operator handles domains + channel enablement. AI installs the plugin. User does QR pairing.
+
+_Considered and rejected: Option A (exclude — inconsistent UX across channels), Option C (full plugin management in operator — too much scope for this proposal)_
+
+---
+
+## Q5: What should PLATFORM.md tell the AI about channels?
+
+The PLATFORM.md skill (injected into the OpenClaw workspace) currently instructs the AI to run `openclaw channels add` after a credential is configured. With declarative channels, this instruction becomes wrong.
+
+### Decision: B+C — explain operator-managed channels, mention custom channels are user/AI-managed
+
+Update PLATFORM.md to:
+1. Explain that channels declared in the Claw CR (`channel: telegram/discord/slack/whatsapp`) are **operator-managed** — the AI must NOT run `openclaw channels add/remove` for these. They are configured automatically on pod start.
+2. For WhatsApp specifically: AI installs the `@openclaw/whatsapp` plugin when asked, and guides user through QR pairing.
+3. For custom/unknown channels not in the CR: AI and user are on their own — standard `openclaw channels add` workflow applies. If the user wants operator management, guide them to update the Claw CR with the `channel:` field.
+
+_Considered and rejected: Option A (remove all instructions — AI can't help at all), standalone Option B (doesn't cover custom channels), standalone Option C (didn't clearly explain what the operator manages)_


### PR DESCRIPTION
- Design for operator-managed messaging channels (Telegram, Discord, Slack, WhatsApp)
- New `channel` field on CredentialSpec mirrors the existing `provider` pattern
- SecretRef changes from single pointer to array with role discriminator
- Opaque channelConfig (runtime.RawExtension) for channel-specific settings
- Companion questions doc with all decisions resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a final design proposal for declarative messaging-channel configuration in credentials.
  * Introduced an optional channel and opaque channel-config passthrough, operator-inferred channel defaults, and protected merge semantics for channel settings.
  * Specified multi-secret credential handling via array-style secret references with optional roles and required operator behavior.
  * Documented WhatsApp flow, AI/platform guidance, and a phased implementation and testing plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->