### PR TITLE
docs: add MCP server documentation (Phase 3)

### DIFF
--- a/docs/proposals/mcp-support-design.md
+++ b/docs/proposals/mcp-support-design.md
@@ -264,7 +264,7 @@ Adds the `envFrom` field and reconciler logic to mount real secrets into the gat
 7. Enhance `McpServersConfigured` condition to report secret validation failures
 8. Add unit tests
 
-### Phase 3: MCP documentation
+### Phase 3: MCP documentation - DONE
 
 Required part of the feature — not follow-up work.
 

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -1,6 +1,6 @@
 # Provider Setup
 
-This guide covers configuring LLM providers, external services, and messaging channels for use with Claw. Each section walks through creating the necessary Secret and Claw CR configuration.
+This guide covers configuring LLM providers, external services, messaging channels, and MCP servers for use with Claw. Each section walks through creating the necessary Secret and Claw CR configuration.
 
 All examples assume you have set your target namespace:
 
@@ -654,3 +654,205 @@ EOF
 The proxy intercepts requests to `api.github.com` and injects `Authorization: Bearer <real PAT>`. Skills that use `curl` with the GitHub REST API (like the built-in `gh-issues` skill) work through the proxy — they use a placeholder token that the proxy replaces transparently.
 
 > **`gh` CLI vs curl:** The `gh` CLI manages its own credentials via `gh auth login` (interactive OAuth). It doesn't use the `Authorization` header in the same way as `curl`-based skills, so proxy-based credential injection is less reliable with `gh`. For best results, use skills that call the GitHub REST API with `curl` directly.
+
+## MCP Servers
+
+MCP (Model Context Protocol) servers extend the AI assistant's capabilities by providing structured tool access to external services (GitHub API, filesystems, databases, etc.). The operator manages MCP server configuration declaratively via `spec.mcpServers` in the Claw CR, injecting the config into `operator.json` at reconciliation time.
+
+The operator uses a three-tier security model for MCP server credentials:
+
+| Tier | Transport | Secret handling | Secrets on gateway? |
+|------|-----------|-----------------|---------------------|
+| 1. HTTP/SSE (preferred) | HTTP URL | Proxy `credentials` entry for the domain | No |
+| 2. Stdio + proxy placeholder | Subprocess | Placeholder env var + proxy `credentials` entry | No |
+| 3. Stdio + real secret (escape hatch) | Subprocess | `envFrom` with `secretKeyRef` on gateway | Yes |
+
+**Tier 1** is the recommended path — traffic goes through the MITM proxy, and credentials are injected transparently. **Tier 2** keeps secrets off the gateway for stdio MCP servers whose target domain and auth type are known. **Tier 3** is an explicit escape hatch for cases where tiers 1–2 are not viable.
+
+### Tier 1: HTTP/SSE MCP (No Auth)
+
+The simplest case — an unauthenticated HTTP MCP server. The domain is auto-extracted from the URL and added as a passthrough route in the proxy. No secret or credential entry needed.
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  mcpServers:
+    context7:
+      url: https://mcp.context7.com/mcp
+      transport: streamable-http
+EOF
+```
+
+### Tier 1: HTTP/SSE MCP (With Auth)
+
+An HTTP MCP server that requires authentication. Add both the MCP server entry and a `credentials` entry for the domain. The proxy injects the auth header — no secrets reach the gateway.
+
+**1. Create the Secret:**
+
+```sh
+oc create secret generic mcp-api-key \
+  --from-literal=api-key=YOUR_API_KEY \
+  -n $NS
+```
+
+**2. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: my-mcp-service
+      type: bearer
+      domain: api.example.com
+      secretRef:
+        - name: mcp-api-key
+          key: api-key
+
+  mcpServers:
+    my-service:
+      url: https://api.example.com/mcp
+      transport: streamable-http
+EOF
+```
+
+The proxy intercepts requests to `api.example.com` and injects `Authorization: Bearer <real key>`. The MCP server itself never sees credentials in its configuration.
+
+### Tier 2: Stdio MCP with Proxy Placeholder (GitHub)
+
+For stdio MCP servers where you know which domain is called and what auth type it uses. The env var is set to a placeholder value — the proxy intercepts outbound requests and replaces the placeholder with the real credential.
+
+**1. Create the Secret:**
+
+```sh
+oc create secret generic github-pat-secret \
+  --from-literal=token=YOUR_GITHUB_PAT \
+  -n $NS
+```
+
+**2. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: github
+      type: bearer
+      domain: api.github.com
+      secretRef:
+        - name: github-pat-secret
+          key: token
+
+  mcpServers:
+    github:
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: placeholder
+EOF
+```
+
+How it works: The GitHub MCP server subprocess inherits `HTTP_PROXY`/`HTTPS_PROXY` from the gateway container, so its outbound HTTPS calls to `api.github.com` go through the MITM proxy. The server sends `Authorization: Bearer placeholder` (from the env var), and the proxy strips it and injects the real PAT from the Secret. The real token never reaches the gateway.
+
+> **Reusing credentials:** If you already have a `credentials` entry for `api.github.com` (e.g., for GitHub REST API access via skills), the same entry covers the MCP server too — no duplication needed.
+
+### Tier 3: Stdio MCP with Real Secret (Escape Hatch)
+
+When you don't know the MCP server's internals, or it uses the secret for non-HTTP purposes (e.g., a database password), use `envFrom` to mount the real secret as a gateway container environment variable. The subprocess inherits it at runtime.
+
+**1. Create the Secret:**
+
+```sh
+oc create secret generic db-credentials \
+  --from-literal=password=YOUR_DB_PASSWORD \
+  -n $NS
+```
+
+**2. Apply the Claw CR:**
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: db-network
+      type: none
+      domain: postgres.internal
+
+  mcpServers:
+    custom-db:
+      command: node
+      args: ["db-mcp-server.js"]
+      env:
+        DB_HOST: postgres.internal
+      envFrom:
+        - name: DB_PASSWORD
+          secretRef:
+            name: db-credentials
+            key: password
+EOF
+```
+
+> **Security note:** Tier 3 places the real secret on the gateway container. Use this only when tiers 1–2 are not viable. The `credentials` entry with `type: none` is still needed to allowlist the domain through the proxy (even without credential injection).
+
+### Combining MCP Servers with Providers
+
+MCP servers work alongside LLM provider credentials and other integrations in the same Claw instance:
+
+```sh
+oc apply -n $NS -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: anthropic
+      type: apiKey
+      secretRef:
+        - name: anthropic-api-key
+          key: api-key
+      provider: anthropic
+
+    - name: github
+      type: bearer
+      domain: api.github.com
+      secretRef:
+        - name: github-pat-secret
+          key: token
+
+  mcpServers:
+    context7:
+      url: https://mcp.context7.com/mcp
+      transport: streamable-http
+
+    github:
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: placeholder
+EOF
+```
+
+### How It Works
+
+The operator reconciles `spec.mcpServers` into the `mcp.servers` section of `operator.json`. At pod startup, the init-config script deep-merges `operator.json` into the user's `openclaw.json`:
+
+- **Merge mode** (default): Operator-managed MCP servers merge alongside any user-managed servers added via `openclaw mcp set` inside the pod. On collision (same server name), the operator-managed entry wins.
+- **Overwrite mode**: The full config is replaced on every pod start, including MCP servers.
+
+The operator also validates that all `envFrom`-referenced Secrets exist and contain the specified keys. If validation fails, the `McpServersConfigured` condition is set to `False` with a descriptive error message, and `Ready` is set to `False`.

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -138,7 +138,7 @@ data:
   PLATFORM.md: |
     ---
     name: platform
-    description: "Platform overview, proxy architecture, LLM provider model management, and messaging channel integration."
+    description: "Platform overview, proxy architecture, LLM provider model management, messaging channel integration, and MCP server configuration."
     ---
 
     # Platform Overview
@@ -444,6 +444,119 @@ data:
     If the user asks about `gh` CLI access, recommend the curl + REST API approach
     instead, or explain that `gh auth login` requires an interactive session inside
     the pod and stores credentials in the gateway container (less secure).
+
+    # MCP Servers
+
+    MCP (Model Context Protocol) servers extend your capabilities with structured tool
+    access to external services. The operator manages MCP server configuration via
+    `spec.mcpServers` in the Claw CR — separate from `credentials`.
+
+    ## Three-tier security model
+
+    | Tier | Transport | Secret handling | Secrets on gateway? |
+    |------|-----------|-----------------|---------------------|
+    | 1. HTTP/SSE (preferred) | HTTP URL | Proxy `credentials` entry for the domain | No |
+    | 2. Stdio + proxy placeholder | Subprocess | Placeholder env + `credentials` entry | No |
+    | 3. Stdio + real secret (escape hatch) | Subprocess | `envFrom` with `secretKeyRef` | Yes |
+
+    ## Which tier to recommend
+
+    Use this decision tree:
+
+    1. **Is the MCP server HTTP/SSE?** → Tier 1. Add the `url` to `mcpServers`. If
+       it needs auth, add a `credentials` entry for the domain (same as any other
+       external service). If unauthenticated, no `credentials` entry needed — the
+       domain is auto-extracted as a passthrough route.
+
+    2. **Is it stdio and you know which domain/auth it uses?** → Tier 2. Add the
+       MCP server with a placeholder env var, and add a `credentials` entry for the
+       target domain. The proxy replaces the placeholder with the real credential.
+
+    3. **Is it stdio but you don't know its internals, or it uses the secret for
+       non-HTTP purposes?** → Tier 3. Use `envFrom` to mount the real secret on
+       the gateway container. The user accepts that the secret is on the gateway.
+
+    ## Worked examples
+
+    ### Context7 (Tier 1 — unauthenticated HTTP)
+
+    No secret, no credential entry needed. The domain is auto-extracted:
+
+    ```yaml
+    mcpServers:
+      context7:
+        url: https://mcp.context7.com/mcp
+        transport: streamable-http
+    ```
+
+    ### GitHub MCP (Tier 2 — stdio with proxy placeholder)
+
+    The GitHub MCP server (`@modelcontextprotocol/server-github`) calls
+    `api.github.com` using the `GITHUB_PERSONAL_ACCESS_TOKEN` env var as a bearer
+    token. The proxy intercepts and injects the real PAT:
+
+    ```yaml
+    credentials:
+      - name: github
+        type: bearer
+        domain: api.github.com
+        secretRef:
+          - name: github-pat-secret
+            key: token
+
+    mcpServers:
+      github:
+        command: npx
+        args: ["-y", "@modelcontextprotocol/server-github"]
+        env:
+          GITHUB_PERSONAL_ACCESS_TOKEN: placeholder
+    ```
+
+    If the user already has a `credentials` entry for `api.github.com` (for REST
+    API access), the **same entry** covers the MCP server too — no duplication needed.
+
+    ### Generic stdio MCP (Tier 3 — real secret on gateway)
+
+    When you don't know what domain the MCP server calls, or it uses the secret
+    for non-HTTP purposes (e.g., database password):
+
+    ```yaml
+    mcpServers:
+      custom-db:
+        command: node
+        args: ["db-mcp-server.js"]
+        env:
+          DB_HOST: postgres.internal
+        envFrom:
+          - name: DB_PASSWORD
+            secretRef:
+              name: db-credentials
+              key: password
+    ```
+
+    The user must also add a `credentials` entry (even `type: none`) for any
+    domains the MCP server needs to reach through the proxy.
+
+    ## How MCP interacts with other config
+
+    - **`spec.mcpServers`** is separate from `spec.credentials`. MCP entries define
+      what servers to run; credentials define proxy routing and auth injection.
+    - **HTTP MCP domains** are auto-extracted as passthrough routes — no `credentials`
+      entry needed for unauthenticated HTTP MCP servers.
+    - **Stdio MCP domains** must be allowlisted via `credentials` entries (the same
+      list used for providers and channels). This applies to both tier 2 and tier 3.
+    - **Merge mode:** Operator-managed MCP servers merge alongside user-managed
+      servers added via `openclaw mcp set`. On collision (same server name), the
+      operator-managed entry wins.
+
+    ## What NOT to do
+
+    **Do NOT** run `openclaw mcp set` or `openclaw mcp remove` for operator-managed
+    MCP servers (those declared in `spec.mcpServers`). The operator owns these entries
+    — manual changes will be overwritten on the next pod restart.
+
+    User-managed MCP servers (added via `openclaw mcp set` inside the pod) coexist
+    fine with operator-managed ones as long as names don't collide.
 
     # Custom Domains
 


### PR DESCRIPTION
- Add MCP Servers section to PLATFORM.md skill with three-tier model, tier selection guidance, worked examples (Context7, GitHub, generic), and do-not-do instructions for the AI assistant
- Add MCP Servers section to docs/provider-setup.md with step-by-step setup for all three tiers, combined CR example, and merge behavior
- Mark Phase 3 as DONE in the design proposal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive MCP server configuration guide including design specifications, three-tier security model, and implementation phases
  * Documented three security tiers for MCP credentials: HTTP/SSE without separate secrets, stdio with proxy placeholder, and secret-backed escape hatch
  * Included end-to-end setup examples for various MCP server types and guidance on validation status conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->