### PR TITLE
feat: add claw-device-pairing deployment managed by operator

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -46,9 +46,10 @@ const (
 
 // Condition types for Claw status.
 const (
-	ConditionTypeReady               = "Ready"
-	ConditionTypeCredentialsResolved = "CredentialsResolved"
-	ConditionTypeProxyConfigured     = "ProxyConfigured"
+	ConditionTypeReady                   = "Ready"
+	ConditionTypeCredentialsResolved     = "CredentialsResolved"
+	ConditionTypeProxyConfigured         = "ProxyConfigured"
+	ConditionTypeDevicePairingConfigured = "DevicePairingConfigured"
 )
 
 // Annotation keys used on pod templates to trigger rollouts on config changes.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - get
@@ -94,6 +95,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes
@@ -105,3 +118,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update

--- a/internal/assets/manifests/claw-device-pairing/clusterrole.yaml
+++ b/internal/assets/manifests/claw-device-pairing/clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing
+rules:
+  - apiGroups:
+      - claw.sandbox.redhat.com
+    resources:
+      - clawdevicepairingrequests
+    verbs:
+      - create
+      - get

--- a/internal/assets/manifests/claw-device-pairing/deployment.yaml
+++ b/internal/assets/manifests/claw-device-pairing/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: claw-device-pairing
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: claw-device-pairing
+    spec:
+      serviceAccountName: CLAW_INSTANCE_NAME-device-pairing
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: device-pairing
+          image: quay.io/xcoulon/claw-device-pairing:latest
+          imagePullPolicy: Always
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLAW_INSTANCE
+              value: CLAW_INSTANCE_NAME
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 256Mi
+              cpu: 500m
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/internal/assets/manifests/claw-device-pairing/kustomization.yaml
+++ b/internal/assets/manifests/claw-device-pairing/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: claw-device-pairing
+
+resources:
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - rolebinding.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml

--- a/internal/assets/manifests/claw-device-pairing/rolebinding.yaml
+++ b/internal/assets/manifests/claw-device-pairing/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: CLAW_INSTANCE_NAME-device-pairing
+subjects:
+  - kind: ServiceAccount
+    name: CLAW_INSTANCE_NAME-device-pairing

--- a/internal/assets/manifests/claw-device-pairing/route.yaml
+++ b/internal/assets/manifests/claw-device-pairing/route.yaml
@@ -6,7 +6,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: /
 spec:
   # host: OPENCLAW_ROUTE_HOST
-  path: /integration/device-pairing
+  path: /integration/device-pairing/
   to:
     kind: Service
     name: CLAW_INSTANCE_NAME-device-pairing

--- a/internal/assets/manifests/claw-device-pairing/route.yaml
+++ b/internal/assets/manifests/claw-device-pairing/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing
+  annotations:
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  # host: OPENCLAW_ROUTE_HOST
+  path: /integration/device-pairing
+  to:
+    kind: Service
+    name: CLAW_INSTANCE_NAME-device-pairing
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/internal/assets/manifests/claw-device-pairing/service.yaml
+++ b/internal/assets/manifests/claw-device-pairing/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: claw-device-pairing
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/internal/assets/manifests/claw-device-pairing/serviceaccount.yaml
+++ b/internal/assets/manifests/claw-device-pairing/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: CLAW_INSTANCE_NAME-device-pairing

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestDevicePairingDeployment(t *testing.T) {
+
+	t.Run("buildKustomizedObjects includes device-pairing resources", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err, "buildKustomizedObjects failed")
+
+		expectedResources := map[string]string{
+			"ServiceAccount": getDevicePairingServiceAccountName(testInstanceName),
+			"Deployment":     getDevicePairingDeploymentName(testInstanceName),
+			"Service":        getDevicePairingServiceName(testInstanceName),
+			"Route":          getDevicePairingRouteName(testInstanceName),
+		}
+
+		for kind, name := range expectedResources {
+			found := false
+			for _, obj := range objects {
+				if obj.GetKind() == kind && obj.GetName() == name {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %s/%s in buildKustomizedObjects output", kind, name)
+		}
+	})
+
+	t.Run("CLAW_INSTANCE_NAME replacement works for device-pairing resources", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		for _, obj := range objects {
+			name := obj.GetName()
+			assert.NotContains(t, name, "CLAW_INSTANCE_NAME",
+				"resource %s/%s still contains placeholder", obj.GetKind(), name)
+		}
+	})
+
+	t.Run("device-pairing Route has correct path", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		var dpRoute *unstructured.Unstructured
+		for _, obj := range objects {
+			if obj.GetKind() == RouteKind && obj.GetName() == getDevicePairingRouteName(testInstanceName) {
+				dpRoute = obj
+				break
+			}
+		}
+		require.NotNil(t, dpRoute, "device-pairing Route not found")
+
+		path, found, err := unstructured.NestedString(dpRoute.Object, "spec", "path")
+		require.NoError(t, err)
+		assert.True(t, found, ".spec.path should be set")
+		assert.Equal(t, "/integration/device-pairing", path)
+	})
+
+	t.Run("device-pairing Route host injection sets spec.host", func(t *testing.T) {
+		dpRoute := &unstructured.Unstructured{}
+		dpRoute.SetKind(RouteKind)
+		dpRoute.SetName(getDevicePairingRouteName(testInstanceName))
+		dpRoute.Object["spec"] = map[string]any{
+			"path": "/integration/device-pairing",
+		}
+
+		objects := []*unstructured.Unstructured{dpRoute}
+		injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName)
+
+		host, found, err := unstructured.NestedString(dpRoute.Object, "spec", "host")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, "claw.example.com", host, "should strip https:// prefix and set bare hostname")
+	})
+
+	t.Run("device-pairing Route host injection is no-op when route not found", func(t *testing.T) {
+		otherRoute := &unstructured.Unstructured{}
+		otherRoute.SetKind(RouteKind)
+		otherRoute.SetName("other-route")
+		otherRoute.Object["spec"] = map[string]any{
+			"path": "/something-else",
+		}
+
+		objects := []*unstructured.Unstructured{otherRoute}
+		injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName)
+
+		_, found, _ := unstructured.NestedString(otherRoute.Object, "spec", "host")
+		assert.False(t, found, "should not set host on other routes")
+	})
+
+	t.Run("device-pairing Deployment has correct security context", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		var dpDeployment *unstructured.Unstructured
+		for _, obj := range objects {
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getDevicePairingDeploymentName(testInstanceName) {
+				dpDeployment = obj
+				break
+			}
+		}
+		require.NotNil(t, dpDeployment, "device-pairing Deployment not found")
+
+		containers, found, err := unstructured.NestedSlice(dpDeployment.Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, found, "containers not found")
+		require.NotEmpty(t, containers)
+
+		container := containers[0].(map[string]any)
+		secCtx := container["securityContext"].(map[string]any)
+		assert.Equal(t, false, secCtx["allowPrivilegeEscalation"])
+		assert.Equal(t, true, secCtx["readOnlyRootFilesystem"])
+
+		caps := secCtx["capabilities"].(map[string]any)
+		drop := caps["drop"].([]any)
+		assert.Contains(t, drop, "ALL")
+	})
+
+	t.Run("device-pairing Deployment references correct ServiceAccount", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		var dpDeployment *unstructured.Unstructured
+		for _, obj := range objects {
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getDevicePairingDeploymentName(testInstanceName) {
+				dpDeployment = obj
+				break
+			}
+		}
+		require.NotNil(t, dpDeployment)
+
+		sa, found, err := unstructured.NestedString(dpDeployment.Object, "spec", "template", "spec", "serviceAccountName")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, getDevicePairingServiceAccountName(testInstanceName), sa)
+	})
+
+	t.Run("device-pairing Deployment has NAMESPACE and CLAW_INSTANCE env vars", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		var dpDeployment *unstructured.Unstructured
+		for _, obj := range objects {
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getDevicePairingDeploymentName(testInstanceName) {
+				dpDeployment = obj
+				break
+			}
+		}
+		require.NotNil(t, dpDeployment)
+
+		containers, _, err := unstructured.NestedSlice(dpDeployment.Object, "spec", "template", "spec", "containers")
+		require.NoError(t, err)
+		require.NotEmpty(t, containers)
+
+		container := containers[0].(map[string]any)
+		envVars, _ := container["env"].([]any)
+		require.NotEmpty(t, envVars, "container should have env vars")
+
+		envMap := map[string]any{}
+		for _, e := range envVars {
+			env := e.(map[string]any)
+			envMap[env["name"].(string)] = env
+		}
+
+		nsEnv, ok := envMap["NAMESPACE"]
+		require.True(t, ok, "NAMESPACE env var should exist")
+		nsEnvMap := nsEnv.(map[string]any)
+		valueFrom := nsEnvMap["valueFrom"].(map[string]any)
+		fieldRef := valueFrom["fieldRef"].(map[string]any)
+		assert.Equal(t, "metadata.namespace", fieldRef["fieldPath"])
+
+		clawEnv, ok := envMap["CLAW_INSTANCE"]
+		require.True(t, ok, "CLAW_INSTANCE env var should exist")
+		clawEnvMap := clawEnv.(map[string]any)
+		assert.Equal(t, testInstanceName, clawEnvMap["value"], "CLAW_INSTANCE should be the instance name after template replacement")
+	})
+
+	t.Run("device-pairing resources have app.kubernetes.io/name label", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err)
+
+		dpNames := map[string]bool{
+			getDevicePairingServiceAccountName(testInstanceName): true,
+			getDevicePairingDeploymentName(testInstanceName):     true,
+			getDevicePairingServiceName(testInstanceName):        true,
+			getDevicePairingRouteName(testInstanceName):          true,
+		}
+
+		for _, obj := range objects {
+			if dpNames[obj.GetName()] {
+				labels := obj.GetLabels()
+				assert.Equal(t, "claw-device-pairing", labels["app.kubernetes.io/name"],
+					"%s/%s should have app.kubernetes.io/name=claw-device-pairing", obj.GetKind(), obj.GetName())
+			}
+		}
+	})
+}
+
+func TestDevicePairingReconciliation(t *testing.T) {
+
+	t.Run("should create device-pairing resources after reconcile", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, resourceName, namespace)
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		sa := &corev1.ServiceAccount{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingServiceAccountName(resourceName),
+				Namespace: namespace,
+			}, sa) == nil
+		}, "device-pairing ServiceAccount should be created")
+
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingDeploymentName(resourceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "device-pairing Deployment should be created")
+
+		svc := &corev1.Service{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingServiceName(resourceName),
+				Namespace: namespace,
+			}, svc) == nil
+		}, "device-pairing Service should be created")
+	})
+
+	t.Run("should set correct owner references on device-pairing resources", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, resourceName, namespace)
+		reconciler := &ClawResourceReconciler{
+			Client: k8sClient,
+			Scheme: scheme.Scheme,
+		}
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		sa := &corev1.ServiceAccount{}
+		waitFor(t, timeout, interval, func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingServiceAccountName(resourceName),
+				Namespace: namespace,
+			}, sa)
+			if err != nil {
+				return false
+			}
+			if len(sa.OwnerReferences) == 0 {
+				return false
+			}
+			ownerRef := sa.OwnerReferences[0]
+			return ownerRef.Kind == ClawResourceKind &&
+				ownerRef.Name == resourceName &&
+				ownerRef.Controller != nil &&
+				*ownerRef.Controller
+		}, "device-pairing ServiceAccount should have correct owner reference")
+	})
+}

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -144,13 +144,17 @@ func TestDevicePairingDeployment(t *testing.T) {
 		require.True(t, found, "containers not found")
 		require.NotEmpty(t, containers)
 
-		container := containers[0].(map[string]any)
-		secCtx := container["securityContext"].(map[string]any)
+		container, ok := containers[0].(map[string]any)
+		require.True(t, ok, "container should be a map")
+		secCtx, ok := container["securityContext"].(map[string]any)
+		require.True(t, ok, "securityContext should be a map")
 		assert.Equal(t, false, secCtx["allowPrivilegeEscalation"])
 		assert.Equal(t, true, secCtx["readOnlyRootFilesystem"])
 
-		caps := secCtx["capabilities"].(map[string]any)
-		drop := caps["drop"].([]any)
+		caps, ok := secCtx["capabilities"].(map[string]any)
+		require.True(t, ok, "capabilities should be a map")
+		drop, ok := caps["drop"].([]any)
+		require.True(t, ok, "drop should be a slice")
 		assert.Contains(t, drop, "ALL")
 	})
 
@@ -194,26 +198,35 @@ func TestDevicePairingDeployment(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, containers)
 
-		container := containers[0].(map[string]any)
-		envVars, _ := container["env"].([]any)
+		container, ok := containers[0].(map[string]any)
+		require.True(t, ok, "container should be a map")
+		envVars, ok := container["env"].([]any)
+		require.True(t, ok, "env should be a slice")
 		require.NotEmpty(t, envVars, "container should have env vars")
 
 		envMap := map[string]any{}
 		for _, e := range envVars {
-			env := e.(map[string]any)
-			envMap[env["name"].(string)] = env
+			env, ok := e.(map[string]any)
+			require.True(t, ok, "env entry should be a map")
+			name, ok := env["name"].(string)
+			require.True(t, ok, "env name should be a string")
+			envMap[name] = env
 		}
 
 		nsEnv, ok := envMap["NAMESPACE"]
 		require.True(t, ok, "NAMESPACE env var should exist")
-		nsEnvMap := nsEnv.(map[string]any)
-		valueFrom := nsEnvMap["valueFrom"].(map[string]any)
-		fieldRef := valueFrom["fieldRef"].(map[string]any)
+		nsEnvMap, ok := nsEnv.(map[string]any)
+		require.True(t, ok, "NAMESPACE env should be a map")
+		valueFrom, ok := nsEnvMap["valueFrom"].(map[string]any)
+		require.True(t, ok, "valueFrom should be a map")
+		fieldRef, ok := valueFrom["fieldRef"].(map[string]any)
+		require.True(t, ok, "fieldRef should be a map")
 		assert.Equal(t, "metadata.namespace", fieldRef["fieldPath"])
 
 		clawEnv, ok := envMap["CLAW_INSTANCE"]
 		require.True(t, ok, "CLAW_INSTANCE env var should exist")
-		clawEnvMap := clawEnv.(map[string]any)
+		clawEnvMap, ok := clawEnv.(map[string]any)
+		require.True(t, ok, "CLAW_INSTANCE env should be a map")
 		assert.Equal(t, testInstanceName, clawEnvMap["value"], "CLAW_INSTANCE should be the instance name after template replacement")
 	})
 

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -87,7 +87,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 		path, found, err := unstructured.NestedString(dpRoute.Object, "spec", "path")
 		require.NoError(t, err)
 		assert.True(t, found, ".spec.path should be set")
-		assert.Equal(t, "/integration/device-pairing", path)
+		assert.Equal(t, "/integration/device-pairing/", path)
 	})
 
 	t.Run("device-pairing Route host injection sets spec.host", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 		}
 
 		objects := []*unstructured.Unstructured{dpRoute}
-		injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName)
+		require.NoError(t, injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName))
 
 		host, found, err := unstructured.NestedString(dpRoute.Object, "spec", "host")
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 		assert.Equal(t, "claw.example.com", host, "should strip https:// prefix and set bare hostname")
 	})
 
-	t.Run("device-pairing Route host injection is no-op when route not found", func(t *testing.T) {
+	t.Run("device-pairing Route host injection errors when route not found", func(t *testing.T) {
 		otherRoute := &unstructured.Unstructured{}
 		otherRoute.SetKind(RouteKind)
 		otherRoute.SetName("other-route")
@@ -116,7 +116,9 @@ func TestDevicePairingDeployment(t *testing.T) {
 		}
 
 		objects := []*unstructured.Unstructured{otherRoute}
-		injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName)
+		err := injectRouteHostIntoDevicePairingRoute(objects, "https://claw.example.com", testInstanceName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in rendered manifests")
 
 		_, found, _ := unstructured.NestedString(otherRoute.Object, "spec", "host")
 		assert.False(t, found, "should not set host on other routes")

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -467,7 +467,9 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 
 		// Inject Claw Route host into device-pairing Route and apply it
-		injectRouteHostIntoDevicePairingRoute(objects, routeHost, instance.Name)
+		if err := injectRouteHostIntoDevicePairingRoute(objects, routeHost, instance.Name); err != nil {
+			return ctrl.Result{}, err
+		}
 		if _, err := r.applyRouteByName(ctx, objects, instance, getDevicePairingRouteName(instance.Name)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to apply device-pairing Route: %w", err)
 		}
@@ -805,7 +807,8 @@ func (r *ClawResourceReconciler) applyResources(ctx context.Context, objects []*
 }
 
 // applyRouteByName applies only the Route with the given name from provided objects.
-// Returns number of routes applied (0 if CRD not registered or route not found).
+// Returns number of routes applied (0 if CRD not registered).
+// Returns an error if objects is non-empty but the named Route is not found.
 func (r *ClawResourceReconciler) applyRouteByName(ctx context.Context, objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw, routeName string) (int, error) {
 	if len(objects) == 0 {
 		return 0, nil
@@ -816,6 +819,10 @@ func (r *ClawResourceReconciler) applyRouteByName(ctx context.Context, objects [
 		if obj.GetKind() == RouteKind && obj.GetName() == routeName {
 			routeObjects = append(routeObjects, obj)
 		}
+	}
+
+	if len(routeObjects) == 0 {
+		return 0, fmt.Errorf("expected Route %q missing in rendered manifests", routeName)
 	}
 
 	for _, obj := range routeObjects {
@@ -838,15 +845,19 @@ func isClusterScoped(obj *unstructured.Unstructured) bool {
 
 // injectRouteHostIntoDevicePairingRoute replaces the OPENCLAW_ROUTE_HOST placeholder
 // in the device-pairing Route's .spec.host with the resolved Claw Route host.
-func injectRouteHostIntoDevicePairingRoute(objects []*unstructured.Unstructured, routeHost, instanceName string) {
+// Returns an error if the device-pairing Route is not found in the objects.
+func injectRouteHostIntoDevicePairingRoute(objects []*unstructured.Unstructured, routeHost, instanceName string) error {
 	routeName := getDevicePairingRouteName(instanceName)
 	host := strings.TrimPrefix(routeHost, "https://")
 	for _, obj := range objects {
 		if obj.GetKind() == RouteKind && obj.GetName() == routeName {
-			_ = unstructured.SetNestedField(obj.Object, host, "spec", "host")
-			return
+			if err := unstructured.SetNestedField(obj.Object, host, "spec", "host"); err != nil {
+				return fmt.Errorf("failed to set host on device-pairing Route %q: %w", routeName, err)
+			}
+			return nil
 		}
 	}
+	return fmt.Errorf("device-pairing Route %q not found in rendered manifests", routeName)
 }
 
 // injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator.json with actual Route host.

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -477,40 +477,8 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Phase 3: Inject Route host into ConfigMap and apply remaining resources
-
-	// Inject Route host into ConfigMap
-	if err := r.injectRouteHostIntoConfigMap(objects, routeHost, instance.Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject Route host into ConfigMap: %w", err)
-	}
-
-	// Inject LLM providers into ConfigMap based on credentials with Provider set
-	if err := injectProvidersIntoConfigMap(objects, instance); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject providers into ConfigMap: %w", err)
-	}
-
-	// Inject model catalog into ConfigMap based on credentials with Provider set
-	if err := injectModelCatalogIntoConfigMap(objects, instance); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject model catalog into ConfigMap: %w", err)
-	}
-
-	// Inject channel config into ConfigMap for credentials with Channel set
-	if err := injectChannelsIntoConfigMap(objects, instance); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject channels into ConfigMap: %w", err)
-	}
-
-	// Inject Kubernetes skill into ConfigMap for OpenClaw skill auto-discovery
-	if err := injectKubernetesSkill(objects, resolvedCreds, instance.Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes skill: %w", err)
-	}
-
-	// Inject non-443 ports from kubernetes credentials into proxy egress NetworkPolicy
-	if err := injectKubePortsIntoNetworkPolicy(objects, resolvedCreds, instance.Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to inject Kubernetes ports into NetworkPolicy: %w", err)
-	}
-
-	// Stamp gateway config hash to trigger rollout when ConfigMap content changes
-	if err := stampGatewayConfigHash(objects, instance.Name); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to stamp gateway config hash: %w", err)
+	if err := r.enrichConfigAndNetworkPolicy(objects, routeHost, instance, resolvedCreds); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Filter out Route (applied in phase above) and proxy ConfigMap (controller-managed)
@@ -605,6 +573,38 @@ func (r *ClawResourceReconciler) resolveAndApplyCredentials(ctx context.Context,
 	}
 
 	return resolvedCreds, nil
+}
+
+// enrichConfigAndNetworkPolicy injects route host, providers, models, channels, and
+// Kubernetes skill into the gateway ConfigMap and updates the egress NetworkPolicy.
+func (r *ClawResourceReconciler) enrichConfigAndNetworkPolicy(
+	objects []*unstructured.Unstructured,
+	routeHost string,
+	instance *clawv1alpha1.Claw,
+	resolvedCreds []resolvedCredential,
+) error {
+	if err := r.injectRouteHostIntoConfigMap(objects, routeHost, instance.Name); err != nil {
+		return fmt.Errorf("failed to inject Route host into ConfigMap: %w", err)
+	}
+	if err := injectProvidersIntoConfigMap(objects, instance); err != nil {
+		return fmt.Errorf("failed to inject providers into ConfigMap: %w", err)
+	}
+	if err := injectModelCatalogIntoConfigMap(objects, instance); err != nil {
+		return fmt.Errorf("failed to inject model catalog into ConfigMap: %w", err)
+	}
+	if err := injectChannelsIntoConfigMap(objects, instance); err != nil {
+		return fmt.Errorf("failed to inject channels into ConfigMap: %w", err)
+	}
+	if err := injectKubernetesSkill(objects, resolvedCreds, instance.Name); err != nil {
+		return fmt.Errorf("failed to inject Kubernetes skill: %w", err)
+	}
+	if err := injectKubePortsIntoNetworkPolicy(objects, resolvedCreds, instance.Name); err != nil {
+		return fmt.Errorf("failed to inject Kubernetes ports into NetworkPolicy: %w", err)
+	}
+	if err := stampGatewayConfigHash(objects, instance.Name); err != nil {
+		return fmt.Errorf("failed to stamp gateway config hash: %w", err)
+	}
+	return nil
 }
 
 // configureDeployments applies deployment overrides (proxy image, pull policy, credentials)

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -71,6 +71,7 @@ const (
 	NetworkPolicyKind         = "NetworkPolicy"
 	ServiceKind               = "Service"
 	PersistentVolumeClaimKind = "PersistentVolumeClaim"
+	ClusterRoleKind           = "ClusterRole"
 )
 
 // sanitizeLabelValue ensures a value conforms to Kubernetes label constraints (max 63 chars,
@@ -351,6 +352,18 @@ func getProxyConfigMapName(instanceName string) string {
 	return instanceName + "-proxy-config"
 }
 
+func getDevicePairingDeploymentName(instanceName string) string {
+	return instanceName + "-device-pairing"
+}
+
+func getDevicePairingServiceName(instanceName string) string {
+	return instanceName + "-device-pairing"
+}
+
+func getDevicePairingServiceAccountName(instanceName string) string {
+	return instanceName + "-device-pairing"
+}
+
 // ClawResourceReconciler reconciles all resources for Claw
 type ClawResourceReconciler struct {
 	client.Client
@@ -368,8 +381,12 @@ type ClawResourceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch
 
 // Reconcile manages the complete lifecycle of resources for Claw instances
 func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -428,16 +445,17 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to stamp secret version annotations: %w", err)
 	}
 
-	// Apply Route and wait for ingress host to be populated
+	// Apply Claw Route and wait for ingress host to be populated
 	var routeHost string
-	var routeApplied int
-	routeApplied, err = r.applyRouteOnly(ctx, objects, instance)
+	var clawRouteApplied int
+	clawRouteName := getRouteName(instance.Name)
+	clawRouteApplied, err = r.applyRouteByName(ctx, objects, instance, clawRouteName)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to apply Route: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to apply Claw Route: %w", err)
 	}
 
 	// Only try to fetch Route URL if Route was actually applied (CRD available)
-	if routeApplied > 0 {
+	if clawRouteApplied > 0 {
 		routeHost, err = r.getRouteURL(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Route URL: %w", err)
@@ -446,6 +464,12 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Route exists but status not yet populated - requeue
 			logger.Info("Route exists but status not populated, requeuing")
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
+		}
+
+		// Inject Claw Route host into device-pairing Route and apply it
+		injectRouteHostIntoDevicePairingRoute(objects, routeHost, instance.Name)
+		if _, err := r.applyRouteByName(ctx, objects, instance, getDevicePairingRouteName(instance.Name)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply device-pairing Route: %w", err)
 		}
 	} else {
 		// Route CRD not registered - proceed with localhost fallback
@@ -491,8 +515,11 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		remainingObjects = append(remainingObjects, obj)
 	}
 
-	// Set namespace and owner references
+	// Set namespace and owner references (skip cluster-scoped resources)
 	for _, obj := range remainingObjects {
+		if isClusterScoped(obj) {
+			continue
+		}
 		obj.SetNamespace(instance.Namespace)
 		if err := controllerutil.SetControllerReference(instance, obj, r.Scheme); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set controller reference: %w", err)
@@ -673,10 +700,22 @@ func (r *ClawResourceReconciler) buildKustomizedObjects(instance *clawv1alpha1.C
 		"manifests/claw-proxy/network-policies.yaml": readEmbeddedFile("manifests/claw-proxy/network-policies.yaml"),
 	}
 
+	// Device pairing component manifests
+	devicePairingManifests := map[string][]byte{
+		"manifests/claw-device-pairing/kustomization.yaml":  readEmbeddedFile("manifests/claw-device-pairing/kustomization.yaml"),
+		"manifests/claw-device-pairing/serviceaccount.yaml": readEmbeddedFile("manifests/claw-device-pairing/serviceaccount.yaml"),
+		"manifests/claw-device-pairing/clusterrole.yaml":    readEmbeddedFile("manifests/claw-device-pairing/clusterrole.yaml"),
+		"manifests/claw-device-pairing/rolebinding.yaml":    readEmbeddedFile("manifests/claw-device-pairing/rolebinding.yaml"),
+		"manifests/claw-device-pairing/deployment.yaml":     readEmbeddedFile("manifests/claw-device-pairing/deployment.yaml"),
+		"manifests/claw-device-pairing/service.yaml":        readEmbeddedFile("manifests/claw-device-pairing/service.yaml"),
+		"manifests/claw-device-pairing/route.yaml":          readEmbeddedFile("manifests/claw-device-pairing/route.yaml"),
+	}
+
 	// Write all files to in-memory filesystem
-	allManifests := make(map[string][]byte, len(clawManifests)+len(proxyManifests))
+	allManifests := make(map[string][]byte, len(clawManifests)+len(proxyManifests)+len(devicePairingManifests))
 	maps.Copy(allManifests, clawManifests)
 	maps.Copy(allManifests, proxyManifests)
+	maps.Copy(allManifests, devicePairingManifests)
 
 	for path, content := range allManifests {
 		replaced := bytes.ReplaceAll(content, []byte("CLAW_INSTANCE_NAME"), []byte(instance.Name))
@@ -697,8 +736,15 @@ func (r *ClawResourceReconciler) buildKustomizedObjects(instance *clawv1alpha1.C
 		return nil, err
 	}
 
-	// Merge both object lists
+	// Build device pairing component
+	devicePairingObjects, err := r.buildKustomizeFromPath(fs, "manifests/claw-device-pairing")
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge all object lists
 	allObjects := append(clawObjects, proxyObjects...)
+	allObjects = append(allObjects, devicePairingObjects...)
 
 	// Inject instance labels into selectors for multi-instance discrimination
 	if err := injectInstanceLabels(allObjects, instance.Name); err != nil {
@@ -732,23 +778,20 @@ func (r *ClawResourceReconciler) applyResources(ctx context.Context, objects []*
 	return appliedCount, nil
 }
 
-// applyRouteOnly applies only the Route resource from provided objects
-// Returns number of routes applied (0 if CRD not registered)
-func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw) (int, error) {
-	// Handle empty objects safely (len() on nil slice returns 0)
+// applyRouteByName applies only the Route with the given name from provided objects.
+// Returns number of routes applied (0 if CRD not registered or route not found).
+func (r *ClawResourceReconciler) applyRouteByName(ctx context.Context, objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw, routeName string) (int, error) {
 	if len(objects) == 0 {
 		return 0, nil
 	}
 
-	// Filter for Route only
 	routeObjects := []*unstructured.Unstructured{}
 	for _, obj := range objects {
-		if obj.GetKind() == RouteKind {
+		if obj.GetKind() == RouteKind && obj.GetName() == routeName {
 			routeObjects = append(routeObjects, obj)
 		}
 	}
 
-	// Set namespace and owner references
 	for _, obj := range routeObjects {
 		obj.SetNamespace(instance.Namespace)
 		if err := controllerutil.SetControllerReference(instance, obj, r.Scheme); err != nil {
@@ -756,8 +799,28 @@ func (r *ClawResourceReconciler) applyRouteOnly(ctx context.Context, objects []*
 		}
 	}
 
-	// Apply Route and return count
 	return r.applyResources(ctx, routeObjects)
+}
+
+func getDevicePairingRouteName(instanceName string) string {
+	return instanceName + "-device-pairing"
+}
+
+func isClusterScoped(obj *unstructured.Unstructured) bool {
+	return obj.GetKind() == ClusterRoleKind
+}
+
+// injectRouteHostIntoDevicePairingRoute replaces the OPENCLAW_ROUTE_HOST placeholder
+// in the device-pairing Route's .spec.host with the resolved Claw Route host.
+func injectRouteHostIntoDevicePairingRoute(objects []*unstructured.Unstructured, routeHost, instanceName string) {
+	routeName := getDevicePairingRouteName(instanceName)
+	host := strings.TrimPrefix(routeHost, "https://")
+	for _, obj := range objects {
+		if obj.GetKind() == RouteKind && obj.GetName() == routeName {
+			_ = unstructured.SetNestedField(obj.Object, host, "spec", "host")
+			return
+		}
+	}
 }
 
 // injectRouteHostIntoConfigMap replaces OPENCLAW_ROUTE_HOST placeholder in operator.json with actual Route host.

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -58,27 +58,23 @@ func (r *ClawResourceReconciler) getDeploymentAvailableStatus(ctx context.Contex
 	return false, nil
 }
 
-// checkDeploymentsReady checks if both claw and claw-proxy Deployments are ready
+// checkDeploymentsReady checks if all managed Deployments (claw, claw-proxy, claw-device-pairing) are ready
 func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, namespace, instanceName string) (bool, []string, error) {
-	clawDeployName := getClawDeploymentName(instanceName)
-	proxyDeployName := getProxyDeploymentName(instanceName)
-
-	clawReady, err := r.getDeploymentAvailableStatus(ctx, namespace, clawDeployName)
-	if err != nil {
-		return false, nil, err
-	}
-
-	proxyReady, err := r.getDeploymentAvailableStatus(ctx, namespace, proxyDeployName)
-	if err != nil {
-		return false, nil, err
+	deployNames := []string{
+		getClawDeploymentName(instanceName),
+		getProxyDeploymentName(instanceName),
+		getDevicePairingDeploymentName(instanceName),
 	}
 
 	var pending []string
-	if !clawReady {
-		pending = append(pending, clawDeployName)
-	}
-	if !proxyReady {
-		pending = append(pending, proxyDeployName)
+	for _, name := range deployNames {
+		ready, err := r.getDeploymentAvailableStatus(ctx, namespace, name)
+		if err != nil {
+			return false, nil, err
+		}
+		if !ready {
+			pending = append(pending, name)
+		}
 	}
 
 	return len(pending) == 0, pending, nil
@@ -231,6 +227,17 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 
 	// Set Ready condition
 	setReadyCondition(instance, ready, pending)
+
+	// Set DevicePairingConfigured condition based on device-pairing deployment availability
+	dpReady, err := r.getDeploymentAvailableStatus(ctx, instance.Namespace, getDevicePairingDeploymentName(instance.Name))
+	if err != nil {
+		return fmt.Errorf("failed to check device-pairing deployment readiness: %w", err)
+	}
+	if dpReady {
+		setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionTrue, clawv1alpha1.ConditionReasonConfigured, "Device pairing deployment is available")
+	} else {
+		setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonProvisioning, "Waiting for device pairing deployment to become ready")
+	}
 
 	// Expose gateway secret name in status
 	instance.Status.GatewayTokenSecretRef = getGatewaySecretName(instance.Name)

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -228,11 +229,8 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 	// Set Ready condition
 	setReadyCondition(instance, ready, pending)
 
-	// Set DevicePairingConfigured condition based on device-pairing deployment availability
-	dpReady, err := r.getDeploymentAvailableStatus(ctx, instance.Namespace, getDevicePairingDeploymentName(instance.Name))
-	if err != nil {
-		return fmt.Errorf("failed to check device-pairing deployment readiness: %w", err)
-	}
+	// Set DevicePairingConfigured condition — derived from the pending list above to avoid a duplicate API call
+	dpReady := !slices.Contains(pending, getDevicePairingDeploymentName(instance.Name))
 	if dpReady {
 		setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionTrue, clawv1alpha1.ConditionReasonConfigured, "Device pairing deployment is available")
 	} else {

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -229,7 +229,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			assert.Equal(t, clawv1alpha1.ConditionReasonProvisioning, condition.Reason, "Ready condition reason")
 		})
 
-		t.Run("should set Ready condition to True when both Deployments are ready", func(t *testing.T) {
+		t.Run("should set Ready condition to True when all Deployments are ready", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)
 			})
@@ -256,33 +256,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			})
 			require.NoError(t, err, "reconcile failed")
 
-			deployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-				return err == nil
-			}, "claw Deployment should be created")
-
-			deployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update deployment status")
-
-			proxyDeployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-				return err == nil
-			}, "claw-proxy Deployment should be created")
-
-			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update proxy deployment status")
+			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
@@ -298,6 +272,64 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			require.NotNil(t, condition, "Ready condition should not be nil")
 			assert.Equal(t, metav1.ConditionTrue, condition.Status, "Ready condition status")
 			assert.Equal(t, clawv1alpha1.ConditionReasonReady, condition.Reason, "Ready condition reason")
+		})
+
+		t.Run("should set DevicePairingConfigured to False after initial reconcile", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeDevicePairingConfigured)
+			require.NotNil(t, condition, "DevicePairingConfigured condition should exist")
+			assert.Equal(t, metav1.ConditionFalse, condition.Status)
+			assert.Equal(t, clawv1alpha1.ConditionReasonProvisioning, condition.Reason)
+		})
+
+		t.Run("should set DevicePairingConfigured to True when device-pairing Deployment is available", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			setDeploymentAvailable(t, ctx, getDevicePairingDeploymentName(testInstanceName), namespace)
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeDevicePairingConfigured)
+			require.NotNil(t, condition, "DevicePairingConfigured condition should exist")
+			assert.Equal(t, metav1.ConditionTrue, condition.Status)
+			assert.Equal(t, clawv1alpha1.ConditionReasonConfigured, condition.Reason)
+		})
+
+		t.Run("should keep Ready False when claw and proxy are ready but device-pairing is not", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			setDeploymentAvailable(t, ctx, getClawDeploymentName(testInstanceName), namespace)
+			setDeploymentAvailable(t, ctx, getProxyDeploymentName(testInstanceName), namespace)
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+			require.NotNil(t, condition)
+			assert.Equal(t, metav1.ConditionFalse, condition.Status, "Ready should be False when device-pairing is not ready")
+			assert.Equal(t, clawv1alpha1.ConditionReasonProvisioning, condition.Reason)
 		})
 
 		t.Run("should update LastTransitionTime only on status change", func(t *testing.T) {
@@ -342,33 +374,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				return false
 			}, "initial Ready condition should be set")
 
-			deployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-				return err == nil
-			}, "claw Deployment should be created")
-
-			deployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update deployment status")
-
-			proxyDeployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-				return err == nil
-			}, "claw-proxy Deployment should be created")
-
-			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update proxy deployment status")
+			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
@@ -701,33 +707,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				})
 				require.NoError(t, err, "reconcile failed")
 
-				deployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-					return err == nil
-				}, "claw Deployment should be created")
-
-				deployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update deployment status")
-
-				proxyDeployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-					return err == nil
-				}, "claw-proxy Deployment should be created")
-
-				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update proxy deployment status")
+				setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -737,6 +717,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				})
 				require.NoError(t, err, "reconcile failed")
 
+				deployment := &appsv1.Deployment{}
 				waitFor(t, timeout, interval, func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
 					if err != nil {
@@ -792,33 +773,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				})
 				require.NoError(t, err, "reconcile failed")
 
-				deployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-					return err == nil
-				}, "claw Deployment should be created")
-
-				deployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update deployment status")
-
-				proxyDeployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-					return err == nil
-				}, "claw-proxy Deployment should be created")
-
-				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update proxy deployment status")
+				setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -971,33 +926,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 					return found && host == routeHost
 				}, "Route status should have ingress host")
 
-				deployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-					return err == nil
-				}, "claw Deployment should be created")
-
-				deployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update deployment status")
-
-				proxyDeployment := &appsv1.Deployment{}
-				waitFor(t, timeout, interval, func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-					return err == nil
-				}, "claw-proxy Deployment should be created")
-
-				proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}
-				require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update proxy deployment status")
+				setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -1122,33 +1051,7 @@ func TestOpenClawURLStatusField(t *testing.T) {
 			})
 			require.NoError(t, err, "reconcile failed")
 
-			deployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getClawDeploymentName(testInstanceName), Namespace: namespace}, deployment)
-				return err == nil
-			}, "claw deployment to be created")
-
-			deployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update claw deployment status")
-
-			proxyDeployment := &appsv1.Deployment{}
-			waitFor(t, timeout, interval, func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: getProxyDeploymentName(testInstanceName), Namespace: namespace}, proxyDeployment)
-				return err == nil
-			}, "claw-proxy deployment to be created")
-
-			proxyDeployment.Status.Conditions = []appsv1.DeploymentCondition{
-				{
-					Type:   appsv1.DeploymentAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			}
-			require.NoError(t, k8sClient.Status().Update(ctx, proxyDeployment), "failed to update claw-proxy deployment status")
+			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -147,6 +147,9 @@ func deleteAndWaitAllResources(t *testing.T, namespace string, instanceNames ...
 		{&appsv1.Deployment{}, client.ObjectKey{Name: getClawDeploymentName(instanceName), Namespace: namespace}},
 		{&corev1.Service{}, client.ObjectKey{Name: getProxyServiceName(instanceName), Namespace: namespace}},
 		{&appsv1.Deployment{}, client.ObjectKey{Name: getProxyDeploymentName(instanceName), Namespace: namespace}},
+		{&corev1.ServiceAccount{}, client.ObjectKey{Name: getDevicePairingServiceAccountName(instanceName), Namespace: namespace}},
+		{&corev1.Service{}, client.ObjectKey{Name: getDevicePairingServiceName(instanceName), Namespace: namespace}},
+		{&appsv1.Deployment{}, client.ObjectKey{Name: getDevicePairingDeploymentName(instanceName), Namespace: namespace}},
 	}
 
 	for _, r := range resources {
@@ -341,6 +344,31 @@ func createClawReconciler() *ClawResourceReconciler {
 		Client: k8sClient,
 		Scheme: scheme.Scheme,
 	}
+}
+
+// setDeploymentAvailable marks a Deployment as Available=True in its status.
+func setDeploymentAvailable(t *testing.T, ctx context.Context, name, namespace string) {
+	t.Helper()
+	deployment := &appsv1.Deployment{}
+	waitFor(t, timeout, interval, func() bool {
+		return k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment) == nil
+	}, name+" Deployment should be created")
+
+	deployment.Status.Conditions = []appsv1.DeploymentCondition{
+		{
+			Type:   appsv1.DeploymentAvailable,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	require.NoError(t, k8sClient.Status().Update(ctx, deployment), "failed to update "+name+" deployment status")
+}
+
+// setAllDeploymentsAvailable marks claw, claw-proxy, and claw-device-pairing Deployments as available.
+func setAllDeploymentsAvailable(t *testing.T, ctx context.Context, instanceName, namespace string) { //nolint:unparam
+	t.Helper()
+	setDeploymentAvailable(t, ctx, getClawDeploymentName(instanceName), namespace)
+	setDeploymentAvailable(t, ctx, getProxyDeploymentName(instanceName), namespace)
+	setDeploymentAvailable(t, ctx, getDevicePairingDeploymentName(instanceName), namespace)
 }
 
 // reconcileClaw performs a reconciliation for the given Claw resource.

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/design.md
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The operator currently deploys two component groups via embedded Kustomize manifests: `claw` (gateway) and `claw-proxy`. Each group lives in its own subdirectory under `internal/assets/manifests/` with a `kustomization.yaml` and resource YAMLs. The controller's `buildKustomizedObjects()` loads both groups, performs `CLAW_INSTANCE_NAME` template replacement, builds each via Kustomize, and merges the resulting objects. Routes are applied in Phase 2 (`applyRouteOnly`), and all remaining resources in Phase 3.
+
+A new device pairing web application (`claw-device-pairing`) needs to be deployed alongside these existing components, sharing the same Route host but serving traffic on a `/integration/device-pairing` path prefix.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy the `claw-device-pairing` application as an operator-managed component with ServiceAccount, Deployment, Service, and Route
+- Follow the existing manifest embedding and Kustomize build patterns exactly
+- Share the Claw Route host using path-based routing at `/integration/device-pairing`
+- Apply device-pairing resources in the same reconciliation cycle, after claw and claw-proxy
+
+**Non-Goals:**
+- Adding new CRD fields to configure the device-pairing application (image is hardcoded in the manifest)
+- Health checks or readiness dependencies between claw-device-pairing and the gateway/proxy
+- Network policies for the device-pairing component (can be added later if needed)
+- Exposing the device-pairing service on vanilla Kubernetes (Route is OpenShift-only; same graceful skip as the claw Route)
+
+## Decisions
+
+### 1. Manifest structure: separate Kustomize directory
+
+The device-pairing manifests live in `internal/assets/manifests/claw-device-pairing/` with their own `kustomization.yaml`, following the same pattern as `claw/` and `claw-proxy/`. This keeps each component self-contained.
+
+**Alternative considered**: Adding the resources to the existing `claw/` kustomization. Rejected because it conflates concerns and makes it harder to reason about or remove the device-pairing component independently.
+
+### 2. Route host sharing via path-based routing
+
+The device-pairing Route sets `.spec.host` to match the Claw Route host (obtained from `getRouteURL()`) and uses `.spec.path: /integration/device-pairing`. OpenShift HAProxy router supports path-based routing natively with longest-prefix matching.
+
+The Route host is injected into the device-pairing Route manifest the same way it's injected into the ConfigMap: by replacing a `OPENCLAW_ROUTE_HOST` placeholder in the Route's `.spec.host` field after the Claw Route status is resolved. Since all Route objects are already filtered and applied together in `applyRouteOnly()`, the device-pairing Route is naturally included.
+
+However, the host injection needs a new step: `injectRouteHostIntoDevicePairingRoute()` that replaces the placeholder in the device-pairing Route's `.spec.host` field. This runs after `getRouteURL()` resolves the host, alongside the existing `injectRouteHostIntoConfigMap()`.
+
+### 3. Resource naming and labeling
+
+All resources use `CLAW_INSTANCE_NAME-device-pairing` as their name in the YAML templates. The existing `CLAW_INSTANCE_NAME` replacement in `buildKustomizedObjects()` handles this automatically since it does a global `bytes.ReplaceAll` on the manifest content.
+
+The `kustomization.yaml` applies `app.kubernetes.io/name: claw-device-pairing` to all resources via the Kustomize `labels` directive. This follows the same label key as the existing `claw` and `claw-proxy` groups (`app.kubernetes.io/name`) but with a distinct value (`claw-device-pairing`) for independent selection by Services and selectors.
+
+### 4. ServiceAccount inclusion
+
+A dedicated ServiceAccount (`CLAW_INSTANCE_NAME-device-pairing`) is created for the device-pairing Deployment. This follows security best practices — the device-pairing pod runs with its own identity rather than the default ServiceAccount, enabling future RBAC scoping.
+
+### 5. Deployment in Phase 3 (alongside remaining resources)
+
+The device-pairing resources (ServiceAccount, Deployment, Service) are applied in Phase 3 alongside other non-Route resources. The device-pairing Route is applied in Phase 2 alongside the Claw Route via `applyRouteOnly()`, which already filters all Route-kind objects. This means no changes to the phase structure — the existing three-phase reconciliation handles the new component naturally.
+
+## Risks / Trade-offs
+
+- **[Risk] Route host not available on vanilla Kubernetes** → Same graceful skip as the Claw Route. The device-pairing Route is silently skipped when the Route CRD is not registered. The Service remains accessible via port-forward.
+- **[Risk] Path-based routing conflicts** → The `/integration/device-pairing` path prefix is specific enough to avoid conflicts with the gateway's paths. OpenShift uses longest-prefix matching.
+- **[Trade-off] Hardcoded image in manifest** → The `quay.io/xcoulon/claw-device-pairing:latest` image is embedded in the manifest. To make it configurable, a future change could add a `DevicePairingImage` field to the controller (like `ProxyImage`) with env var override. Not needed now.
+- **[Risk] Route host placeholder injection timing** → The device-pairing Route needs the Claw Route host, which is only available after Phase 2. Since the device-pairing Route is also applied in Phase 2 via `applyRouteOnly()`, the host injection must happen between applying the Claw Route and applying the device-pairing Route — or both Routes can be applied with the placeholder replaced beforehand. The chosen approach replaces the placeholder in all Route objects before `applyRouteOnly()` runs, which simplifies the flow.

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/proposal.md
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The device pairing flow requires a dedicated web application (`claw-device-pairing`) to serve the pairing UI. Currently, the operator deploys the gateway and proxy components but has no mechanism to deploy the device pairing service alongside them. Adding this as an operator-managed component ensures it shares the same lifecycle, Route host, and namespace as the Claw instance.
+
+## What Changes
+
+- Add a new `claw-device-pairing` Kustomize manifest folder under `internal/assets/manifests/` containing a ServiceAccount, Deployment, Service, and Route
+- Extend `buildKustomizedObjects()` to load and build the device-pairing manifests alongside the existing claw and claw-proxy components
+- The device-pairing Route shares the same `.spec.host` as the Claw Route but serves traffic on the `/integration/device-pairing` path prefix
+- All resource names follow the `CLAW_INSTANCE_NAME-device-pairing` naming convention (template-replaced at build time, same as existing components)
+- The device-pairing resources are applied after the Claw and Claw Proxy resources (Phase 3, alongside remaining resources)
+
+## Capabilities
+
+### New Capabilities
+- `device-pairing-deployment`: Operator-managed deployment of the claw-device-pairing web application (ServiceAccount, Deployment, Service, Route) using embedded Kustomize manifests, sharing the Claw Route host with path-based routing
+
+### Modified Capabilities
+- `claw-controller`: The `buildKustomizedObjects()` function is extended to load the new device-pairing manifests, and `applyRouteOnly()` now applies the device-pairing Route alongside the Claw Route
+
+## Impact
+
+- **Code**: `internal/controller/claw_resource_controller.go` — `buildKustomizedObjects()` gains a third manifest group; Route filtering in `applyRouteOnly()` already handles all Route-kind objects so the device-pairing Route is automatically included
+- **Embedded assets**: New `internal/assets/manifests/claw-device-pairing/` directory with 5 files (kustomization.yaml + 4 resource YAMLs)
+- **RBAC**: ServiceAccount resource creation requires existing RBAC permissions (the operator already has broad resource management permissions via server-side apply)
+- **Networking**: The device-pairing Route uses path-based routing on the existing Claw Route host, so no additional DNS or TLS configuration is needed

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/specs/claw-controller/spec.md
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/specs/claw-controller/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Controller builds kustomized objects from embedded manifests
+The system SHALL build kustomized objects from three embedded manifest directories: `claw`, `claw-proxy`, and `claw-device-pairing`. The `buildKustomizedObjects()` function SHALL load all three groups, perform `CLAW_INSTANCE_NAME` template replacement, build each via Kustomize, and merge the resulting objects.
+
+#### Scenario: Device pairing manifests are loaded
+- **WHEN** `buildKustomizedObjects()` is called
+- **THEN** it SHALL load manifest files from `manifests/claw-device-pairing/` alongside `manifests/claw/` and `manifests/claw-proxy/`
+
+#### Scenario: CLAW_INSTANCE_NAME replacement applies to device-pairing manifests
+- **WHEN** the Claw CR is named "instance"
+- **THEN** all `CLAW_INSTANCE_NAME` occurrences in device-pairing manifests SHALL be replaced with "instance"
+
+#### Scenario: All three component groups are merged
+- **WHEN** `buildKustomizedObjects()` completes
+- **THEN** the returned objects SHALL include resources from all three directories: claw, claw-proxy, and claw-device-pairing
+
+### Requirement: Route host is injected into device-pairing Route
+The controller SHALL inject the resolved Claw Route host into the device-pairing Route's `.spec.host` field during reconciliation, using the same host obtained from `getRouteURL()`.
+
+#### Scenario: Device-pairing Route host injection
+- **WHEN** the Claw Route host is resolved to `claw.example.com`
+- **THEN** the controller SHALL replace `OPENCLAW_ROUTE_HOST` in the device-pairing Route's `.spec.host` with `claw.example.com`
+
+#### Scenario: Device-pairing Route applied in Phase 2
+- **WHEN** `applyRouteOnly()` filters for Route-kind objects
+- **THEN** both the Claw Route and device-pairing Route SHALL be included and applied
+
+### Requirement: Device-pairing resources applied in Phase 3
+The device-pairing non-Route resources (ServiceAccount, Deployment, Service) SHALL be applied in Phase 3 alongside other remaining resources, after the Route has been applied in Phase 2.
+
+#### Scenario: ServiceAccount applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing ServiceAccount SHALL be included in the apply batch
+
+#### Scenario: Deployment applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing Deployment SHALL be included in the apply batch
+
+#### Scenario: Service applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing Service SHALL be included in the apply batch

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/specs/device-pairing-deployment/spec.md
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/specs/device-pairing-deployment/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Device pairing manifests exist as embedded Kustomize directory
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route.
+
+#### Scenario: Kustomize directory structure
+- **WHEN** examining `internal/assets/manifests/claw-device-pairing/`
+- **THEN** it SHALL contain `kustomization.yaml`, `serviceaccount.yaml`, `deployment.yaml`, `service.yaml`, and `route.yaml`
+
+#### Scenario: Kustomization references all resources
+- **WHEN** examining `kustomization.yaml`
+- **THEN** it SHALL list all four resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+
+### Requirement: Device pairing resources use CLAW_INSTANCE_NAME naming
+All device-pairing resource names SHALL use the `CLAW_INSTANCE_NAME-device-pairing` template, which is replaced with the actual Claw CR name at build time by the existing `bytes.ReplaceAll` in `buildKustomizedObjects()`.
+
+#### Scenario: ServiceAccount name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the ServiceAccount SHALL be named `instance-device-pairing`
+
+#### Scenario: Deployment name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Deployment SHALL be named `instance-device-pairing`
+
+#### Scenario: Service name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Service SHALL be named `instance-device-pairing`
+
+#### Scenario: Route name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Route SHALL be named `instance-device-pairing`
+
+### Requirement: Device pairing Deployment uses correct image and security context
+The Deployment SHALL use the `quay.io/xcoulon/claw-device-pairing:latest` image with security hardening matching the operator's conventions.
+
+#### Scenario: Container image
+- **WHEN** examining the device-pairing Deployment
+- **THEN** its container image SHALL be `quay.io/xcoulon/claw-device-pairing:latest`
+
+#### Scenario: Security context
+- **WHEN** examining the device-pairing Deployment
+- **THEN** it SHALL run as non-root with `allowPrivilegeEscalation: false`, all capabilities dropped, `readOnlyRootFilesystem: true`, and `RuntimeDefault` seccomp profile
+
+#### Scenario: ServiceAccount reference
+- **WHEN** examining the device-pairing Deployment
+- **THEN** its `spec.template.spec.serviceAccountName` SHALL reference `CLAW_INSTANCE_NAME-device-pairing`
+
+### Requirement: Device pairing Service exposes the application
+The Service SHALL expose the device-pairing Deployment on a ClusterIP with an appropriate target port.
+
+#### Scenario: Service type and selector
+- **WHEN** examining the device-pairing Service
+- **THEN** it SHALL be of type ClusterIP and select pods with the `app.kubernetes.io/name: claw-device-pairing` label
+
+#### Scenario: Service port
+- **WHEN** examining the device-pairing Service
+- **THEN** it SHALL expose a named port targeting the device-pairing container port
+
+### Requirement: Device pairing Route uses path-based routing on the Claw host
+The Route SHALL share the same host as the Claw Route and serve traffic at the `/integration/device-pairing` path prefix.
+
+#### Scenario: Route host matches Claw Route
+- **WHEN** the Claw Route has host `claw.example.com`
+- **THEN** the device-pairing Route's `.spec.host` SHALL be `claw.example.com`
+
+#### Scenario: Route path prefix
+- **WHEN** examining the device-pairing Route
+- **THEN** its `.spec.path` SHALL be `/integration/device-pairing`
+
+#### Scenario: Route TLS configuration
+- **WHEN** examining the device-pairing Route
+- **THEN** it SHALL use edge TLS termination with redirect for insecure traffic, matching the Claw Route pattern
+
+#### Scenario: Route targets the device-pairing Service
+- **WHEN** examining the device-pairing Route `.spec.to`
+- **THEN** it SHALL reference the `CLAW_INSTANCE_NAME-device-pairing` Service
+
+#### Scenario: Route skipped on vanilla Kubernetes
+- **WHEN** the Route CRD is not registered in the cluster
+- **THEN** the device-pairing Route SHALL be silently skipped (same as the Claw Route)
+
+### Requirement: Device pairing Route host is injected from Claw Route status
+The controller SHALL inject the resolved Claw Route host into the device-pairing Route's `.spec.host` field, replacing the `OPENCLAW_ROUTE_HOST` placeholder.
+
+#### Scenario: Host placeholder replacement
+- **WHEN** the Claw Route status provides host `claw.example.com`
+- **THEN** the device-pairing Route's `.spec.host` placeholder SHALL be replaced with `claw.example.com`
+
+#### Scenario: No Route CRD available
+- **WHEN** the Route CRD is not registered (vanilla Kubernetes)
+- **THEN** the device-pairing Route SHALL be skipped entirely by the existing `applyResources` NoMatch handling

--- a/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/tasks.md
+++ b/openspec/changes/archive/2026-05-07-add-device-pairing-deployment/tasks.md
@@ -1,0 +1,22 @@
+## 1. Kustomize Manifests
+
+- [x] 1.1 Create `internal/assets/manifests/claw-device-pairing/kustomization.yaml` with resource list and `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+- [x] 1.2 Create `internal/assets/manifests/claw-device-pairing/serviceaccount.yaml` with name `CLAW_INSTANCE_NAME-device-pairing`
+- [x] 1.3 Create `internal/assets/manifests/claw-device-pairing/deployment.yaml` with image `quay.io/xcoulon/claw-device-pairing:latest`, security hardening (non-root, drop all caps, readOnlyRootFilesystem, RuntimeDefault seccomp), and serviceAccountName `CLAW_INSTANCE_NAME-device-pairing`
+- [x] 1.4 Create `internal/assets/manifests/claw-device-pairing/service.yaml` as ClusterIP targeting the device-pairing pod port
+- [x] 1.5 Create `internal/assets/manifests/claw-device-pairing/route.yaml` with `OPENCLAW_ROUTE_HOST` as `.spec.host`, `.spec.path: /integration/device-pairing`, edge TLS termination, targeting `CLAW_INSTANCE_NAME-device-pairing` Service
+
+## 2. Controller Integration
+
+- [x] 2.1 Add device-pairing manifest entries to `buildKustomizedObjects()` — load files from `manifests/claw-device-pairing/`, write to in-memory filesystem, build via Kustomize, and merge with claw + proxy objects
+- [x] 2.2 Add `injectRouteHostIntoDevicePairingRoute()` function to replace `OPENCLAW_ROUTE_HOST` placeholder in the device-pairing Route's `.spec.host` with the resolved Claw Route host
+- [x] 2.3 Call `injectRouteHostIntoDevicePairingRoute()` in the `Reconcile()` function after `getRouteURL()` resolves the host, before `applyRouteOnly()`
+
+## 3. Tests
+
+- [x] 3.1 Add test verifying device-pairing manifests are included in `buildKustomizedObjects()` output (ServiceAccount, Deployment, Service, Route all present with correct names)
+- [x] 3.2 Add test verifying `CLAW_INSTANCE_NAME` replacement works for device-pairing resources
+- [x] 3.3 Add test verifying device-pairing Route host injection replaces `OPENCLAW_ROUTE_HOST` with the resolved host
+- [x] 3.4 Add test verifying device-pairing Route has correct path `/integration/device-pairing`
+- [x] 3.5 Add test verifying reconciliation applies device-pairing resources (ServiceAccount, Deployment, Service exist after reconcile)
+- [x] 3.6 Run `make test` and `make lint` to verify all tests pass and no lint issues

--- a/openspec/specs/claw-controller/spec.md
+++ b/openspec/specs/claw-controller/spec.md
@@ -1,5 +1,3 @@
-## ADDED Requirements
-
 ### Requirement: Claw controller exists
 The system SHALL provide a controller that reconciles Claw custom resources.
 
@@ -198,3 +196,44 @@ The system SHALL configure the ConfigMap watch to only trigger reconciliation fo
 #### Scenario: ConfigMap with different name is ignored
 - **WHEN** a ConfigMap with a name other than 'claw-config' is created or updated
 - **THEN** the controller's Reconcile function SHALL NOT be invoked
+
+### Requirement: Controller builds kustomized objects from embedded manifests
+The system SHALL build kustomized objects from three embedded manifest directories: `claw`, `claw-proxy`, and `claw-device-pairing`. The `buildKustomizedObjects()` function SHALL load all three groups, perform `CLAW_INSTANCE_NAME` template replacement, build each via Kustomize, and merge the resulting objects.
+
+#### Scenario: Device pairing manifests are loaded
+- **WHEN** `buildKustomizedObjects()` is called
+- **THEN** it SHALL load manifest files from `manifests/claw-device-pairing/` alongside `manifests/claw/` and `manifests/claw-proxy/`
+
+#### Scenario: CLAW_INSTANCE_NAME replacement applies to device-pairing manifests
+- **WHEN** the Claw CR is named "instance"
+- **THEN** all `CLAW_INSTANCE_NAME` occurrences in device-pairing manifests SHALL be replaced with "instance"
+
+#### Scenario: All three component groups are merged
+- **WHEN** `buildKustomizedObjects()` completes
+- **THEN** the returned objects SHALL include resources from all three directories: claw, claw-proxy, and claw-device-pairing
+
+### Requirement: Route host is injected into device-pairing Route
+The controller SHALL inject the resolved Claw Route host into the device-pairing Route's `.spec.host` field during reconciliation, using the same host obtained from `getRouteURL()`.
+
+#### Scenario: Device-pairing Route host injection
+- **WHEN** the Claw Route host is resolved to `claw.example.com`
+- **THEN** the controller SHALL replace `OPENCLAW_ROUTE_HOST` in the device-pairing Route's `.spec.host` with `claw.example.com`
+
+#### Scenario: Device-pairing Route applied in Phase 2
+- **WHEN** `applyRouteOnly()` filters for Route-kind objects
+- **THEN** both the Claw Route and device-pairing Route SHALL be included and applied
+
+### Requirement: Device-pairing resources applied in Phase 3
+The device-pairing non-Route resources (ServiceAccount, Deployment, Service) SHALL be applied in Phase 3 alongside other remaining resources, after the Route has been applied in Phase 2.
+
+#### Scenario: ServiceAccount applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing ServiceAccount SHALL be included in the apply batch
+
+#### Scenario: Deployment applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing Deployment SHALL be included in the apply batch
+
+#### Scenario: Service applied with remaining resources
+- **WHEN** Phase 3 applies remaining resources
+- **THEN** the device-pairing Service SHALL be included in the apply batch

--- a/openspec/specs/device-pairing-deployment/spec.md
+++ b/openspec/specs/device-pairing-deployment/spec.md
@@ -1,0 +1,89 @@
+### Requirement: Device pairing manifests exist as embedded Kustomize directory
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route.
+
+#### Scenario: Kustomize directory structure
+- **WHEN** examining `internal/assets/manifests/claw-device-pairing/`
+- **THEN** it SHALL contain `kustomization.yaml`, `serviceaccount.yaml`, `deployment.yaml`, `service.yaml`, and `route.yaml`
+
+#### Scenario: Kustomization references all resources
+- **WHEN** examining `kustomization.yaml`
+- **THEN** it SHALL list all four resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+
+### Requirement: Device pairing resources use CLAW_INSTANCE_NAME naming
+All device-pairing resource names SHALL use the `CLAW_INSTANCE_NAME-device-pairing` template, which is replaced with the actual Claw CR name at build time by the existing `bytes.ReplaceAll` in `buildKustomizedObjects()`.
+
+#### Scenario: ServiceAccount name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the ServiceAccount SHALL be named `instance-device-pairing`
+
+#### Scenario: Deployment name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Deployment SHALL be named `instance-device-pairing`
+
+#### Scenario: Service name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Service SHALL be named `instance-device-pairing`
+
+#### Scenario: Route name
+- **WHEN** the Claw CR is named "instance"
+- **THEN** the Route SHALL be named `instance-device-pairing`
+
+### Requirement: Device pairing Deployment uses correct image and security context
+The Deployment SHALL use the `quay.io/xcoulon/claw-device-pairing:latest` image with security hardening matching the operator's conventions.
+
+#### Scenario: Container image
+- **WHEN** examining the device-pairing Deployment
+- **THEN** its container image SHALL be `quay.io/xcoulon/claw-device-pairing:latest`
+
+#### Scenario: Security context
+- **WHEN** examining the device-pairing Deployment
+- **THEN** it SHALL run as non-root with `allowPrivilegeEscalation: false`, all capabilities dropped, `readOnlyRootFilesystem: true`, and `RuntimeDefault` seccomp profile
+
+#### Scenario: ServiceAccount reference
+- **WHEN** examining the device-pairing Deployment
+- **THEN** its `spec.template.spec.serviceAccountName` SHALL reference `CLAW_INSTANCE_NAME-device-pairing`
+
+### Requirement: Device pairing Service exposes the application
+The Service SHALL expose the device-pairing Deployment on a ClusterIP with an appropriate target port.
+
+#### Scenario: Service type and selector
+- **WHEN** examining the device-pairing Service
+- **THEN** it SHALL be of type ClusterIP and select pods with the `app.kubernetes.io/name: claw-device-pairing` label
+
+#### Scenario: Service port
+- **WHEN** examining the device-pairing Service
+- **THEN** it SHALL expose a named port targeting the device-pairing container port
+
+### Requirement: Device pairing Route uses path-based routing on the Claw host
+The Route SHALL share the same host as the Claw Route and serve traffic at the `/integration/device-pairing` path prefix.
+
+#### Scenario: Route host matches Claw Route
+- **WHEN** the Claw Route has host `claw.example.com`
+- **THEN** the device-pairing Route's `.spec.host` SHALL be `claw.example.com`
+
+#### Scenario: Route path prefix
+- **WHEN** examining the device-pairing Route
+- **THEN** its `.spec.path` SHALL be `/integration/device-pairing`
+
+#### Scenario: Route TLS configuration
+- **WHEN** examining the device-pairing Route
+- **THEN** it SHALL use edge TLS termination with redirect for insecure traffic, matching the Claw Route pattern
+
+#### Scenario: Route targets the device-pairing Service
+- **WHEN** examining the device-pairing Route `.spec.to`
+- **THEN** it SHALL reference the `CLAW_INSTANCE_NAME-device-pairing` Service
+
+#### Scenario: Route skipped on vanilla Kubernetes
+- **WHEN** the Route CRD is not registered in the cluster
+- **THEN** the device-pairing Route SHALL be silently skipped (same as the Claw Route)
+
+### Requirement: Device pairing Route host is injected from Claw Route status
+The controller SHALL inject the resolved Claw Route host into the device-pairing Route's `.spec.host` field, replacing the `OPENCLAW_ROUTE_HOST` placeholder.
+
+#### Scenario: Host placeholder replacement
+- **WHEN** the Claw Route status provides host `claw.example.com`
+- **THEN** the device-pairing Route's `.spec.host` placeholder SHALL be replaced with `claw.example.com`
+
+#### Scenario: No Route CRD available
+- **WHEN** the Route CRD is not registered (vanilla Kubernetes)
+- **THEN** the device-pairing Route SHALL be skipped entirely by the existing `applyResources` NoMatch handling

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -59,6 +59,10 @@ const (
 	ingressNetPolName   = clawInstanceName + "-ingress"
 	pvcName             = clawInstanceName + "-home-pvc"
 	proxyServiceName    = clawInstanceName + "-proxy"
+
+	devicePairingDeploymentName = clawInstanceName + "-device-pairing"
+	devicePairingServiceName    = clawInstanceName + "-device-pairing"
+	devicePairingSAName         = clawInstanceName + "-device-pairing"
 )
 
 // clawYAMLWithGemini returns a Claw CR YAML using spec.credentials[] with apiKey type.
@@ -823,6 +827,123 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "failed to get gateway env")
 			assert.Equal(t, "1", logOutput,
 				"OPENCLAW_PROXY_ACTIVE should be set to 1")
+		})
+
+		t.Run("should deploy claw-device-pairing alongside Claw and proxy", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create Secret")
+
+			t.Log("applying the Claw CR")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				"config/samples/claw_v1alpha1_claw.yaml", "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw ProxyConfigured condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw ProxyConfigured did not become True within %v", defaultTimeout)
+
+			t.Log("verifying device-pairing ServiceAccount exists")
+			cmd = exec.Command("kubectl", "get", "serviceaccount", devicePairingSAName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "device-pairing ServiceAccount should exist")
+
+			t.Log("verifying device-pairing Deployment exists")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+						"-n", userNamespace)
+					_, err := utils.Run(t, cmd)
+					return err == nil, nil
+				})
+			require.NoError(t, err, "device-pairing Deployment should exist")
+
+			t.Log("verifying device-pairing Deployment uses the correct image")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-o", "jsonpath={.spec.template.spec.containers[0].image}",
+				"-n", userNamespace)
+			image, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "quay.io/xcoulon/claw-device-pairing:latest", image,
+				"device-pairing container should use the correct image")
+
+			t.Log("verifying device-pairing Deployment references its ServiceAccount")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-o", "jsonpath={.spec.template.spec.serviceAccountName}",
+				"-n", userNamespace)
+			sa, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, devicePairingSAName, sa,
+				"device-pairing Deployment should reference its own ServiceAccount")
+
+			t.Log("verifying device-pairing Service exists and targets the correct port")
+			cmd = exec.Command("kubectl", "get", "service", devicePairingServiceName,
+				"-o", "jsonpath={.spec.ports[0].targetPort}",
+				"-n", userNamespace)
+			port, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "8080", port, "device-pairing Service should target port 8080")
+
+			t.Log("verifying device-pairing Deployment has app.kubernetes.io/name label")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-o", "jsonpath={.metadata.labels.app\\.kubernetes\\.io/name}",
+				"-n", userNamespace)
+			label, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "claw-device-pairing", label,
+				"device-pairing Deployment should have app.kubernetes.io/name=claw-device-pairing")
+
+			t.Log("verifying device-pairing resources have owner references")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-o", "jsonpath={.metadata.ownerReferences[0].kind}",
+				"-n", userNamespace)
+			ownerKind, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "Claw", ownerKind, "device-pairing Deployment should be owned by Claw")
+
+			t.Log("verifying device-pairing Deployment security context")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-o", "jsonpath={.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem}",
+				"-n", userNamespace)
+			readOnly, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "true", readOnly, "device-pairing container should have readOnlyRootFilesystem")
+
+			t.Log("verifying DevicePairingConfigured condition")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='DevicePairingConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "DevicePairingConfigured did not become True within %v", defaultTimeout)
 		})
 
 		t.Run("should proxy kubectl requests with kubernetes credential type", func(t *testing.T) {


### PR DESCRIPTION
Deploy the `claw-device-pairing` web application alongside the gateway
and proxy as an operator-managed component. The new Kustomize manifest
group includes a ServiceAccount, ClusterRole, RoleBinding, Deployment,
Service, and Route.

- Route uses path-based routing at `/integration/device-pairing` on the
  Claw Route host, with `haproxy.router.openshift.io/rewrite-target: /`
  to strip the path prefix
- Deployment injects `NAMESPACE` (downward API) and `CLAW_INSTANCE`
  (template-replaced) env vars, mounts the SA token
- ClusterRole grants `create` and `get` on `clawdevicepairingrequests`
- `DevicePairingConfigured` status condition tracks deployment readiness
- `Ready` condition now requires all three deployments (claw, proxy,
  device-pairing) to be available
- RBAC markers added for `serviceaccounts`, `clusterroles`,
  `rolebindings`, and `routes/custom-host`

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds operator-managed device-pairing app (ServiceAccount, Deployment, Service, Route) serving /integration/device-pairing with injected Claw Route host and hardened container security.

* **RBAC**
  * Expands controller RBAC (manager-role) and adds device-pairing ClusterRole/RoleBinding and serviceaccount permissions.

* **Status**
  * Introduces DevicePairingConfigured status condition and includes device-pairing in overall readiness checks.

* **Tests**
  * Adds unit, controller and E2E tests covering manifest rendering, reconciliation and status.

* **Documentation**
  * Adds design, specs and task docs for device-pairing deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->