### PR TITLE
feat: set open dmPolicy for operator-managed Telegram channels

### DIFF
--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -477,7 +477,9 @@ EOF
 
 The operator infers `type: pathToken`, `domain: api.telegram.org`, and `pathToken.prefix: /bot`. The proxy intercepts requests like `/botplaceholder/sendMessage` and forwards them as `/bot<REAL_TOKEN>/sendMessage`. The real token never reaches the gateway pod.
 
-To customize channel behavior (e.g., restrict who can DM the bot), use `channelConfig`:
+By default, the operator sets `dmPolicy: "open"` so anyone who knows the bot's username can message it. This means Telegram works immediately after setup — no pairing approval needed.
+
+To restrict who can DM the bot, override with `channelConfig`:
 
 ```yaml
     - name: telegram
@@ -487,8 +489,10 @@ To customize channel behavior (e.g., restrict who can DM the bot), use `channelC
           key: token
       channelConfig:
         dmPolicy: allowlist
-        allowFrom: [12345]
+        allowFrom: [12345, 67890]
 ```
+
+Valid `dmPolicy` values: `open` (default — anyone can message), `allowlist` (only listed user IDs), `pairing` (manual approval via CLI), `disabled` (no DMs).
 
 ### Discord
 

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -340,12 +340,16 @@ data:
     **Step 4.** Tell the user to scan the QR code with their phone
     (WhatsApp → Linked Devices).
 
-    ### Channel customization (channelConfig)
+    ### Telegram DM access policy
 
-    Users can pass extra settings to operator-managed channels via `channelConfig`
-    on the credential entry. These are deep-merged into the channel's config block:
+    By default, the operator sets `dmPolicy: "open"` with `allowFrom: ["*"]` for
+    Telegram, meaning **anyone** who knows the bot username can message it. This is
+    the simplest setup since each Claw instance is a personal assistant.
+
+    To restrict access, the user can override via `channelConfig`:
 
     ```yaml
+    # Allow only specific Telegram user IDs
     - name: telegram
       channel: telegram
       secretRef:
@@ -353,8 +357,24 @@ data:
           key: token
       channelConfig:
         dmPolicy: allowlist
-        allowFrom: [12345]
+        allowFrom: [12345, 67890]
     ```
+
+    Valid `dmPolicy` values:
+    - `open` (operator default) — allow anyone (requires `allowFrom: ["*"]`)
+    - `allowlist` — only Telegram user IDs listed in `allowFrom` can chat
+    - `pairing` — unknown users get a pairing code; requires manual approval
+      via `openclaw pairing approve telegram <CODE>` in the gateway pod
+    - `disabled` — all DMs blocked
+
+    Do NOT tell users to run `openclaw pairing approve` commands. If they need
+    DM restrictions, advise them to set `dmPolicy: "allowlist"` with specific
+    Telegram user IDs in the Claw CR instead.
+
+    ### Channel customization (channelConfig)
+
+    Users can pass extra settings to operator-managed channels via `channelConfig`
+    on the credential entry. These are deep-merged into the channel's config block.
 
     Protected keys (`enabled`, `botToken`, `token`, `appToken`) cannot be set via
     `channelConfig` — they are operator-managed.

--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.3-slim
+    newTag: 2026.5.7-slim

--- a/internal/controller/claw_channels.go
+++ b/internal/controller/claw_channels.go
@@ -64,7 +64,9 @@ var knownChannels = map[string]channelDefault{
 			{Placeholder: "placeholder"},
 		},
 		ConfigBase: map[string]any{
-			"botToken": "placeholder",
+			"botToken":  "placeholder",
+			"dmPolicy":  "open",
+			"allowFrom": []any{"*"},
 		},
 	},
 	"discord": {

--- a/internal/controller/claw_channels_test.go
+++ b/internal/controller/claw_channels_test.go
@@ -197,12 +197,17 @@ func TestGenerateCompanionRoutes(t *testing.T) {
 }
 
 func TestBuildChannelConfig(t *testing.T) {
-	t.Run("telegram builds base config with enabled and botToken", func(t *testing.T) {
+	t.Run("telegram builds base config with enabled, botToken, and open dmPolicy", func(t *testing.T) {
 		cred := clawv1alpha1.CredentialSpec{Name: "tg", Channel: "telegram"}
 		config, err := buildChannelConfig(cred)
 		require.NoError(t, err)
 		assert.Equal(t, true, config["enabled"])
 		assert.Equal(t, "placeholder", config["botToken"])
+		assert.Equal(t, "open", config["dmPolicy"])
+		allowFrom, ok := config["allowFrom"].([]any)
+		require.True(t, ok, "allowFrom should be a slice")
+		require.Len(t, allowFrom, 1)
+		assert.Equal(t, "*", allowFrom[0])
 	})
 
 	t.Run("discord builds base config with enabled and botToken", func(t *testing.T) {
@@ -230,7 +235,7 @@ func TestBuildChannelConfig(t *testing.T) {
 		assert.Len(t, config, 1)
 	})
 
-	t.Run("channelConfig is deep-merged into base config", func(t *testing.T) {
+	t.Run("channelConfig overrides operator dmPolicy default", func(t *testing.T) {
 		cred := clawv1alpha1.CredentialSpec{
 			Name:    "tg",
 			Channel: "telegram",
@@ -245,7 +250,8 @@ func TestBuildChannelConfig(t *testing.T) {
 		assert.Equal(t, "allowlist", config["dmPolicy"])
 		allowFrom, ok := config["allowFrom"].([]any)
 		require.True(t, ok)
-		assert.Len(t, allowFrom, 1)
+		require.Len(t, allowFrom, 1)
+		assert.Equal(t, float64(12345), allowFrom[0])
 	})
 
 	t.Run("protected key enabled is rejected", func(t *testing.T) {
@@ -349,6 +355,7 @@ func TestInjectChannelsIntoConfigMap(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, true, tg["enabled"])
 		assert.Equal(t, "placeholder", tg["botToken"])
+		assert.Equal(t, "open", tg["dmPolicy"])
 
 		plugins, ok := operatorJSON["plugins"].(map[string]any)
 		require.True(t, ok)
@@ -390,7 +397,7 @@ func TestInjectChannelsIntoConfigMap(t *testing.T) {
 		assert.False(t, hasChannels, "channels should not be injected when no channel credentials exist")
 	})
 
-	t.Run("channelConfig is merged into channel config block", func(t *testing.T) {
+	t.Run("channelConfig overrides operator dmPolicy in configmap", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials([]clawv1alpha1.CredentialSpec{
 			{
@@ -414,7 +421,7 @@ func TestInjectChannelsIntoConfigMap(t *testing.T) {
 		tg := channels["telegram"].(map[string]any)
 		assert.Equal(t, true, tg["enabled"])
 		assert.Equal(t, "placeholder", tg["botToken"])
-		assert.Equal(t, "allowlist", tg["dmPolicy"])
+		assert.Equal(t, "allowlist", tg["dmPolicy"], "user channelConfig should override operator default")
 	})
 
 	t.Run("protected key in channelConfig returns error", func(t *testing.T) {
@@ -669,6 +676,7 @@ func TestChannelCredentialReconciliation(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, true, tg["enabled"])
 		assert.Equal(t, "placeholder", tg["botToken"])
+		assert.Equal(t, "open", tg["dmPolicy"], "operator should set open dmPolicy for Telegram")
 
 		proxyCM := &corev1.ConfigMap{}
 		waitFor(t, timeout, interval, func() bool {

--- a/internal/controller/claw_channels_test.go
+++ b/internal/controller/claw_channels_test.go
@@ -356,6 +356,7 @@ func TestInjectChannelsIntoConfigMap(t *testing.T) {
 		assert.Equal(t, true, tg["enabled"])
 		assert.Equal(t, "placeholder", tg["botToken"])
 		assert.Equal(t, "open", tg["dmPolicy"])
+		assert.Equal(t, []any{"*"}, tg["allowFrom"])
 
 		plugins, ok := operatorJSON["plugins"].(map[string]any)
 		require.True(t, ok)
@@ -677,6 +678,7 @@ func TestChannelCredentialReconciliation(t *testing.T) {
 		assert.Equal(t, true, tg["enabled"])
 		assert.Equal(t, "placeholder", tg["botToken"])
 		assert.Equal(t, "open", tg["dmPolicy"], "operator should set open dmPolicy for Telegram")
+		assert.Equal(t, []any{"*"}, tg["allowFrom"], "operator should set wildcard allowFrom for Telegram")
 
 		proxyCM := &corev1.ConfigMap{}
 		waitFor(t, timeout, interval, func() bool {


### PR DESCRIPTION
Telegram's default dmPolicy is "pairing", which blocks all new DMs until manually approved via `openclaw pairing approve` in the gateway pod. The operator had no mechanism for this, making Telegram unusable out of the box.

- Set dmPolicy: "open" with allowFrom: ["*"] in Telegram ConfigBase
- Users can still restrict access via channelConfig overrides
- Document all four dmPolicy values (open, allowlist, pairing, disabled)
- Update PLATFORM.md skill with Telegram DM access policy section
- Bump OpenClaw image to 2026.5.7-slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram DM policy is now configurable with modes: open, allowlist, pairing, or disabled; default behavior is open (allows direct messages).

* **Documentation**
  * Expanded Telegram setup docs with DM policy defaults, guidance on restricting DMs via channel configuration, and updated channel customization examples recommending explicit allowlist configuration.

* **Chores**
  * Updated OpenClaw container image to 2026.5.7-slim
<!-- end of auto-generated comment: release notes by coderabbit.ai -->