### PR TITLE
fix: increase controller-manager memory limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -94,10 +94,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
         volumeMounts: []
       volumes: []
       serviceAccountName: controller-manager


### PR DESCRIPTION
The previous limits (128Mi/64Mi) were too low and could cause OOM kills
under normal operation.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container resource allocation for enhanced system stability and performance. Memory limits increased from 128Mi to 256Mi and memory requests increased from 64Mi to 128Mi. These resource adjustments improve overall availability and support better application performance and responsiveness under varying load conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->