### PR TITLE
fix: wait for cluster ready before running scorecard

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,13 +60,15 @@ jobs:
           bin/kind create cluster --name scorecard
 
       - name: Wait for cluster ready
+        id: cluster_ready
         if: steps.kind.outcome == 'success'
+        continue-on-error: true
         run: |
           kubectl wait --for=condition=Ready nodes --all --timeout=60s
           kubectl -n default wait --for=jsonpath='{.metadata.name}'=default serviceaccount/default --timeout=60s
 
       - name: Run scorecard tests
-        if: steps.kind.outcome == 'success'
+        if: steps.kind.outcome == 'success' && steps.cluster_ready.outcome == 'success'
         continue-on-error: true
         run: |
           bin/operator-sdk scorecard ./bundle \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,12 @@ jobs:
           make kind
           bin/kind create cluster --name scorecard
 
+      - name: Wait for cluster ready
+        if: steps.kind.outcome == 'success'
+        run: |
+          kubectl wait --for=condition=Ready nodes --all --timeout=60s
+          kubectl -n default wait --for=jsonpath='{.metadata.name}'=default serviceaccount/default --timeout=60s
+
       - name: Run scorecard tests
         if: steps.kind.outcome == 'success'
         continue-on-error: true


### PR DESCRIPTION
- Wait for nodes to be Ready and default ServiceAccount to exist before launching scorecard tests, avoiding the race condition where the SA controller hasn't populated the namespace yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD pipeline now waits (up to 60s) for the cluster and default service account to be ready after cluster creation.
  * Test step updated to run only after both cluster creation and readiness checks succeed; it still continues on error.

* **Note:** No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->