### PR TITLE
chore: bump OpenClaw image to 2026.5.18-slim

### DIFF
--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -101,8 +101,12 @@ spec:
           env:
             - name: HOME
               value: /home/node
-            - name: OPENCLAW_CONFIG_DIR
+            - name: OPENCLAW_HOME
+              value: /home/node
+            - name: OPENCLAW_STATE_DIR
               value: /home/node/.openclaw
+            - name: OPENCLAW_CONFIG_PATH
+              value: /home/node/.openclaw/openclaw.json
             - name: NODE_ENV
               value: production
             - name: OPENCLAW_PROXY_ACTIVE

--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.12-slim
+    newTag: 2026.5.18-slim


### PR DESCRIPTION
- Update image tag from 2026.5.12-slim to 2026.5.18-slim
- Replace unused OPENCLAW_CONFIG_DIR env var with OPENCLAW_HOME, OPENCLAW_STATE_DIR, and OPENCLAW_CONFIG_PATH to match upstream docker-compose and pin path resolution explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment environment variables with separate declarations for home directory, state directory, and configuration file path
  * Upgraded container image version from `2026.5.12-slim` to `2026.5.18-slim`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->