### PR TITLE
feat: add operator-managed instance idling

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -62,6 +62,7 @@ const (
 	ConditionTypeDevicePairingConfigured = "DevicePairingConfigured"
 	ConditionTypeMcpServersConfigured    = "McpServersConfigured"
 	ConditionTypeWebSearchConfigured     = "WebSearchConfigured"
+	ConditionTypeIdle                    = "Idle"
 )
 
 // Annotation keys used on pod templates to trigger rollouts on config changes.
@@ -82,6 +83,8 @@ const (
 	ConditionReasonValidationFailed = "ValidationFailed"
 	ConditionReasonConfigured       = "Configured"
 	ConditionReasonConfigFailed     = "ConfigFailed"
+	ConditionReasonIdle             = "Idle"
+	ConditionReasonIdledByRequest   = "IdledByRequest"
 )
 
 // SecretRefEntry references a specific key in a Secret.
@@ -368,6 +371,12 @@ type ClawSpec struct {
 	// permitted by credentials, search providers, or builtins are reachable.
 	// +optional
 	WebFetch *WebFetchSpec `json:"webFetch,omitempty"`
+
+	// Idle, when set to true, instructs the operator to scale all managed
+	// Deployments to zero replicas. Set to false (or omit) to run normally.
+	// +optional
+	// +kubebuilder:default=false
+	Idle bool `json:"idle,omitempty"`
 }
 
 // ClawStatus defines the observed state of Claw

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -291,6 +291,12 @@ spec:
                       inferred defaults
                     rule: self.type != 'oauth2' || has(self.oauth2) || has(self.channel)
                 type: array
+              idle:
+                default: false
+                description: |-
+                  Idle, when set to true, instructs the operator to scale all managed
+                  Deployments to zero replicas. Set to false (or omit) to run normally.
+                type: boolean
               mcpServers:
                 additionalProperties:
                   description: McpServerSpec defines an MCP server the operator injects

--- a/docs/proposals/idling-design.md
+++ b/docs/proposals/idling-design.md
@@ -1,0 +1,210 @@
+# Claw Instance Idling
+
+**Status:** Final
+
+## Overview
+
+Operator-managed idling allows external systems to request that a Claw instance
+be scaled to zero (idled) without directly manipulating the Deployments. The
+operator acts as the single source of truth for replica counts — external
+controllers idle and unidle by setting a spec field on the Claw CR, and the
+operator translates that intent into deployment scale changes.
+
+This is important because the Claw operator already reconciles deployments to
+`replicas: 1`. Without a dedicated idle mechanism, any external system that
+scales deployments to zero would be immediately reverted on the next reconcile.
+
+## Design Principles
+
+1. **Operator owns deployment lifecycle** — No external system directly scales
+   Claw deployments. The operator is the sole actor that sets replica counts.
+2. **Simple boolean interface** — A single spec field toggles idle state; the
+   operator handles the complexity of scaling multiple deployments.
+3. **Data preservation** — PVCs and Secrets are never deleted during idling.
+   User data and configuration persist across idle/unidle cycles.
+4. **Status visibility** — The CR status clearly indicates whether the instance
+   is idled, making it easy for UIs and monitoring tools to present the state.
+5. **Fast unidle** — Unidling should be as fast as a normal cold start; no
+   special warm-up procedures are needed beyond the standard init containers.
+
+## Architecture / How It Works
+
+### Idle Flow
+
+```
+External System            Claw CR              Claw Operator           Deployments
+      |                       |                       |                       |
+      |-- PATCH spec.idle --> |                       |                       |
+      |                       |-- reconcile trigger ->|                       |
+      |                       |                       |-- scale to 0 -------> |
+      |                       |                       |-- update status -----> |
+      |                       |<-- status: Idle=True--|                       |
+```
+
+### Unidle Flow
+
+```
+External System            Claw CR              Claw Operator           Deployments
+      |                       |                       |                       |
+      |-- PATCH spec.idle --> |                       |                       |
+      |                       |-- reconcile trigger ->|                       |
+      |                       |                       |-- full reconcile ---> |
+      |                       |                       |-- scale to 1 -------> |
+      |                       |<-- status: Ready=True |                       |
+```
+
+### Integration with External Idlers
+
+The Claw operator creates resources with an ownership chain:
+`Claw CR → Deployment → ReplicaSet → Pod`. External workload idlers (such as
+the DevSandbox member-operator idler) walk this chain from pod to top-level
+owner. For them to idle Claw instances via `spec.idle` rather than directly
+scaling the Deployment, they must add a handler for the `Claw` kind — analogous
+to how `AnsibleAutomationPlatform` is handled today:
+
+```go
+case "Claw":
+    err = i.idleClaw(ctx, ownerWithGVR) // patches spec.idle: true
+```
+
+Without this idler-side change, the idler would match `Deployment` in the chain
+and scale it directly — which the Claw operator would immediately revert on the
+next reconcile. The idler also needs RBAC for
+`claw.sandbox.redhat.com/claws` (get, list, patch).
+
+This change is outside the scope of the claw-operator itself but is a required
+companion change for environments that use workload idling.
+
+### Reconcile Behavior When Idled
+
+When `spec.idle` is `true`, the controller short-circuits the reconcile loop
+early: it ensures all managed Deployments have `replicas: 0`, updates the status
+to reflect the idled state, and returns without processing credentials, building
+proxy config, or applying the full Kustomize stack. This minimizes unnecessary
+work and avoids transient errors (e.g., trying to check Route readiness when pods
+are down).
+
+When `spec.idle` is `false` (the default — the field is omitted for normal
+operation), the reconcile runs the full pipeline — credentials, proxy config,
+Kustomize, server-side apply — which applies deployments with `replicas: 1`.
+
+### What Gets Scaled Down
+
+When idled, the operator sets `replicas: 0` on:
+- The gateway Deployment (`<instance>`)
+- The proxy Deployment (`<instance>-proxy`)
+- The device-pairing Deployment (`<instance>-device-pairing`)
+
+### What Is Preserved
+
+- PVCs (user data on `/home/node/.openclaw`)
+- Secrets (gateway token, proxy CA, credential secrets)
+- ConfigMaps (operator config, proxy config)
+- Routes (so URLs remain stable for dashboards/bookmarks)
+- Services (for Route→Service referential integrity)
+- NetworkPolicies
+
+## Core Concepts
+
+### The `idle` Spec Field
+
+A boolean field in `ClawSpec` that external systems set to `true` to request
+idling and `false` to request unidling. The operator watches for changes to this
+field and acts accordingly.
+
+```go
+type ClawSpec struct {
+    // ...existing fields...
+
+    // Idle, when set to true, instructs the operator to scale all managed
+    // Deployments to zero replicas. Set to false (or omit) to run normally.
+    // +optional
+    // +kubebuilder:default=false
+    Idle bool `json:"idle,omitempty"`
+}
+```
+
+External systems interact via a simple patch:
+
+```bash
+# Idle
+kubectl patch claw my-instance --type=merge -p '{"spec":{"idle":true}}'
+
+# Unidle
+kubectl patch claw my-instance --type=merge -p '{"spec":{"idle":false}}'
+```
+
+### Status Representation
+
+Two conditions work together to communicate idle state:
+
+```yaml
+status:
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: Idle
+      message: "Instance is idled — set spec.idle to false to resume"
+    - type: Idle
+      status: "True"
+      reason: IdledByRequest
+      message: "Instance scaled to zero by spec.idle"
+```
+
+When unidled and running normally, the `Idle` condition is removed (absent
+from the list) and Ready reports normally:
+
+```yaml
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: "Claw instance is ready"
+```
+
+The `Idle` condition is only present when the instance is (or was recently)
+idled. This follows the pattern used by `McpServersConfigured` in this
+operator — conditions are added when relevant and removed when not applicable.
+
+This approach lets:
+- Simple tools check `Ready` to know if the instance is serving traffic.
+- Aware tools check for the presence of `Idle=True` to distinguish
+  "intentionally stopped" from "broken."
+
+### Constants
+
+```go
+const (
+    ConditionTypeIdle = "Idle"
+
+    ConditionReasonIdle           = "Idle"
+    ConditionReasonIdledByRequest = "IdledByRequest"
+)
+```
+
+## Implementation Plan
+
+Single PR covering API, controller, and tests:
+
+1. Add `Idle` field to `ClawSpec` in `api/v1alpha1/claw_types.go`
+2. Add `ConditionTypeIdle` and related reason constants
+3. Run `make manifests generate` to regenerate CRD YAML and DeepCopy
+4. Add early-return logic at the top of `Reconcile()` that checks `spec.idle`:
+   - When `true`: fetch managed Deployments by name (gateway, proxy,
+     device-pairing); for each that exists with replicas > 0, patch to
+     `replicas: 0`; skip NotFound (handles CR created idle before resources
+     exist); set `Idle` condition to True, `Ready` to False (reason: Idle);
+     clear `status.url`; update status and return
+   - When `false` (default): remove `Idle` condition if present, proceed
+     with the existing full reconcile
+5. Unit tests (envtest):
+   - idle → deployments scaled to 0, status reflects idle
+   - unidle → full reconcile runs, deployments at replicas 1
+   - status transitions (Ready → Idle → Ready)
+   - no-op when already idled (patch idempotency)
+   - idling when deployments don't exist yet (no error)
+6. E2E test (Kind cluster):
+   - Create Claw, wait for Ready
+   - Patch `spec.idle: true`, verify pods terminate and status is Idle
+   - Patch `spec.idle: false`, verify pods come back and status is Ready

--- a/docs/proposals/idling-questions.md
+++ b/docs/proposals/idling-questions.md
@@ -1,0 +1,94 @@
+# Claw Instance Idling — Design Questions
+
+**Status:** Resolved — all decisions made
+**Related:** [Design document](idling-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them one by one to form the design, then update the design document.
+
+---
+
+## Q1: What should the reconcile loop do when `spec.idle` is true?
+
+When the operator sees that idling is requested, it needs to decide how much
+work to perform. The full reconcile is non-trivial (credential resolution, proxy
+config generation, Kustomize build, Route host resolution, server-side apply).
+We need to decide whether any of that is necessary during idle.
+
+### Option B: Short-circuit early — only manage deployment scale and status
+
+Check `spec.idle` early in Reconcile. If true, ensure Deployments are at 0
+replicas, update status, and return immediately without processing the rest.
+
+- **Pro:** Fast and cheap reconcile when idled — no unnecessary API calls.
+- **Pro:** Won't fail on unrelated issues (missing secrets, Route not ready)
+  when nothing is running.
+- **Con:** Spec changes made while idled aren't applied until unidle. The next
+  unidle reconcile will pick them up (since generation changed or field changed).
+- **Con:** Slightly more complex — two code paths in Reconcile.
+
+**Decision:** Option B — The idle state should be low-cost. Spec changes while
+idled are uncommon, and the full reconcile runs naturally on unidle.
+
+_Considered and rejected: Option A (wasteful — runs full pipeline for no-pod state, can fail on unrelated issues), Option C (most complex, marginal benefit over B since errors surface on unidle anyway)_
+
+---
+
+## Q2: What should the spec field be named?
+
+The AAP operator uses `idle_aap` (snake_case, product-specific). We need a
+field name that is idiomatic for a Kubernetes CRD and clear in intent.
+
+### Option A: `idle` (bool)
+
+```go
+Idle bool `json:"idle,omitempty"`
+```
+
+- **Pro:** Concise, clear intent. Matches the AAP pattern conceptually.
+- **Pro:** Easy for external systems to understand and use.
+- **Con:** Very generic — could theoretically conflict with future Kubernetes
+  conventions (unlikely).
+
+**Decision:** Option A (`idle`) — Concise, intuitive for external idling systems,
+trivial interaction contract (set `true` to idle, `false` to unidle).
+
+_Considered and rejected: Option B `suspended` (implies pause/resume semantics rather than stop/start), Option C `replicas` (over-engineered for single-replica design, invites misuse)_
+
+---
+
+## Q3: How should idle state be represented in status?
+
+The status needs to communicate that the instance is idle (not broken, not
+provisioning — intentionally stopped). Dashboards and external tools rely on
+status to determine what to show users.
+
+### Option C: Both — Idle condition + Ready adjusted
+
+Add the `Idle` condition AND set Ready to a specific state.
+```yaml
+conditions:
+  - type: Ready
+    status: "False"
+    reason: Idle
+  - type: Idle
+    status: "True"
+    reason: IdledByRequest
+```
+
+- **Pro:** Tools watching either condition get useful information.
+- **Pro:** Clear semantic separation.
+- **Con:** Slightly more status management code.
+
+**Decision:** Option C — Maximum compatibility. Tools watching Ready see it's not
+running; tools that understand the Idle condition can distinguish "intentionally
+stopped" from "broken."
+
+_Considered and rejected: Option A (Idle condition only — tools watching Ready wouldn't know why it's missing/stale), Option B (Ready reason only — conflates intentional idle with failures for tools that don't inspect reason)_
+
+---
+
+## Q4: What should the Ready condition report when idled?
+
+**Resolved by Q3.** The decision on Q3 (Option C) already specifies
+`Ready=False, reason=Idle` alongside the dedicated `Idle` condition. No
+additional decision needed.

--- a/internal/controller/claw_idle.go
+++ b/internal/controller/claw_idle.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
+)
+
+// handleIdle short-circuits the reconcile loop when spec.idle is true.
+// It scales all managed Deployments to zero replicas and updates status
+// to reflect the idled state.
+func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv1alpha1.Claw) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Instance is idled, scaling deployments to zero")
+
+	deploymentNames := []string{
+		getClawDeploymentName(instance.Name),
+		getProxyDeploymentName(instance.Name),
+		getDevicePairingDeploymentName(instance.Name),
+	}
+
+	for _, name := range deploymentNames {
+		if err := r.scaleDeploymentToZero(ctx, instance.Namespace, name); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to scale deployment %s to zero: %w", name, err)
+		}
+	}
+
+	setCondition(instance, clawv1alpha1.ConditionTypeIdle, metav1.ConditionTrue,
+		clawv1alpha1.ConditionReasonIdledByRequest, "Instance scaled to zero by spec.idle")
+	setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse,
+		clawv1alpha1.ConditionReasonIdle, "Instance is idled — set spec.idle to false to resume")
+	instance.Status.URL = ""
+
+	if err := r.Status().Update(ctx, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update status after idling: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// scaleDeploymentToZero patches a Deployment's replicas to 0.
+// Returns nil if the Deployment does not exist (NotFound).
+func (r *ClawResourceReconciler) scaleDeploymentToZero(ctx context.Context, namespace, name string) error {
+	logger := log.FromContext(ctx)
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Deployment not found during idle, skipping", "name", name)
+			return nil
+		}
+		return fmt.Errorf("failed to get deployment %s: %w", name, err)
+	}
+
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
+		return nil
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"replicas": 0,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal scale patch: %w", err)
+	}
+
+	if err := r.Patch(ctx, deployment, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		return fmt.Errorf("failed to patch deployment %s to zero replicas: %w", name, err)
+	}
+
+	logger.Info("Scaled deployment to zero", "name", name)
+	return nil
+}

--- a/internal/controller/claw_idle.go
+++ b/internal/controller/claw_idle.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,9 +47,20 @@ func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv
 	}
 
 	for _, name := range deploymentNames {
-		if err := r.scaleDeploymentToZero(ctx, instance.Namespace, name); err != nil {
+		if err := r.scaleDeploymentToZero(ctx, instance, name); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to scale deployment %s to zero: %w", name, err)
 		}
+	}
+
+	idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+	readyCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+	alreadyIdled := idleCond != nil && idleCond.Status == metav1.ConditionTrue &&
+		readyCond != nil && readyCond.Status == metav1.ConditionFalse &&
+		readyCond.Reason == clawv1alpha1.ConditionReasonIdle &&
+		instance.Status.URL == ""
+
+	if alreadyIdled {
+		return ctrl.Result{}, nil
 	}
 
 	setCondition(instance, clawv1alpha1.ConditionTypeIdle, metav1.ConditionTrue,
@@ -65,17 +77,23 @@ func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv
 }
 
 // scaleDeploymentToZero patches a Deployment's replicas to 0.
-// Returns nil if the Deployment does not exist (NotFound).
-func (r *ClawResourceReconciler) scaleDeploymentToZero(ctx context.Context, namespace, name string) error {
+// Returns nil if the Deployment does not exist (NotFound) or is not owned by
+// the given Claw instance (defensive guard against same-named Deployments).
+func (r *ClawResourceReconciler) scaleDeploymentToZero(ctx context.Context, instance *clawv1alpha1.Claw, name string) error {
 	logger := log.FromContext(ctx)
 
 	deployment := &appsv1.Deployment{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: name}, deployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Deployment not found during idle, skipping", "name", name)
 			return nil
 		}
 		return fmt.Errorf("failed to get deployment %s: %w", name, err)
+	}
+
+	if !metav1.IsControlledBy(deployment, instance) {
+		logger.Info("Deployment not owned by this Claw instance, skipping", "name", name)
+		return nil
 	}
 
 	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {

--- a/internal/controller/claw_idle_test.go
+++ b/internal/controller/claw_idle_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2026 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
+)
+
+func TestClawIdling(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should scale all deployments to zero when idle is set", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, testInstanceName, namespace)
+		reconciler := createClawReconciler()
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify deployments exist with replicas > 0
+		for _, name := range []string{
+			getClawDeploymentName(testInstanceName),
+			getProxyDeploymentName(testInstanceName),
+			getDevicePairingDeploymentName(testInstanceName),
+		} {
+			deployment := &appsv1.Deployment{}
+			waitFor(t, timeout, interval, func() bool {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment) == nil
+			}, name+" Deployment should be created")
+			require.NotNil(t, deployment.Spec.Replicas, "replicas should be set on %s", name)
+			assert.Equal(t, int32(1), *deployment.Spec.Replicas, "expected 1 replica on %s", name)
+		}
+
+		// Set idle
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// All deployments should be scaled to 0
+		for _, name := range []string{
+			getClawDeploymentName(testInstanceName),
+			getProxyDeploymentName(testInstanceName),
+			getDevicePairingDeploymentName(testInstanceName),
+		} {
+			deployment := &appsv1.Deployment{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
+			require.NotNil(t, deployment.Spec.Replicas, "replicas should be set on %s", name)
+			assert.Equal(t, int32(0), *deployment.Spec.Replicas, "expected 0 replicas on %s after idle", name)
+		}
+	})
+
+	t.Run("should set correct status conditions when idled", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, testInstanceName, namespace)
+		reconciler := createClawReconciler()
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify Ready=True before idling
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		readyCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+		// Set idle
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify status
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+
+		idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		require.NotNil(t, idleCond, "Idle condition should be present")
+		assert.Equal(t, metav1.ConditionTrue, idleCond.Status)
+		assert.Equal(t, clawv1alpha1.ConditionReasonIdledByRequest, idleCond.Reason)
+
+		readyCond = meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond, "Ready condition should be present")
+		assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
+		assert.Equal(t, clawv1alpha1.ConditionReasonIdle, readyCond.Reason)
+
+		assert.Empty(t, instance.Status.URL, "status.url should be cleared when idled")
+	})
+
+	t.Run("should restore normal operation on unidle", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, testInstanceName, namespace)
+		reconciler := createClawReconciler()
+
+		// Initial reconcile to create resources
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Idle
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify idled
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		require.NotNil(t, idleCond, "Idle condition should be present after idling")
+
+		// Unidle
+		instance.Spec.Idle = false
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify unidled: Idle condition removed
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		idleCond = meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		assert.Nil(t, idleCond, "Idle condition should be removed after unidle")
+
+		// Deployments should be back to replicas 1
+		for _, name := range []string{
+			getClawDeploymentName(testInstanceName),
+			getProxyDeploymentName(testInstanceName),
+			getDevicePairingDeploymentName(testInstanceName),
+		} {
+			deployment := &appsv1.Deployment{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
+			require.NotNil(t, deployment.Spec.Replicas, "replicas should be set on %s", name)
+			assert.Equal(t, int32(1), *deployment.Spec.Replicas, "expected 1 replica on %s after unidle", name)
+		}
+	})
+
+	t.Run("should be idempotent when already idled", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, testInstanceName, namespace)
+		reconciler := createClawReconciler()
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Idle
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Reconcile again while still idled — should succeed without errors
+		// Need to re-fetch since status was updated
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify still idled
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		require.NotNil(t, idleCond, "Idle condition should still be present")
+		assert.Equal(t, metav1.ConditionTrue, idleCond.Status)
+
+		for _, name := range []string{
+			getClawDeploymentName(testInstanceName),
+			getProxyDeploymentName(testInstanceName),
+			getDevicePairingDeploymentName(testInstanceName),
+		} {
+			deployment := &appsv1.Deployment{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
+			require.NotNil(t, deployment.Spec.Replicas, "replicas should be set on %s", name)
+			assert.Equal(t, int32(0), *deployment.Spec.Replicas, "expected 0 replicas on %s", name)
+		}
+	})
+
+	t.Run("should succeed when idled before deployments exist", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		// Create instance with idle already set
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = testInstanceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = testCredentials()
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+
+		// Reconcile should succeed (no deployments to scale, NotFound skipped)
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify status is set correctly
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+
+		idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		require.NotNil(t, idleCond, "Idle condition should be present")
+		assert.Equal(t, metav1.ConditionTrue, idleCond.Status)
+		assert.Equal(t, clawv1alpha1.ConditionReasonIdledByRequest, idleCond.Reason)
+
+		readyCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond, "Ready condition should be present")
+		assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
+		assert.Equal(t, clawv1alpha1.ConditionReasonIdle, readyCond.Reason)
+	})
+
+	t.Run("should complete full status transition Ready→Idle→Ready", func(t *testing.T) {
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, testInstanceName, namespace)
+		reconciler := createClawReconciler()
+
+		// Phase 1: Ready
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		readyCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionTrue, readyCond.Status, "should be Ready before idle")
+		assert.Nil(t, meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle),
+			"Idle condition should not exist when running")
+
+		// Phase 2: Idle
+		instance.Spec.Idle = true
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		readyCond = meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionFalse, readyCond.Status, "should not be Ready when idled")
+		assert.Equal(t, clawv1alpha1.ConditionReasonIdle, readyCond.Reason)
+		idleCond := meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		require.NotNil(t, idleCond)
+		assert.Equal(t, metav1.ConditionTrue, idleCond.Status)
+
+		// Phase 3: Unidle → Ready
+		instance.Spec.Idle = false
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))
+		readyCond = meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+		require.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionTrue, readyCond.Status, "should be Ready after unidle")
+		assert.Equal(t, clawv1alpha1.ConditionReasonReady, readyCond.Reason)
+		assert.Nil(t, meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle),
+			"Idle condition should be removed after unidle")
+	})
+}

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -405,6 +405,13 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// Short-circuit when idled — scale deployments to zero and return
+	if instance.Spec.Idle {
+		return r.handleIdle(ctx, instance)
+	}
+	// On unidle, remove stale Idle condition before full reconcile
+	meta.RemoveStatusCondition(&instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+
 	// Create or update the gateway Secret with token
 	if err := r.applyGatewaySecret(ctx, instance); err != nil {
 		logger.Error(err, "Failed to apply gateway secret")

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -409,8 +409,14 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if instance.Spec.Idle {
 		return r.handleIdle(ctx, instance)
 	}
-	// On unidle, remove stale Idle condition before full reconcile
-	meta.RemoveStatusCondition(&instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+	// On unidle, persist Idle condition removal so a partial reconcile failure
+	// cannot leave spec.idle=false with a stale Idle=True condition.
+	if meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle) != nil {
+		meta.RemoveStatusCondition(&instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
+		if err := r.Status().Update(ctx, instance); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to persist Idle condition removal: %w", err)
+		}
+	}
 
 	// Create or update the gateway Secret with token
 	if err := r.applyGatewaySecret(ctx, instance); err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1113,6 +1113,116 @@ spec:
 				"OPENCLAW_GATEWAY_PASSWORD should reference the correct key")
 		})
 
+		t.Run("should idle and unidle a Claw instance", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create Secret")
+
+			t.Log("applying the Claw CR")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				"config/samples/claw_v1alpha1_claw.yaml", "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready=True")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
+
+			t.Log("idling the instance via spec.idle patch")
+			cmd = exec.Command("kubectl", "patch", "claw", "instance",
+				"--type=merge", "-p", `{"spec":{"idle":true}}`,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to patch spec.idle to true")
+
+			t.Log("waiting for Idle=True condition")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Idle')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Idle condition did not become True")
+
+			t.Log("verifying Ready=False with reason Idle")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+				"-n", userNamespace)
+			readyStatus, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "False", readyStatus, "Ready should be False when idled")
+
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].reason}",
+				"-n", userNamespace)
+			readyReason, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "Idle", readyReason, "Ready reason should be Idle")
+
+			t.Log("verifying all pods are terminated")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods",
+						"-l", "claw.sandbox.redhat.com/instance=instance",
+						"-o", "jsonpath={.items}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && (output == "[]" || output == ""), nil
+				})
+			require.NoError(t, err, "Pods should be terminated after idling")
+
+			t.Log("unidling the instance")
+			cmd = exec.Command("kubectl", "patch", "claw", "instance",
+				"--type=merge", "-p", `{"spec":{"idle":false}}`,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to patch spec.idle to false")
+
+			t.Log("waiting for Claw Ready=True after unidle")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True after unidle")
+
+			t.Log("verifying Idle condition is removed")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.conditions[?(@.type=='Idle')].status}",
+				"-n", userNamespace)
+			idleStatus, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, idleStatus, "Idle condition should be absent after unidle")
+		})
+
 		t.Run("should proxy kubectl requests with kubernetes credential type", func(t *testing.T) {
 			const (
 				kubeWorkspace = "e2e-kube-workspace"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1184,6 +1184,14 @@ spec:
 			require.NoError(t, err)
 			assert.Equal(t, "Idle", readyReason, "Ready reason should be Idle")
 
+			t.Log("verifying status.url is cleared when idled")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.url}",
+				"-n", userNamespace)
+			urlOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, urlOutput, "status.url should be empty when idled")
+
 			t.Log("verifying all pods are terminated")
 			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
 				func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
- Add spec.idle boolean field to Claw CR for external idler integration
- Short-circuit reconcile when idled: scale deployments to zero, skip full pipeline (credentials, Kustomize, Route resolution)
- Set Idle=True and Ready=False/Idle conditions; clear status.url
- Remove Idle condition on unidle; full reconcile restores replicas
- Add envtest unit tests (idle, unidle, idempotency, pre-creation)
- Add e2e test covering idle/unidle lifecycle with pod termination
- Include design docs (idling-design.md, idling-questions.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claw instance idling: set spec.idle to pause the instance (scale managed deployments to zero) and unidle to restore; status reflects Idle/Ready transitions and clears the public URL while idled.

* **Documentation**
  * Added design and decision docs describing idling behavior, preserved resources, and status representation.

* **Tests**
  * Added unit and end-to-end tests validating idling, unidling, status transitions, and idempotent reconciles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->