### PR TITLE
chore: bump OpenClaw image to 2026.5.20-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.19-slim
+    newTag: 2026.5.20-slim


### PR DESCRIPTION
- Update ghcr.io/openclaw/openclaw tag from 2026.5.19-slim to 2026.5.20-slim
- No operator changes required: release contains internal gateway refactors, Discord voice features, Android app overhaul, CLI perf improvements, and channel-specific fixes with no integration surface changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the underlying service to a newer version with improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->