### PR TITLE
chore: bump OpenClaw image to 2026.5.22-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.20-slim
+    newTag: 2026.5.22-slim

--- a/internal/controller/claw_models.go
+++ b/internal/controller/claw_models.go
@@ -31,13 +31,12 @@ var modelCatalog = map[string][]modelEntry{
 	"google": {
 		{Name: "gemini-3-flash-preview", Alias: "Gemini 3 Flash"},
 		{Name: "gemini-3.1-pro-preview", Alias: "Gemini 3.1 Pro"},
-		{Name: "gemini-3.1-flash-lite-preview", Alias: "Gemini 3.1 Flash Lite"},
+		{Name: "gemini-3.1-flash-lite", Alias: "Gemini 3.1 Flash Lite"},
 	},
 	"anthropic": {
 		{Name: "claude-sonnet-4-6", Alias: "Claude Sonnet 4.6"},
 		{Name: "claude-opus-4-7", Alias: "Claude Opus 4.7"},
 		{Name: "claude-opus-4-6", Alias: "Claude Opus 4.6"},
-		{Name: "claude-haiku-4-5", Alias: "Claude Haiku 4.5"},
 	},
 	"openai": {
 		{Name: "gpt-5.4", Alias: "GPT-5.4"},


### PR DESCRIPTION
- Update image tag from 2026.5.20-slim to 2026.5.22-slim
- Remove retired claude-haiku-4-5 from model catalog (upstream redirects haiku family to claude-sonnet-4-6)
- Use canonical gemini-3.1-flash-lite model name instead of deprecated -preview alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 3.1 Flash Lite model to enhance available AI provider options and provide users with additional model selections.

* **Chores**
  * Updated container image to latest version for enhanced stability, performance, and security improvements.
  * Removed Claude Haiku 4.5 model from available AI provider options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->