### PR TITLE
fix: stop force-disabling cron in operator-managed config

### DIFF
--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -22,8 +22,7 @@ data:
       },
       "models": {
         "providers": {}
-      },
-      "cron": { "enabled": false }
+      }
     }
   openclaw.json: |
     {
@@ -184,6 +183,11 @@ data:
       reconciles the CR into Deployments, ConfigMaps, Secrets, NetworkPolicies, and
       Routes. Non-operator-managed config (custom plugins, agent settings, tools) is
       managed separately via `openclaw config patch` on the PVC.
+    - **Do NOT invent Claw CR fields.** Only reference `spec.*` fields that are
+      explicitly documented in this skill. If a setting is not mentioned here, it is
+      not a CR field — do not suggest CR changes for it. When unsure, say you don't
+      know rather than guessing. The operator source is at
+      https://github.com/codeready-toolchain/claw-operator for reference.
     - **Important:** Each `oc apply` of the Claw CR **replaces** the entire `credentials`
       list. The user must include all existing credentials when applying — otherwise they
       will be removed. Retrieve the current state first:


### PR DESCRIPTION
- Remove `"cron": { "enabled": false }` from operator.json so users can enable scheduled tasks via `openclaw config patch`
- Add guardrail to PLATFORM.md telling the LLM not to fabricate Claw CR fields that aren't documented in the skill
- Link to the operator GitHub repo for reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified best practices for configuration, specifying which fields are customizable and directing users to official documentation for complete reference.

* **Chores**
  * Simplified configuration by removing unnecessary settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->