### PR TITLE
docs: add GitHub REST API provider setup

### DIFF
--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -613,3 +613,44 @@ You can override any inferred field if needed (e.g., routing through a corporate
 ```
 
 The `channel` field still enables declarative channel config injection into `operator.json` — only the proxy routing is overridden. You can override `type`, `domain`, and type-specific config (`apiKey`, `pathToken`) independently.
+
+## External Services
+
+### GitHub REST API
+
+Gives OpenClaw access to GitHub's REST API for working with issues, pull requests, code search, and repositories. The proxy injects a Personal Access Token as a bearer credential — the real token never reaches the gateway pod.
+
+> **Note:** The pre-allowed `github.com` domain covers git HTTPS clones only (for npm dependencies). `api.github.com` is a separate host and requires an explicit credential entry.
+
+**1. Create a Personal Access Token** at [github.com/settings/tokens](https://github.com/settings/tokens). A fine-grained token scoped to specific repositories is recommended over a classic token.
+
+**2. Create the Secret:**
+
+```sh
+oc create secret generic github-pat-secret \
+  --from-literal=token=YOUR_GITHUB_PAT \
+  -n $NS
+```
+
+**3. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: github
+      type: bearer
+      domain: api.github.com
+      secretRef:
+        - name: github-pat-secret
+          key: token
+EOF
+```
+
+The proxy intercepts requests to `api.github.com` and injects `Authorization: Bearer <real PAT>`. Skills that use `curl` with the GitHub REST API (like the built-in `gh-issues` skill) work through the proxy — they use a placeholder token that the proxy replaces transparently.
+
+> **`gh` CLI vs curl:** The `gh` CLI manages its own credentials via `gh auth login` (interactive OAuth). It doesn't use the `Authorization` header in the same way as `curl`-based skills, so proxy-based credential injection is less reliable with `gh`. For best results, use skills that call the GitHub REST API with `curl` directly.

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -414,6 +414,37 @@ data:
     (`xoxb-...`) handles all other API calls. WebSocket connections to
     `*.slack.com` pass through without injection.
 
+    # GitHub API Access
+
+    The pre-allowed `github.com` domain covers **git HTTPS operations only** (clones,
+    tarball fetches for npm dependencies). It does NOT cover `api.github.com`, which
+    is a separate host used by GitHub's REST and GraphQL APIs.
+
+    To give OpenClaw access to the GitHub REST API (for issues, PRs, code search,
+    etc.), the user needs a bearer credential for `api.github.com`:
+
+    ```yaml
+    - name: github
+      type: bearer
+      domain: api.github.com
+      secretRef:
+        - name: github-pat-secret
+          key: token
+    ```
+
+    The proxy injects `Authorization: Bearer <real PAT>` into every request to
+    `api.github.com`. Skills that use `curl` with the GitHub REST API (like
+    `gh-issues`) work through the proxy — the skill uses a placeholder token, and
+    the proxy replaces it transparently.
+
+    **Important:** The `gh` CLI manages its own credentials via `gh auth login`
+    (interactive OAuth flow stored in `~/.config/gh/`). It does NOT use the
+    `Authorization` header on REST requests in the same way, so the proxy-based
+    approach works best with **curl-based skills** rather than the `gh` CLI.
+    If the user asks about `gh` CLI access, recommend the curl + REST API approach
+    instead, or explain that `gh auth login` requires an interactive session inside
+    the pod and stores credentials in the gateway container (less secure).
+
     # Custom Domains
 
     For any other external service, the user can add a `type: none` entry with the


### PR DESCRIPTION
- Document bearer credential setup for api.github.com
- Add configmap skill guidance on GitHub API vs gh CLI
- Explain why api.github.com needs a separate credential from the pre-allowed github.com domain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced provider setup documentation with a new "External Services" section explaining how to configure GitHub REST API access using Kubernetes Secrets and bearer credentials
  * Added guidance on setting up credentials for GitHub API and understanding how authorization headers are injected during requests
  * Included clarification on the differences between standard git operations and REST API access requirements
  * Added recommendations for using curl-based GitHub REST API skills

<!-- end of auto-generated comment: release notes by coderabbit.ai -->