### PR TITLE
feat: bypass proxy for cluster-internal service traffic

### DIFF
--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -173,6 +173,9 @@ spec:
               value: http://CLAW_INSTANCE_NAME-proxy:8080
             - name: https_proxy
               value: http://CLAW_INSTANCE_NAME-proxy:8080
+            # Cluster-internal traffic bypasses the MITM proxy.
+            # Assumes a NetworkPolicy exists to control which namespaces accept
+            # ingress from this pod (managed outside the operator).
             - name: NO_PROXY
               value: localhost,127.0.0.1,CLAW_INSTANCE_NAME-proxy,.svc,.svc.cluster.local
             - name: no_proxy

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -174,9 +174,9 @@ spec:
             - name: https_proxy
               value: http://CLAW_INSTANCE_NAME-proxy:8080
             - name: NO_PROXY
-              value: localhost,127.0.0.1,CLAW_INSTANCE_NAME-proxy
+              value: localhost,127.0.0.1,CLAW_INSTANCE_NAME-proxy,.svc,.svc.cluster.local
             - name: no_proxy
-              value: localhost,127.0.0.1,CLAW_INSTANCE_NAME-proxy
+              value: localhost,127.0.0.1,CLAW_INSTANCE_NAME-proxy,.svc,.svc.cluster.local
             - name: NODE_USE_ENV_PROXY
               value: "1"
             - name: NPM_CONFIG_CACHE


### PR DESCRIPTION
- Add .svc and .svc.cluster.local to NO_PROXY/no_proxy on the gateway container so MCP servers and tools can reach services in the user's -dev namespace without the MITM proxy blocking them
- NetworkPolicy on the -dev side remains the access control boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated proxy bypass configuration to include localhost, loopback IPs and Kubernetes service DNS suffixes, plus instance proxy entries — improving connectivity and reliability for local and in-cluster service interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->