### PR TITLE
chore: bump OpenClaw image to 2026.5.12-slim

### DIFF
--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -87,6 +87,9 @@ spec:
           image: ghcr.io/openclaw/openclaw:slim
           imagePullPolicy: IfNotPresent
           command:
+            - tini
+            - -s
+            - --
             - node
             - /app/dist/index.js
             - gateway

--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.7-slim
+    newTag: 2026.5.12-slim


### PR DESCRIPTION
- Update ghcr.io/openclaw/openclaw tag from 2026.5.7-slim to 2026.5.12-slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenCLAW container image to the latest stable version.
  * Improved container startup handling to reduce orphaned processes and improve shutdown reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->