### PR TITLE
fix: mount PVC via subPath to avoid chmod EPERM on OpenShift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ reset-test-e2e: ## Remove leftover operator resources from a previous e2e run
 test-e2e: ## Run the e2e tests. Expected an isolated environment using Kind.
 	@trap '$(MAKE) cleanup-test-e2e >/dev/null 2>&1 || true' EXIT; \
 	$(MAKE) setup-test-e2e manifests generate fmt vet reset-test-e2e; \
-	KIND_CLUSTER=$(KIND_CLUSTER) go test -v -timeout 15m ./test/e2e/
+	KIND_BIN=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -v -timeout 15m ./test/e2e/
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -108,10 +108,10 @@ data:
         merged.agents.defaults.model = merged.agents.defaults.model || {};
         merged.agents.defaults.model.primary = savedPrimary;
       }
-      fs.writeFileSync(pvcPath, JSON.stringify(merged, null, 2));
+      fs.writeFileSync(pvcPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
       console.log("[init-config] merged operator.json into existing openclaw.json");
     } else {
-      fs.writeFileSync(pvcPath, JSON.stringify(deepMerge(seed, ops), null, 2));
+      fs.writeFileSync(pvcPath, JSON.stringify(deepMerge(seed, ops), null, 2), { mode: 0o600 });
       console.log(`[init-config] wrote openclaw.json (mode=${mode}, first_run=${!fs.existsSync(pvcPath)})`);
     }
 

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -21,6 +21,53 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
+        # --- init-volume: PVC subdirectory bootstrap ---
+        #
+        # On OpenShift, the restricted SCC assigns a UID from the namespace
+        # range (e.g. 1001970000) and drops all capabilities. PVC root
+        # directories are created by the storage provisioner as root:<fsGroup>,
+        # so the running user can write files (via group perms + setgid) but
+        # is NOT the owner.
+        #
+        # OpenClaw ≥ 2026.5.12 (commit b971ebaaab, PR #77907) added a
+        # chmodSync(stateDir, 0o700) call in exec-approvals.ts that runs
+        # before every shell command. Linux chmod requires euid == file owner
+        # or CAP_FOWNER — neither holds when the PVC root is owned by root
+        # and the container runs as a namespace-assigned UID. This causes
+        # every exec tool call to fail with EPERM.
+        #
+        # Fix: all containers mount the PVC via subPath ("home") instead of
+        # the raw root. This init container creates that subdirectory — owned
+        # by the running user — so chmod succeeds. Existing PVCs with data at
+        # the root need their PVC deleted and recreated (no auto-migration).
+        # The upstream community operator (openclaw-operator) mounts the PVC
+        # root directly and sets runAsUser/fsGroup to a fixed UID (1000),
+        # which works on vanilla Kubernetes but not on OpenShift where the
+        # SCC overrides the UID.
+        #
+        - name: init-volume
+          image: mirror.gcr.io/library/busybox:1.37
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - mkdir -p /mnt/pvc/home
+          resources:
+            requests:
+              memory: 16Mi
+              cpu: 10m
+            limits:
+              memory: 32Mi
+              cpu: 50m
+          volumeMounts:
+            - name: claw-home
+              mountPath: /mnt/pvc
         - name: init-config
           image: ghcr.io/openclaw/openclaw:slim
           imagePullPolicy: IfNotPresent
@@ -45,6 +92,7 @@ spec:
           volumeMounts:
             - name: claw-home
               mountPath: /home/node/.openclaw
+              subPath: home
             - name: config
               mountPath: /config
         - name: wait-for-proxy
@@ -189,15 +237,16 @@ spec:
           volumeMounts:
             - name: claw-home
               mountPath: /home/node/.openclaw
+              subPath: home
             - name: claw-home
               mountPath: /home/node/.local
-              subPath: .local
+              subPath: home/.local
             - name: claw-home
               mountPath: /home/node/.cache
-              subPath: .cache
+              subPath: home/.cache
             - name: claw-home
               mountPath: /home/node/.config
-              subPath: .config
+              subPath: home/.config
             - name: tmp-volume
               mountPath: /tmp
             - name: proxy-ca

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -p /mnt/pvc/home
+            - mkdir -p -m 0777 /mnt/pvc/home
           resources:
             requests:
               memory: 16Mi

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -40,13 +40,14 @@ spec:
         # the raw root. This init container creates that subdirectory — owned
         # by the running user — so chmod succeeds. Existing PVCs with data at
         # the root need their PVC deleted and recreated (no auto-migration).
-        # The upstream community operator (openclaw-operator) mounts the PVC
-        # root directly and sets runAsUser/fsGroup to a fixed UID (1000),
-        # which works on vanilla Kubernetes but not on OpenShift where the
-        # SCC overrides the UID.
+        #
+        # The init-volume container uses the same OpenClaw image as gateway so
+        # that it runs as the same UID on both OpenShift (namespace-assigned)
+        # and vanilla Kubernetes (image default 1000), keeping the 0700 dir
+        # accessible to all subsequent containers without world-writable bits.
         #
         - name: init-volume
-          image: mirror.gcr.io/library/busybox:1.37
+          image: ghcr.io/openclaw/openclaw:slim
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -57,7 +58,7 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -p -m 0777 /mnt/pvc/home
+            - mkdir -p -m 0700 /mnt/pvc/home
           resources:
             requests:
               memory: 16Mi

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -1002,6 +1002,70 @@ func TestConfigureGatewayForMcpServers(t *testing.T) {
 	})
 }
 
+// --- PVC volume mount safety tests ---
+
+func TestClawHomePVCMountsUseSubPath(t *testing.T) {
+	expectedSubPaths := map[string]string{
+		"/home/node/.openclaw": "home",
+		"/home/node/.local":    "home/.local",
+		"/home/node/.cache":    "home/.cache",
+		"/home/node/.config":   "home/.config",
+	}
+
+	reconciler := createClawReconciler()
+	instance := testClawWithCredentials(testCredentials())
+	objects, err := reconciler.buildKustomizedObjects(instance)
+	require.NoError(t, err)
+
+	gatewayName := getClawDeploymentName(testInstanceName)
+	var gatewayDep *unstructured.Unstructured
+	for _, obj := range objects {
+		if obj.GetKind() == DeploymentKind && obj.GetName() == gatewayName {
+			gatewayDep = obj
+			break
+		}
+	}
+	require.NotNil(t, gatewayDep, "gateway deployment should exist in rendered manifests")
+
+	seen := make(map[string]bool)
+	for _, containerPath := range [][]string{
+		{"spec", "template", "spec", "containers"},
+		{"spec", "template", "spec", "initContainers"},
+	} {
+		containers, _, err := unstructured.NestedSlice(gatewayDep.Object, containerPath...)
+		require.NoError(t, err)
+
+		for _, c := range containers {
+			container := c.(map[string]any)
+			name, _, _ := unstructured.NestedString(container, "name")
+			if name == "init-volume" {
+				continue // init-volume intentionally mounts the raw PVC root
+			}
+			mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
+			for _, m := range mounts {
+				mount := m.(map[string]any)
+				if mount["name"] != "claw-home" {
+					continue
+				}
+				mountPath, _ := mount["mountPath"].(string)
+				subPath, _ := mount["subPath"].(string)
+				expected, known := expectedSubPaths[mountPath]
+				require.True(t, known,
+					"container %q: unexpected claw-home mount at %s", name, mountPath)
+				assert.Equal(t, expected, subPath,
+					"container %q: claw-home mount at %s must use correct subPath",
+					name, mountPath)
+				seen[mountPath] = true
+			}
+		}
+	}
+
+	for mountPath := range expectedSubPaths {
+		assert.True(t, seen[mountPath],
+			"expected claw-home mount at %s not found in any container", mountPath)
+	}
+}
+
 func TestMcpAnnotationKey(t *testing.T) {
 	t.Run("should produce valid annotation key segment", func(t *testing.T) {
 		key := mcpAnnotationKey("my-server", "MY_VAR")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -74,7 +74,9 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "manager image setup failed: %v\n", err)
 		os.Exit(1)
 	}
-	if err := buildAndLoadImage("proxy", "container-build-proxy", "PROXY_IMG", proxyImage, kindBin, kindCluster); err != nil {
+	err := buildAndLoadImage("proxy", "container-build-proxy",
+		"PROXY_IMG", proxyImage, kindBin, kindCluster)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "proxy image setup failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -61,21 +61,25 @@ func TestMain(m *testing.M) {
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		kindCluster = v
 	}
+	kindBin := "kind"
+	if v, ok := os.LookupEnv("KIND_BIN"); ok {
+		kindBin = v
+	}
 
 	// Build, save, and load the manager and proxy images into Kind.
 	// Images are saved to tar first because podman and kind do not work well
 	// together when loading from a docker registry.
 	// See https://github.com/kubernetes-sigs/kind/issues/2038
-	if err := buildAndLoadImage("manager", "container-build", "IMG", projectImage, kindCluster); err != nil {
+	if err := buildAndLoadImage("manager", "container-build", "IMG", projectImage, kindBin, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "manager image setup failed: %v\n", err)
 		os.Exit(1)
 	}
-	if err := buildAndLoadImage("proxy", "container-build-proxy", "PROXY_IMG", proxyImage, kindCluster); err != nil {
+	if err := buildAndLoadImage("proxy", "container-build-proxy", "PROXY_IMG", proxyImage, kindBin, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "proxy image setup failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := pullAndLoadImage(gatewayImage, kindCluster); err != nil {
+	if err := pullAndLoadImage(gatewayImage, kindBin, kindCluster); err != nil {
 		fmt.Fprintf(os.Stderr, "gateway image setup failed: %v\n", err)
 		os.Exit(1)
 	}
@@ -115,7 +119,7 @@ func TestMain(m *testing.M) {
 // a Kind cluster. label is a human-readable name for log messages, buildTarget
 // is the make target (e.g. "container-build"), imgVar is the make variable that
 // receives the image name (e.g. "IMG" or "PROXY_IMG").
-func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) error {
+func buildAndLoadImage(label, buildTarget, imgVar, image, kindBin, kindCluster string) error {
 	tarFile := fmt.Sprintf("tmp/%s.tar", label)
 
 	fmt.Printf("Building %s image...\n", label)
@@ -129,7 +133,7 @@ func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) er
 		fmt.Sprintf("OUTPUT_FILE=%s", tarFile)); err != nil {
 		return fmt.Errorf("save %s image: %w", label, err)
 	}
-	if err := runStreaming("kind", "load", "image-archive", tarFile,
+	if err := runStreaming(kindBin, "load", "image-archive", tarFile,
 		"--name", kindCluster); err != nil {
 		return fmt.Errorf("load %s image into Kind: %w", label, err)
 	}
@@ -137,7 +141,7 @@ func buildAndLoadImage(label, buildTarget, imgVar, image, kindCluster string) er
 }
 
 // pullAndLoadImage pulls a public container image and loads it into Kind.
-func pullAndLoadImage(image, kindCluster string) error {
+func pullAndLoadImage(image, kindBin, kindCluster string) error {
 	tarFile := fmt.Sprintf("tmp/%s.tar", strings.ReplaceAll(
 		strings.ReplaceAll(image, "/", "_"), ":", "_"))
 
@@ -152,7 +156,7 @@ func pullAndLoadImage(image, kindCluster string) error {
 	if err := runStreaming("podman", "save", "-o", tarFile, image); err != nil {
 		return fmt.Errorf("save %s: %w", image, err)
 	}
-	if err := runStreaming("kind", "load", "image-archive", tarFile,
+	if err := runStreaming(kindBin, "load", "image-archive", tarFile,
 		"--name", kindCluster); err != nil {
 		return fmt.Errorf("load %s into Kind: %w", image, err)
 	}


### PR DESCRIPTION
OpenClaw ≥ 2026.5.12 chmods ~/.openclaw to 0700 before every exec tool call. On OpenShift the restricted SCC assigns a namespace UID while the PVC root directory is owned by root, so chmod fails with EPERM and every shell command is broken.

- Add init-volume init container that creates a user-owned "home/" subdirectory inside the PVC
- Mount all claw-home volumes via subPath ("home") so the mount point is owned by the running user, not by root
- Add TestClawHomePVCMountsUseSubPath to guard against regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an init container that prepares a PVC-backed shared home directory before app containers start.

* **Refactor**
  * Standardized user home mounts to consistently target subdirectories (home, .local, .cache, .config).
  * Hardened init container security posture (reduced privileges, read-only root, dropped capabilities).

* **Tests**
  * Added a unit test verifying home volume mounts use expected subPath mappings.

* **Chores**
  * Made end-to-end test runner configurable to use a specified Kind binary and ensured the Makefile passes it to tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->