### PR TITLE
chore: bump OpenClaw image to 2026.5.19-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.18-slim
+    newTag: 2026.5.19-slim


### PR DESCRIPTION
- Update ghcr.io/openclaw/openclaw tag from 2026.5.18-slim to 2026.5.19-slim
- No operator changes needed: release contains internal refactoring, channel fixes, Codex integration fixes, and gateway startup improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal application components to the latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->