### PR TITLE
docs: update channel documentation for declarative channel: field

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The controller uses three phases because the Route host (populated asynchronousl
 
 **Phase 2 — Route + Host Resolution**: Apply only the Route resource from the Kustomize output, then read back its `.status.ingress[0].host`. If the router hasn't populated the host yet, requeue with 5s backoff. On vanilla Kubernetes (no Route CRD), fall back to `http://localhost:18789`.
 
-**Phase 3 — ConfigMap Injection + Remaining Resources**: With the Route host now known, inject it (plus providers, model catalog, kubernetes skill, network policy ports, config hash) into the in-memory Kustomize objects, then server-side apply everything except the Route (already applied) and proxy ConfigMap (controller-managed).
+**Phase 3 — ConfigMap Injection + Remaining Resources**: With the Route host now known, inject it (plus providers, model catalog, channel config, kubernetes skill, network policy ports, config hash) into the in-memory Kustomize objects, then server-side apply everything except the Route (already applied) and proxy ConfigMap (controller-managed).
 
 This ordering ensures the gateway ConfigMap always has the correct CORS origin on first apply.
 
@@ -22,15 +22,17 @@ The operator needs to manage certain config keys (gateway settings, CORS, provid
 2. `openclaw.json` on the PVC holds the live config — modified by users and by OpenClaw itself
 3. On pod start, `init-config` runs `merge.js` which deep-merges operator keys into the PVC config
 
-Objects merge recursively (operator keys win), arrays and primitives from operator replace user values. This means operator-managed sections like `gateway.*` and `models.providers` are always current, while user-owned sections like `plugins.*`, `channels.*`, and `agents.list` survive restarts.
+Objects merge recursively (operator keys win), arrays and primitives from operator replace user values. This means operator-managed sections like `gateway.*` and `models.providers` are always current, while user-owned sections like `plugins.*` and `agents.list` survive restarts.
+
+`channels.*` has split ownership: channels declared with the `channel:` field in the Claw CR are operator-managed (injected into `operator.json` with enabled state and placeholder tokens), while channels configured manually via CLI remain user-owned on the PVC. Because deep-merge is key-level, operator-managed channel entries (e.g., `channels.telegram`) overwrite user values for those keys, but user-managed channels (e.g., `channels.mycustom`) are preserved.
 
 **Config ownership summary (merge mode):**
 
 | Owner | Sections | Restart behavior |
 |---|---|---|
-| Operator | `gateway.*`, `models.providers`, `agents.defaults.models` | Overwritten every restart |
+| Operator | `gateway.*`, `models.providers`, `agents.defaults.models`, `channels.<declared>`, `plugins.entries.<declared>` | Overwritten every restart |
 | Operator → User | `agents.defaults.model.primary` | Set on first run, then preserved |
-| User | `agents.list`, `plugins.*`, `channels.*`, `tools.*`, `cron.*` | Preserved across restarts |
+| User | `agents.list`, `plugins.*` (non-declared), `channels.*` (non-declared), `tools.*`, `cron.*` | Preserved across restarts |
 
 In `overwrite` mode, the PVC config is ignored and `operator.json` is merged into the seed `openclaw.json` from the ConfigMap. User edits are wiped on every restart.
 
@@ -45,6 +47,8 @@ The proxy sits between the gateway and external APIs, injecting credentials into
 **Why two CONNECT modes?** Most domains need MITM for credential injection, path filtering, or header injection. But some protocols (WhatsApp Noise handshake, certain WebSocket tunnels) break under TLS interception. Domains with `type: none` and no path/header restrictions use a direct CONNECT tunnel instead.
 
 **Provider defaults**: known providers (google, anthropic, openai, openrouter, xai) have pre-configured domain and apiKey header defaults. Users only need to specify `provider` and `secretRef` — the operator infers the rest. Explicit values always take precedence as an escape hatch.
+
+**Channel defaults**: known channels (telegram, discord, slack, whatsapp) have pre-configured domain, credential type, companion routes, and placeholder tokens. Users only need to specify `channel` and `secretRef` — the operator infers proxy config and injects channel enablement into `operator.json`. This mirrors the `provider` pattern for LLM credentials. Explicit values always take precedence as an escape hatch.
 
 **Vertex AI path**: credentials with `type: gcp` and a non-google `provider` (e.g., anthropic) use the native Vertex AI SDK rather than gateway routing. The operator creates a stub ADC (Application Default Credentials) ConfigMap so google-auth-library can bootstrap, and the proxy intercepts token refresh requests to vend real tokens.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,9 +22,9 @@ The operator needs to manage certain config keys (gateway settings, CORS, provid
 2. `openclaw.json` on the PVC holds the live config — modified by users and by OpenClaw itself
 3. On pod start, `init-config` runs `merge.js` which deep-merges operator keys into the PVC config
 
-Objects merge recursively (operator keys win), arrays and primitives from operator replace user values. This means operator-managed sections like `gateway.*` and `models.providers` are always current, while user-owned sections like `plugins.*` and `agents.list` survive restarts.
+Objects merge recursively (operator keys win), arrays and primitives from operator replace user values. This means operator-managed sections like `gateway.*` and `models.providers` are always current, while user-owned sections like `agents.list` and `tools.*` survive restarts. `plugins.*` and `channels.*` have split ownership — declared entries (from `channel:` credentials) are operator-managed, while everything else is user-owned.
 
-`channels.*` has split ownership: channels declared with the `channel:` field in the Claw CR are operator-managed (injected into `operator.json` with enabled state and placeholder tokens), while channels configured manually via CLI remain user-owned on the PVC. Because deep-merge is key-level, operator-managed channel entries (e.g., `channels.telegram`) overwrite user values for those keys, but user-managed channels (e.g., `channels.mycustom`) are preserved.
+Because deep-merge operates at the key level, operator-managed entries (e.g., `channels.telegram`, `plugins.entries.telegram`) overwrite user values for those specific keys, while user-managed entries (e.g., `channels.mycustom`) are preserved across restarts.
 
 **Config ownership summary (merge mode):**
 

--- a/docs/proposals/declarative-channels-design.md
+++ b/docs/proposals/declarative-channels-design.md
@@ -210,7 +210,7 @@ The AI skill document is updated to explain:
    - Unit: `internal/controller/claw_channels_test.go` — table-driven tests for each channel type, inference with/without overrides, companion route generation, channelConfig passthrough
    - E2E: channel credential → verify operator.json contains channel config, pod starts with channel active
 
-### PR 2: Documentation
+### PR 2: Documentation - DONE
 
 1. Update `docs/provider-setup.md` — simplify channel examples to use `channel:` field
 2. Update PLATFORM.md template in `configmap.yaml` — new AI instructions for operator-managed channels

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -439,11 +439,13 @@ The gateway pod **cannot** reach any API server directly — egress is restricte
 
 ## Messaging Channels
 
-Messaging channels (Telegram, Discord, WhatsApp) use different authentication mechanisms. Unlike LLM providers, messaging channel credentials are injected transparently by the proxy — OpenClaw is configured with placeholder tokens and never sees the real secrets.
+For known channels (`telegram`, `discord`, `slack`, `whatsapp`), the operator automatically infers all proxy configuration — domain, credential type, companion routes, and placeholder tokens. You only need `name`, `channel`, and `secretRef`. The operator also injects the channel's config into `operator.json` so OpenClaw starts with the channel pre-configured. No manual `openclaw channels add` is needed.
+
+> **Adding credentials incrementally:** Each `oc apply` of the Claw CR **replaces** the entire `credentials` list. When adding a new channel, include all existing credentials in the YAML — otherwise they will be removed. You can retrieve your current configuration with `oc get claw instance -n $NS -o yaml` and add the new entry to the list.
 
 ### Telegram
 
-The Telegram Bot API embeds the bot token in the URL path (`/bot<TOKEN>/method`). The proxy uses `pathToken` credential injection to replace the placeholder with the real token on every request.
+Uses the Telegram Bot API with path-based token injection (`/bot<TOKEN>/method`).
 
 **1. Create a bot** via [@BotFather](https://t.me/BotFather) and copy the bot token.
 
@@ -466,23 +468,31 @@ metadata:
 spec:
   credentials:
     - name: telegram
-      type: pathToken
+      channel: telegram
       secretRef:
         - name: telegram-bot-secret
           key: token
-      domain: "api.telegram.org"
-      pathToken:
-        prefix: "/bot"
 EOF
 ```
 
-**4.** Once the CR is applied, the OpenClaw assistant should configure the channel with a placeholder token automatically when the user asks to set up Telegram.
+The operator infers `type: pathToken`, `domain: api.telegram.org`, and `pathToken.prefix: /bot`. The proxy intercepts requests like `/botplaceholder/sendMessage` and forwards them as `/bot<REAL_TOKEN>/sendMessage`. The real token never reaches the gateway pod.
 
-The proxy intercepts requests like `/botplaceholder/sendMessage` and forwards them as `/bot<REAL_TOKEN>/sendMessage`. The real token never reaches the gateway pod.
+To customize channel behavior (e.g., restrict who can DM the bot), use `channelConfig`:
+
+```yaml
+    - name: telegram
+      channel: telegram
+      secretRef:
+        - name: telegram-bot-secret
+          key: token
+      channelConfig:
+        dmPolicy: allowlist
+        allowFrom: [12345]
+```
 
 ### Discord
 
-Discord Bot API uses `Authorization: Bot <TOKEN>` header authentication. The proxy uses `apiKey` credential injection with a `Bot ` value prefix. Discord also requires passthrough domains for its WebSocket gateway and CDN.
+Uses the Discord Bot API with `Authorization: Bot <TOKEN>` header injection. The operator automatically creates companion routes for Discord's WebSocket gateway (`gateway.discord.gg`) and CDN (`cdn.discordapp.com`).
 
 **1. Create a bot** in the [Discord Developer Portal](https://discord.com/developers/applications) and copy the bot token.
 
@@ -505,30 +515,18 @@ metadata:
 spec:
   credentials:
     - name: discord
-      type: apiKey
+      channel: discord
       secretRef:
         - name: discord-bot-secret
           key: token
-      domain: "discord.com"
-      apiKey:
-        header: Authorization
-        valuePrefix: "Bot "
-    - name: discord-gateway
-      type: none
-      domain: "gateway.discord.gg"
-    - name: discord-cdn
-      type: none
-      domain: "cdn.discordapp.com"
 EOF
 ```
 
-**4.** Once the CR is applied, the OpenClaw assistant should configure the channel with a placeholder token automatically when the user asks to set up Discord.
-
-The `discord-gateway` and `discord-cdn` entries allow Discord's WebSocket connection and media/avatar downloads without credential injection.
+The operator infers `type: apiKey`, `domain: discord.com`, and the `Authorization` header with `Bot ` prefix. Companion domains for WebSocket and CDN are generated automatically.
 
 ### Slack
 
-Slack requires two tokens on the same domain (`slack.com`): an app-level token (`xapp-...`) for Socket Mode and a bot token (`xoxb-...`) for the REST API. The proxy uses `bearer` credential injection with `allowedPaths` to route each request to the correct token based on the URL path.
+Slack requires two tokens: an app-level token (`xapp-...`) for Socket Mode and a bot token (`xoxb-...`) for the REST API. Use the `role` field to distinguish them.
 
 **1. Create a Slack app** at [api.slack.com/apps](https://api.slack.com/apps). Enable Socket Mode, add the required OAuth scopes, and install the app to your workspace. Copy the bot token (`xoxb-...`) and app-level token (`xapp-...`).
 
@@ -551,34 +549,25 @@ metadata:
   name: instance
 spec:
   credentials:
-    - name: slack-app
-      type: bearer
-      secretRef:
-        - name: slack-secret
-          key: app-token
-      domain: "slack.com"
-      allowedPaths: ["/api/apps.connections.open"]
-    - name: slack-bot
-      type: bearer
+    - name: slack
+      channel: slack
       secretRef:
         - name: slack-secret
           key: bot-token
-      domain: "slack.com"
-    - name: slack-ws
-      type: none
-      domain: ".slack.com"
+          role: botToken
+        - name: slack-secret
+          key: app-token
+          role: appToken
 EOF
 ```
 
-**4.** Once the CR is applied, the OpenClaw assistant should configure the channel with Bolt-shaped placeholder tokens (`xoxb-placeholder`, `xapp-placeholder`) automatically when the user asks to set up Slack.
-
-The `slack-app` credential handles only the Socket Mode handshake endpoint (`/api/apps.connections.open`). The `slack-bot` credential is the catch-all for all other `slack.com` API calls. The `slack-ws` entry (suffix match `.slack.com`) passes through WebSocket connections to `wss-primary.slack.com` without credential injection.
+The operator infers `type: bearer`, `domain: slack.com`, path-based routing for the two tokens, and a companion route for WebSocket connections (`.slack.com`).
 
 ### WhatsApp
 
-OpenClaw supports WhatsApp as a messaging channel via WhatsApp Web (the Baileys library). The gateway maintains a linked-device session over WebSocket to WhatsApp's servers.
+WhatsApp Web uses phone-based QR pairing — no API keys or secrets needed. The operator allowlists the required WhatsApp domains and enables the channel plugin.
 
-All gateway egress goes through the credential-injecting proxy, which blocks unknown domains by default. To allow WhatsApp traffic, add two `type: none` credentials that allowlist the required domains:
+**1. Apply the Claw CR:**
 
 ```sh
 oc apply -n $NS -f - <<EOF
@@ -588,29 +577,35 @@ metadata:
   name: instance
 spec:
   credentials:
-    - name: gemini
-      type: apiKey
-      secretRef:
-        - name: gemini-api-key
-          key: api-key
-      provider: google
     - name: whatsapp
-      type: none
-      domain: ".whatsapp.com"
-    - name: whatsapp-net
-      type: none
-      domain: ".whatsapp.net"
+      channel: whatsapp
 EOF
 ```
 
-The leading dot makes these suffix matches — `.whatsapp.com` covers `web.whatsapp.com` (WebSocket), `api.whatsapp.com`, and fallback hosts; `.whatsapp.net` covers `mmg.whatsapp.net` (media), `pps.whatsapp.net` (profile pictures), and CDN subdomains.
+The operator infers `type: none` and creates companion routes for `.whatsapp.com` and `.whatsapp.net`. It also enables the WhatsApp plugin entry in `operator.json`.
 
-No Secret is needed. WhatsApp Web uses phone-based QR pairing, not API keys — the session state is managed by OpenClaw on the gateway pod's persistent storage. The `none` type tells the proxy to allow traffic to these domains without injecting any credentials.
-
-After deploying, the OpenClaw assistant should handle plugin installation and channel configuration when the user asks to set up WhatsApp. However, WhatsApp requires an npm plugin (`@openclaw/whatsapp`) that only loads on a full pod restart. The assistant should ask the user to restart the pod:
+After applying, the OpenClaw assistant handles plugin installation (`@openclaw/whatsapp`) and QR pairing. A pod restart is required after plugin install since npm plugins load at boot:
 
 ```sh
 oc delete pod -n $NS -l app=claw
 ```
 
-Once the new pod is ready, the assistant can complete the pairing flow. The user will need to scan the QR code with their phone (WhatsApp → Linked Devices) when prompted.
+Once the new pod is ready, the assistant completes the pairing flow. The user scans the QR code with their phone (WhatsApp → Linked Devices).
+
+### Explicit Override
+
+You can override any inferred field if needed (e.g., routing through a corporate proxy or using a custom domain):
+
+```yaml
+    - name: telegram
+      channel: telegram
+      type: pathToken
+      domain: "telegram.internal.corp.com"
+      pathToken:
+        prefix: "/bot"
+      secretRef:
+        - name: telegram-bot-secret
+          key: token
+```
+
+The `channel` field still enables declarative channel config injection into `operator.json` — only the proxy routing is overridden. You can override `type`, `domain`, and type-specific config (`apiKey`, `pathToken`) independently.

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -582,7 +582,7 @@ spec:
 EOF
 ```
 
-The operator infers `type: none` and creates companion routes for `.whatsapp.com` and `.whatsapp.net`. It also enables the WhatsApp plugin entry in `operator.json`.
+The operator infers `type: none` and creates companion routes for `.whatsapp.com`, `.whatsapp.net`, `.facebook.com`, `.facebook.net`, and `.fbcdn.net` (WhatsApp Web relies on Meta's auth and CDN infrastructure). It also enables the WhatsApp plugin entry in `operator.json`.
 
 After applying, the OpenClaw assistant handles plugin installation (`@openclaw/whatsapp`) and QR pairing. A pod restart is required after plugin install since npm plugins load at boot:
 

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -148,11 +148,11 @@ data:
     - **Non-root execution:** All containers run as a random non-root UID assigned by
       OpenShift's Security Context Constraints (restricted seccomp, all capabilities
       dropped). You cannot bind privileged ports or write outside designated paths.
-    - **Claw CR manages infrastructure:** LLM provider credentials, proxy domain
-      allowlisting, and Kubernetes API access. The operator reconciles the CR into
-      Deployments, ConfigMaps, Secrets, NetworkPolicies, and Routes. Application-level
-      config (plugins, channels, agent settings) is managed separately via
-      `openclaw config patch` on the PVC.
+    - **Claw CR manages infrastructure:** LLM provider credentials, messaging
+      channels, proxy domain allowlisting, and Kubernetes API access. The operator
+      reconciles the CR into Deployments, ConfigMaps, Secrets, NetworkPolicies, and
+      Routes. Non-operator-managed config (custom plugins, agent settings, tools) is
+      managed separately via `openclaw config patch` on the PVC.
     - **Important:** Each `oc apply` of the Claw CR **replaces** the entire `credentials`
       list. The user must include all existing credentials when applying — otherwise they
       will be removed. Retrieve the current state first:
@@ -252,189 +252,147 @@ data:
 
     # Messaging Channels
 
-    ## WhatsApp
+    Messaging channels can be either **operator-managed** or **user-managed**.
 
-    WhatsApp Web uses phone-based QR pairing (not API keys). Setup has TWO parts:
-    proxy domain allowlisting (Claw CR — needs the user) and plugin/channel
-    configuration (openclaw CLI — you do this yourself).
+    ## Operator-Managed Channels
 
-    **Do NOT** invent Claw CR fields like `spec.channels` — the Claw CRD has no
-    such field. Channel config lives in `openclaw.json` and you configure it
-    yourself using `openclaw config patch`.
+    When a credential in the Claw CR has a `channel:` field (e.g., `channel: telegram`),
+    the operator fully manages that channel:
+    - Proxy config (domain, credential type, companion routes) is auto-inferred
+    - Channel config is injected into `operator.json` (enabled + placeholder tokens)
+    - Plugin entries are added to `operator.json`
+    - Pod rolls out automatically when channel config changes
 
-    **Important:** `openclaw config patch` WORKS. Config writes are NOT blocked.
-    Do not tell the user that config patches are blocked or protected — that is
-    incorrect.
+    **Do NOT** run `openclaw channels add` or `openclaw channels remove` for
+    operator-managed channels. The operator owns these entries — manual CLI changes
+    will be overwritten on the next pod restart.
 
-    ### Part 1: Proxy domains (user must do this)
+    Known operator-managed channels: `telegram`, `discord`, `slack`, `whatsapp`.
 
-    The user needs to add these entries to the Claw CR `credentials` list.
-    Beyond `*.whatsapp.*`, WhatsApp Web also relies on Meta's auth and CDN
-    infrastructure.
+    ### How to tell the user to add a channel
+
+    The user adds a `channel:` credential entry to the Claw CR. The simplified
+    syntax infers all proxy details automatically:
 
     ```yaml
-        - name: whatsapp
-          type: none
-          domain: ".whatsapp.com"
-        - name: whatsapp-net
-          type: none
-          domain: ".whatsapp.net"
-        - name: facebook
-          type: none
-          domain: ".facebook.com"
-        - name: facebook-net
-          type: none
-          domain: ".facebook.net"
-        - name: fbcdn
-          type: none
-          domain: ".fbcdn.net"
+    # Telegram — single secret
+    - name: telegram
+      channel: telegram
+      secretRef:
+        - name: telegram-bot-secret
+          key: token
+
+    # Discord — single secret, companion routes auto-generated
+    - name: discord
+      channel: discord
+      secretRef:
+        - name: discord-bot-secret
+          key: token
+
+    # Slack — two secrets with roles
+    - name: slack
+      channel: slack
+      secretRef:
+        - name: slack-secret
+          key: bot-token
+          role: botToken
+        - name: slack-secret
+          key: app-token
+          role: appToken
+
+    # WhatsApp — no secret needed (QR pairing)
+    - name: whatsapp
+      channel: whatsapp
     ```
 
-    ### Part 2: Plugin and channel setup (you do this yourself)
+    Walk the user through retrieving their current CR first:
+    ```sh
+    oc get claw <name> -n <namespace> -o yaml
+    ```
+    Then add the new channel credential to the existing `credentials` list.
 
-    Once the proxy domains are configured, run these commands yourself — do not
-    ask the user to do them.
+    ### WhatsApp special case
 
-    **Step 1.** Install the WhatsApp plugin:
+    The operator enables the WhatsApp plugin entry and channel config in
+    `operator.json`, and auto-generates companion routes for `.whatsapp.com`,
+    `.whatsapp.net`, `.facebook.com`, `.facebook.net`, and `.fbcdn.net`.
+    However, WhatsApp requires an npm package that must be installed inside
+    the pod. After the user applies the CR with `channel: whatsapp`:
+
+    **Step 1.** Install the WhatsApp plugin (you do this yourself):
     ```sh
     openclaw plugins install @openclaw/whatsapp
     ```
     If it says "plugin already exists", use `--force` to re-install.
 
-    **Step 2.** Enable the plugin and configure the channel by running:
-    ```sh
-    echo '{"plugins":{"entries":{"whatsapp":{"enabled":true}}},"channels":{"whatsapp":{"enabled":true,"dmPolicy":"pairing","groupPolicy":"allowlist","debounceMs":0,"mediaMaxMb":50}}}' | openclaw config patch --stdin
-    ```
-    **This step is critical.** Without the `channels.whatsapp` config,
-    `channels login` will fail with "does not support login". The fields
-    `dmPolicy`, `groupPolicy`, `debounceMs`, `mediaMaxMb` are required. The
-    values above are sensible defaults but **may change in future plugin
-    versions**. If the patch is rejected or login still fails, run
-    `openclaw config schema`, find the `channels.whatsapp` section, and use
-    the required fields from the current schema.
-
-    **Step 3.** Tell the user to restart the pod so the gateway loads the
-    new plugin. The in-process `openclaw gateway restart` is NOT enough —
-    npm plugins only load on a full pod restart:
+    **Step 2.** Tell the user to restart the pod — npm plugins only load on
+    a full pod restart. The in-process `openclaw gateway restart` is NOT enough:
     ```sh
     oc delete pod -n <namespace> -l app=claw
     ```
     Wait for the new pod to be ready before continuing.
 
-    **Step 4.** Link the device:
+    **Step 3.** Link the device:
     ```sh
     openclaw channels login --channel whatsapp
     ```
 
-    **Step 5.** Tell the user to scan the QR code with their phone
+    **Step 4.** Tell the user to scan the QR code with their phone
     (WhatsApp → Linked Devices).
 
-    ## Telegram
+    ### Channel customization (channelConfig)
 
-    Telegram Bot API embeds the bot token in the URL path (`/bot<TOKEN>/method`).
-    The proxy uses `pathToken` credential injection: OpenClaw is configured with a
-    placeholder token, and the proxy replaces it with the real token on every request.
-
-    The user needs to add this credential entry to the Claw CR:
+    Users can pass extra settings to operator-managed channels via `channelConfig`
+    on the credential entry. These are deep-merged into the channel's config block:
 
     ```yaml
-        - name: telegram
-          type: pathToken
-          secretRef:
-            - name: telegram-bot-secret
-              key: token
-          domain: "api.telegram.org"
-          pathToken:
-            prefix: "/bot"
+    - name: telegram
+      channel: telegram
+      secretRef:
+        - name: telegram-bot-secret
+          key: token
+      channelConfig:
+        dmPolicy: allowlist
+        allowFrom: [12345]
     ```
 
-    Once the proxy credential is configured, configure the channel yourself — do not
-    ask the user to do this:
+    Protected keys (`enabled`, `botToken`, `token`, `appToken`) cannot be set via
+    `channelConfig` — they are operator-managed.
+
+    ## User-Managed Channels
+
+    If a channel is NOT one of the four known channels above, or the user adds
+    a credential without the `channel:` field (using explicit `type`, `domain`,
+    etc. instead), the channel is user-managed. For these, you configure the
+    channel yourself using the CLI:
+
     ```sh
-    openclaw channels add --channel telegram --token placeholder
-    ```
-    The proxy strips whatever placeholder token it finds and injects the real one.
-
-    The real bot token is stored in the Kubernetes Secret and never reaches the
-    gateway pod. The proxy intercepts `/botplaceholder/sendMessage` and forwards
-    it as `/bot<REAL_TOKEN>/sendMessage`.
-
-    ## Discord
-
-    Discord Bot API uses `Authorization: Bot <TOKEN>` header authentication. The
-    proxy uses `apiKey` credential injection with `valuePrefix: "Bot "` to inject
-    the real token into the Authorization header.
-
-    The user needs to add these credential entries to the Claw CR:
-
-    ```yaml
-        - name: discord
-          type: apiKey
-          secretRef:
-            - name: discord-bot-secret
-              key: token
-          domain: "discord.com"
-          apiKey:
-            header: Authorization
-            valuePrefix: "Bot "
-        - name: discord-gateway
-          type: none
-          domain: "gateway.discord.gg"
-        - name: discord-cdn
-          type: none
-          domain: "cdn.discordapp.com"
+    openclaw channels add --channel <name> --token <placeholder>
     ```
 
-    Once the proxy credentials are configured, configure the channel yourself — do not
-    ask the user to do this:
-    ```sh
-    openclaw channels add --channel discord --token placeholder
-    ```
+    The user handles proxy domain allowlisting in the Claw CR, and you handle
+    channel config via `openclaw config patch` or `openclaw channels add`.
 
-    The `discord-gateway` and `discord-cdn` entries are passthrough domains for
-    Discord's WebSocket gateway and CDN (media/avatars). They don't need credential
-    injection.
+    **Important:** `openclaw config patch` WORKS. Config writes are NOT blocked.
+    Do not tell the user that config patches are blocked or protected.
 
-    ## Slack
+    ## Telegram (proxy details)
 
-    Slack requires two tokens on the same domain (`slack.com`): an app-level token
-    (`xapp-...`) for Socket Mode and a bot token (`xoxb-...`) for the REST API. The
-    proxy uses `bearer` credential injection with `allowedPaths` to route each request
-    to the correct token.
+    The proxy intercepts `/botplaceholder/sendMessage` and forwards it as
+    `/bot<REAL_TOKEN>/sendMessage`. The real bot token never reaches the gateway pod.
 
-    The user needs to add these credential entries to the Claw CR:
+    ## Discord (proxy details)
 
-    ```yaml
-        - name: slack-app
-          type: bearer
-          secretRef:
-            - name: slack-secret
-              key: app-token
-          domain: "slack.com"
-          allowedPaths: ["/api/apps.connections.open"]
-        - name: slack-bot
-          type: bearer
-          secretRef:
-            - name: slack-secret
-              key: bot-token
-          domain: "slack.com"
-        - name: slack-ws
-          type: none
-          domain: ".slack.com"
-    ```
+    The proxy injects `Authorization: Bot <REAL_TOKEN>` into every request to
+    `discord.com`. Companion domains (`gateway.discord.gg`, `cdn.discordapp.com`)
+    pass through without credential injection.
 
-    Once the proxy credentials are configured, configure the channel yourself — do not
-    ask the user to do this:
-    ```sh
-    openclaw channels add --channel slack --bot-token xoxb-placeholder --app-token xapp-placeholder
-    ```
-    The Bolt-shaped placeholders (`xoxb-placeholder`, `xapp-placeholder`) pass Slack's
-    startup regex validation. The proxy strips them and injects real tokens.
+    ## Slack (proxy details)
 
-    The `slack-app` credential handles the Socket Mode handshake (`/api/apps.connections.open`).
-    The `slack-bot` credential is the catch-all for all other `slack.com` API calls. The
-    `slack-ws` entry (suffix match `.slack.com`) passes through WebSocket connections to
-    `wss-primary.slack.com` without credential injection.
+    Two tokens on `slack.com`: the app-level token (`xapp-...`) handles only
+    `/api/apps.connections.open` (Socket Mode handshake), and the bot token
+    (`xoxb-...`) handles all other API calls. WebSocket connections to
+    `*.slack.com` pass through without injection.
 
     # Custom Domains
 

--- a/internal/controller/claw_channels.go
+++ b/internal/controller/claw_channels.go
@@ -102,6 +102,9 @@ var knownChannels = map[string]channelDefault{
 		Companions: []string{
 			".whatsapp.com",
 			".whatsapp.net",
+			".facebook.com",
+			".facebook.net",
+			".fbcdn.net",
 		},
 		ConfigBase: map[string]any{},
 	},

--- a/internal/controller/claw_channels_test.go
+++ b/internal/controller/claw_channels_test.go
@@ -161,10 +161,10 @@ func TestGenerateCompanionRoutes(t *testing.T) {
 			wantInjectors: []string{"none"},
 		},
 		{
-			name:          "whatsapp generates two companion routes",
+			name:          "whatsapp generates five companion routes",
 			cred:          clawv1alpha1.CredentialSpec{Channel: "whatsapp"},
-			wantDomains:   []string{".whatsapp.com", ".whatsapp.net"},
-			wantInjectors: []string{"none", "none"},
+			wantDomains:   []string{".whatsapp.com", ".whatsapp.net", ".facebook.com", ".facebook.net", ".fbcdn.net"},
+			wantInjectors: []string{"none", "none", "none", "none", "none"},
 		},
 		{
 			name: "telegram generates no companion routes",


### PR DESCRIPTION
- Rewrite provider-setup.md channel examples to use simplified channel: field syntax instead of verbose type/domain/companion entries
- Rewrite PLATFORM.md AI skill to distinguish operator-managed vs user-managed channels, removing openclaw channels add instructions
- Update architecture.md with channel config injection in Phase 3 and split ownership semantics for channels.*
- Add Meta domains (.facebook.com, .facebook.net, .fbcdn.net) to WhatsApp companion routes for WhatsApp Web compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative messaging-channel setup: add Telegram, Discord, Slack, WhatsApp with automatic proxy/credential inference and operator injection of channel configuration.
  * Expanded WhatsApp proxy companion domains for broader routing.

* **Documentation**
  * Updated architecture, provider setup, and platform docs to clarify channel ownership, defaults, overrides, and onboarding steps.

* **Breaking Changes**
  * Credential secret referencing format and credential/channel fields updated (migration required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->