### PR TITLE
chore: give CI jobs unique, descriptive names

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION
- Rename all three workflow job names from generic "Run on Ubuntu" to Lint, Unit Tests, and E2E Tests
- Fixes checks appearing indistinguishable in branch protection settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow step names across lint, unit test, and E2E test workflows for improved clarity and visibility in CI/CD pipeline reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->