### PR TITLE
fix: separate build and push steps in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,21 +20,32 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Login to Quay.io
-        run: |
-          mkdir -p $HOME/.docker
-          echo "${{ secrets.QUAY_TOKEN }}" | base64 -d > $HOME/.docker/config.json
-
-      - name: Build and push operator image
+      - name: Build operator image
         run: |
           SHA=$(git rev-parse --short HEAD)
           make container-build IMG=quay.io/codeready-toolchain/claw-operator:${SHA}
-          make container-push IMG=quay.io/codeready-toolchain/claw-operator:${SHA}
 
-      - name: Build and push proxy image
+      - name: Build proxy image
         run: |
           SHA=$(git rev-parse --short HEAD)
           make container-build-proxy PROXY_IMG=quay.io/codeready-toolchain/claw-proxy:${SHA}
+
+      - name: Login to Quay.io
+        run: |
+          set -e
+          export XDG_RUNTIME_DIR=/run/user/${UID}
+          mkdir -p ${XDG_RUNTIME_DIR}/containers || true
+          echo '{"auths":{"quay.io":{"auth":"${{ secrets.QUAY_TOKEN }}"}}}' > ${XDG_RUNTIME_DIR}/containers/auth.json
+          podman login --get-login quay.io
+
+      - name: Push operator image
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          make container-push IMG=quay.io/codeready-toolchain/claw-operator:${SHA}
+
+      - name: Push proxy image
+        run: |
+          SHA=$(git rev-parse --short HEAD)
           make container-push-proxy PROXY_IMG=quay.io/codeready-toolchain/claw-proxy:${SHA}
 
       - name: Publish staging bundle and catalog

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,11 +32,12 @@ jobs:
 
       - name: Login to Quay.io
         run: |
-          set -e
-          export XDG_RUNTIME_DIR=/run/user/${UID}
-          mkdir -p ${XDG_RUNTIME_DIR}/containers || true
-          echo '{"auths":{"quay.io":{"auth":"${{ secrets.QUAY_TOKEN }}"}}}' > ${XDG_RUNTIME_DIR}/containers/auth.json
-          podman login --get-login quay.io
+          set -euo pipefail
+          REGISTRY_AUTH_FILE="${RUNNER_TEMP}/containers-auth.json"
+          export REGISTRY_AUTH_FILE
+          echo "REGISTRY_AUTH_FILE=${REGISTRY_AUTH_FILE}" >> "${GITHUB_ENV}"
+          printf '%s' '{"auths":{"quay.io":{"auth":"${{ secrets.QUAY_TOKEN }}"}}}' > "${REGISTRY_AUTH_FILE}"
+          podman login --authfile "${REGISTRY_AUTH_FILE}" --get-login quay.io
 
       - name: Push operator image
         run: |


### PR DESCRIPTION
- Move Quay.io login after image builds so pulling public base images is not affected by the auth config
- Use podman-native auth file (containers/auth.json) instead of Docker's config.json
- Construct auth JSON in the workflow with the token as a raw base64 auth value
- Add podman login --get-login verification step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container image build and publication workflow by separating build and push steps for operator and proxy images.
  * Updated the registry authentication approach to use a temporary token-based auth file during publishing for more reliable and secure image uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->