### PR TITLE
docs: add spec.config design proposal and questions

### DIFF
--- a/docs/proposals/spec-config-design.md
+++ b/docs/proposals/spec-config-design.md
@@ -1,0 +1,415 @@
+# Design: `spec.config` — User-Provided OpenClaw Configuration
+
+**Status:** Final — all decisions resolved in
+[spec-config-questions.md](spec-config-questions.md)
+
+---
+
+## Overview
+
+Add a `spec.config` field to the Claw CRD that accepts arbitrary OpenClaw
+configuration (model settings, CORS origins, diagnostics, agent defaults, etc.)
+without requiring per-feature typed CRD fields.
+
+This addresses multiple known gaps: model registration, CORS origins,
+diagnostics/OTEL configuration, and future OpenClaw features — all through a
+single architectural change.
+
+The `spec.config.raw` + enrichment pipeline pattern is well-established in
+similar Kubernetes operators and Helm charts for opinionated applications.
+
+## Design Principles
+
+1. **Typed fields for Kubernetes side effects** — credentials, auth, MCP
+   servers, and anything that drives proxy config, NetworkPolicies, Secrets, or
+   init container behavior stays as typed CRD fields.
+
+2. **Raw config for OpenClaw application settings** — model preferences, CORS
+   extras, diagnostics, agent defaults, session config, and any other
+   `openclaw.json` key goes through `spec.config`.
+
+3. **Backward compatible** — existing CRs without `spec.config` must produce
+   identical behavior to today. The enrichment pipeline produces the same
+   `operator.json` when no user config is provided.
+
+4. **Operator infra works OOTB, user extends** — operator-managed
+   infrastructure (gateway networking, proxy routing, auth, channel wiring)
+   always works out of the box, regardless of what the user sets in
+   `spec.config`. User config *adds to* operator infra, never silently
+   disables it. This means:
+
+   - **Always-win keys**: Driven by typed CRD fields (`spec.auth`,
+     `spec.credentials`, `spec.mcpServers`, `spec.webSearch`). The operator
+     sets these unconditionally — user config cannot override them.
+   - **Append/merge keys**: Operator always provides its part, user *adds*
+     on top. Example: CORS `allowedOrigins` always includes the Route host;
+     user entries are appended. Model catalog always includes auto-discovered
+     models from credentials; user entries are merged in and win on collision.
+   - **User-only keys**: Keys the operator never touches (`diagnostics.*`,
+     `session.*`, `logging.*`, etc.). User fully owns these.
+
+5. **Merge semantics preserved** — `merge.js` and `spec.config.mergeMode`
+   continue to control how `operator.json` is applied to the PVC at pod start.
+   The change is in what goes into `operator.json`, not how `operator.json` is
+   applied to the PVC.
+
+## Architecture
+
+### Current flow (no `spec.config`)
+
+```
+Static operator.json template in configmap.yaml
+        ↓
+Kustomize build (template replacement, label injection)
+        ↓
+Enrichment pipeline (7 operator.json injections, all unconditional)
+        ↓
+operator.json in ConfigMap (only operator-managed keys)
+        ↓
+Init: merge.js deepMerge(PVC, operator.json) → PVC openclaw.json
+        ↓
+OpenClaw reads PVC openclaw.json
+```
+
+### New flow (with `spec.config`)
+
+```
+Kustomize build (same as today)
+        ↓
+Extract operator.json from ConfigMap in Kustomize output
+        ↓
+Deep-merge user's spec.config.raw INTO operator.json template
+  (user keys win over template defaults)
+        ↓
+Enrichment pipeline (three-tier behavior on the merged config)
+        ↓
+Write enriched operator.json back into ConfigMap
+        ↓
+Init: merge.js deepMerge(PVC, operator.json) → PVC openclaw.json
+        ↓
+OpenClaw reads PVC openclaw.json
+```
+
+The key change: after Kustomize produces the ConfigMap, `operator.json` is
+extracted and the user's raw config is deep-merged into it (user wins on
+collision). Then the enrichment pipeline applies the three-tier model —
+always-win keys are set back unconditionally, append keys combine user and
+operator values, user-only keys pass through untouched.
+
+### ConfigMap structure (unchanged)
+
+```yaml
+data:
+  operator.json: |
+    { ... user config + operator enrichment ... }
+  openclaw.json: |
+    { ... seed: agents.list, workspace defaults ... }
+  merge.js: |
+    ...
+  AGENTS.md: |
+    ...
+  PLATFORM.md: |
+    ...
+```
+
+The two-file model (`operator.json` + `openclaw.json` seed) is preserved.
+`operator.json` now contains both user and operator keys. The seed
+`openclaw.json` continues to provide first-run defaults for `agents.list` and
+`agents.defaults.workspace` — it is unchanged regardless of `spec.config`.
+
+## CRD Changes
+
+### New types
+
+```go
+// ConfigSpec defines user-provided OpenClaw configuration.
+type ConfigSpec struct {
+    // Raw is inline openclaw.json configuration as arbitrary JSON.
+    // Keys set here are merged into operator.json before the enrichment
+    // pipeline runs. User-set keys take precedence over operator defaults
+    // for non-security-critical settings.
+    // +kubebuilder:pruning:PreserveUnknownFields
+    // +optional
+    Raw *RawConfig `json:"raw,omitempty"`
+
+    // MergeMode controls how operator config is applied on pod start.
+    // "merge" (default) deep-merges operator settings into the existing
+    // user config, preserving user-owned keys. "overwrite" fully replaces
+    // the config on every pod start.
+    // +optional
+    // +kubebuilder:validation:Enum=merge;overwrite
+    // +kubebuilder:default=merge
+    MergeMode ConfigMode `json:"mergeMode,omitempty"`
+}
+
+// RawConfig holds arbitrary JSON configuration for openclaw.json.
+// +kubebuilder:pruning:PreserveUnknownFields
+type RawConfig struct {
+    runtime.RawExtension `json:",inline"`
+}
+```
+
+### Updated ClawSpec
+
+`spec.configMode` moves into `spec.config.mergeMode`. The top-level
+`configMode` field is removed.
+
+```go
+type ClawSpec struct {
+    // Config provides user-supplied OpenClaw configuration and merge behavior.
+    // +optional
+    Config *ConfigSpec `json:"config,omitempty"`
+
+    Auth        *AuthSpec                `json:"auth,omitempty"`
+    Credentials []CredentialSpec         `json:"credentials,omitempty"`
+    McpServers  map[string]McpServerSpec `json:"mcpServers,omitempty"`
+    WebSearch   *WebSearchSpec           `json:"webSearch,omitempty"`
+    WebFetch    *WebFetchSpec            `json:"webFetch,omitempty"`
+    Idle        bool                     `json:"idle,omitempty"`
+}
+```
+
+### Example CR
+
+```yaml
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: my-claw
+spec:
+  credentials:
+    - name: google
+      provider: google
+      type: apiKey
+      secretRef:
+        - name: gemini-key
+          key: api-key
+  config:
+    mergeMode: merge
+    raw:
+      agents:
+        defaults:
+          model:
+            primary: google/gemini-3-flash-preview
+          models:
+            openrouter/qwen3-14b:
+              alias: Qwen 3 14B
+      gateway:
+        controlUi:
+          allowedOrigins:
+            - "https://custom.example.com"
+      diagnostics:
+        otel:
+          enabled: true
+          endpoint: http://langfuse.observability.svc:3000/api/public/otel/v1/traces
+          captureContent:
+            inputMessages: true
+            outputMessages: true
+      plugins:
+        entries:
+          diagnostics-otel:
+            enabled: true
+```
+
+## Enrichment Pipeline
+
+### Current injection functions (all unconditional)
+
+Seven functions modify `operator.json`. Additionally, `injectKubernetesSkill`
+writes a `KUBERNETES.md` key to the ConfigMap, `injectKubePortsIntoNetworkPolicy`
+modifies the NetworkPolicy, and `stampGatewayConfigHash` stamps a deployment
+annotation — these three are unaffected by `spec.config`.
+
+| # | Function | Keys managed | File |
+|---|----------|--------------|------|
+| 1 | `injectRouteHostIntoConfigMap` | `gateway.controlUi.allowedOrigins` | `claw_resource_controller.go` |
+| 2 | `injectAuthModeIntoConfigMap` | `gateway.auth.*`, `gateway.controlUi.dangerouslyDisableDeviceAuth` | `claw_auth.go` |
+| 3 | `injectProvidersIntoConfigMap` | `models.providers` | `claw_resource_controller.go` |
+| 4 | `injectModelCatalogIntoConfigMap` | `agents.defaults.models`, `agents.defaults.model.primary` | `claw_resource_controller.go` |
+| 5 | `injectChannelsIntoConfigMap` | `channels.*`, `plugins.entries.<channel>` | `claw_channels.go` |
+| 6 | `injectMcpServersIntoConfigMap` | `mcp.servers` | `claw_mcp.go` |
+| 7 | `injectWebSearchIntoConfigMap` | `tools.web.*`, `plugins.entries.<search>` | `claw_web_search.go` |
+
+Note: `gateway.mode`, `gateway.bind`, `gateway.port`, `gateway.controlUi.enabled`,
+and `gateway.trustedProxies` currently have **no enrichment function** — they
+come only from the static template in `configmap.yaml`. Without `spec.config`
+this is fine (no user config to conflict). With `spec.config`, the enrichment
+pipeline must explicitly enforce these values (see proposed changes below).
+
+### Three-tier enrichment behavior
+
+| Key | Tier | Change needed |
+|-----|------|---------------|
+| `gateway.mode`, `gateway.bind`, `gateway.port` | Always-win | **New:** explicit set after merge (currently template-only) |
+| `gateway.controlUi.enabled` | Always-win | **New:** explicit set after merge (currently template-only) |
+| `gateway.auth.*` | Always-win | **Modify:** `injectAuthModeIntoConfigMap` must become unconditional — currently skips when auth is nil/token mode, leaving user-set values intact |
+| `gateway.controlUi.dangerouslyDisableDeviceAuth` | Always-win | Covered by auth function above |
+| `models.providers` | Always-win | No change — already unconditional |
+| `channels.*` | Always-win | No change — already unconditional |
+| `plugins.entries.<channel>` | Always-win | No change — operator entries are merged into `plugins.entries`, user-managed plugin entries for non-declared keys are preserved (see note below) |
+| `plugins.entries.<search>` | Always-win | No change — same merge behavior as channels |
+| `mcp.servers` | Always-win | No change — already unconditional |
+| `tools.web.*` | Always-win | No change — already unconditional |
+| `gateway.controlUi.allowedOrigins` | Append | **Modify:** `injectRouteHostIntoConfigMap` must change from string replacement of `OPENCLAW_ROUTE_HOST` placeholder to JSON-level array append |
+| `gateway.trustedProxies` | Append | **New:** append RFC1918 ranges to user's list (currently template-only) |
+| `agents.defaults.models` | Merge | **Modify:** `injectModelCatalogIntoConfigMap` must change from full overwrite to merge — catalog entries are added, user entries win on collision |
+| `agents.defaults.model.primary` | Merge | **Modify:** user value wins over catalog default; PVC runtime choice wins over both (via `merge.js` primary preservation) |
+| Everything else | User-only | No change — operator doesn't touch these keys |
+
+**`plugins.entries` split ownership:** The `plugins.entries` object is shared.
+Operator-declared entries (from channels and search) are always written by
+their respective functions. User-managed entries (for non-declared plugins) are
+preserved because the current functions merge into the existing entries map
+rather than replacing it. This behavior must be maintained.
+
+### Implementation patterns
+
+**Always-win** — unconditionally set the value, overriding any user config:
+
+```go
+gateway := ensureNestedMap(config, "gateway")
+gateway["mode"] = "local"
+gateway["bind"] = "lan"
+gateway["port"] = int64(18789)
+ensureNestedMap(gateway, "controlUi")["enabled"] = true
+
+// Auth: always set based on spec.auth, even when nil/default
+gateway["auth"] = map[string]any{"mode": resolvedAuthMode}
+```
+
+**Append** — read existing user entries, append operator entries, deduplicate:
+
+```go
+origins := getStringSlice(config, "gateway", "controlUi", "allowedOrigins")
+origins = appendIfMissing(origins, routeHost)
+setNestedValue(config, origins, "gateway", "controlUi", "allowedOrigins")
+```
+
+**Merge** — deep-merge operator catalog into user's models; user wins on
+collision:
+
+```go
+userModels := getUserModels(config)
+for key, entry := range catalogModels {
+    if _, exists := userModels[key]; !exists {
+        userModels[key] = entry
+    }
+}
+// Primary: user value from spec.config.raw wins over catalog default
+if getUserPrimary(config) == "" {
+    setPrimary(config, catalogDefault)
+}
+```
+
+## Config Resolution Flow
+
+```
+1. Kustomize build (unchanged — produces ConfigMap with static template)
+
+2. Extract operator.json from the ConfigMap in Kustomize output
+   Parse as map[string]any
+
+3. Resolve user config:
+   - If spec.config.raw set → parse raw bytes as map[string]any
+   - Else → empty {}
+
+4. Deep-merge user config INTO operator.json template
+   (user keys win over template defaults)
+
+5. Run enrichment pipeline on the merged config
+   (three-tier behavior: always-win / append / user-only)
+
+6. Marshal result, write back as operator.json in the ConfigMap
+
+7. At pod start: merge.js deepMerge(PVC, operator.json) as before
+```
+
+### Config precedence (three layers)
+
+When `merge.js` runs at pod start, the final config has three layers of
+precedence:
+
+1. **PVC runtime state** (highest) — user changes via UI, `config.patch`,
+   or plugin installs. Preserved by `merge.js` for keys not in `operator.json`.
+   The user's runtime primary model choice wins over everything (via the
+   `savedPrimary` logic in `merge.js`).
+2. **`operator.json`** — contains operator-managed keys (always-win tier) plus
+   user keys from `spec.config.raw` (append/merge/user-only tiers). Wins over
+   PVC for matching keys (except primary model).
+3. **`openclaw.json` seed** (lowest) — first-run defaults for `agents.list` and
+   `agents.defaults.workspace`. Used only when no PVC file exists yet.
+
+### Backward compatibility
+
+When `spec.config` is nil (existing CRs):
+- User config = `{}`
+- Deep-merge into template = template unchanged
+- Enrichment pipeline = same behavior as today (no user keys to skip for)
+- Result = identical `operator.json` to current behavior
+
+When `spec.config.mergeMode` is not set, it defaults to `merge` (same default
+as the current `spec.configMode`).
+
+### Nil-safety for `spec.config` access
+
+Code that currently reads `instance.Spec.ConfigMode` must handle the case
+where `spec.config` is nil (the common case for existing CRs):
+
+```go
+func getMergeMode(spec clawv1alpha1.ClawSpec) clawv1alpha1.ConfigMode {
+    if spec.Config != nil && spec.Config.MergeMode != "" {
+        return spec.Config.MergeMode
+    }
+    return clawv1alpha1.ConfigModeMerge
+}
+```
+
+## Controller Changes
+
+### `enrichConfigAndNetworkPolicy` refactor
+
+The function currently operates on `[]*unstructured.Unstructured` (Kustomize
+objects), finding the ConfigMap by name and parsing/re-parsing `operator.json`
+in every injection function. With `spec.config`, the flow becomes:
+
+1. **After Kustomize build**: extract `operator.json` from the ConfigMap,
+   parse it, merge user config, run enrichment on a single `map[string]any`
+2. **Write back**: marshal the enriched config and replace the `operator.json`
+   key in the Kustomize output
+3. **Skip per-function ConfigMap lookup**: each injection function operates on
+   the shared `map[string]any` instead of hunting through Kustomize objects
+
+This is a refactor of the injection functions' signatures **and** their logic.
+The table below lists every function that needs changes:
+
+### Function-by-function changes
+
+| Function | Current behavior | Required change |
+|----------|-----------------|-----------------|
+| `injectRouteHostIntoConfigMap` | String replacement of `OPENCLAW_ROUTE_HOST` placeholder in raw JSON | Rewrite to JSON-level array append: read `allowedOrigins` array from config, append Route host if missing, write back. Must work when user has already set origins in `spec.config.raw` (placeholder may not be present). |
+| `injectAuthModeIntoConfigMap` | Conditional — skips when `spec.auth` is nil and default pairing is used | Make unconditional: always write `gateway.auth.mode` (token or password) and `dangerouslyDisableDeviceAuth` (true or false) to enforce always-win. Currently, if user sets `gateway.auth.mode: "password"` in `spec.config.raw` but `spec.auth` is nil, the function skips and the user's value persists. |
+| `injectProvidersIntoConfigMap` | Unconditional overwrite of `models.providers` | Signature change only (accept `map[string]any`). Logic unchanged. |
+| `injectModelCatalogIntoConfigMap` | Unconditional overwrite of `agents.defaults.models` and `agents.defaults.model.primary` | Change to merge: iterate catalog entries, skip keys the user already set. For primary: only set catalog default when user didn't provide one in `spec.config.raw`. |
+| `injectChannelsIntoConfigMap` | Unconditional write of `channels.*`, merges into `plugins.entries` | Signature change only. Must continue merging into existing `plugins.entries` (not replacing) to preserve user-managed plugin entries. |
+| `injectMcpServersIntoConfigMap` | Unconditional write of `mcp.servers` | Signature change only. Logic unchanged. |
+| `injectWebSearchIntoConfigMap` | Unconditional write of `tools.web.*`, merges into `plugins.entries` | Signature change only. Same `plugins.entries` merge behavior as channels. |
+| **(new)** infrastructure keys | Not currently implemented — values come from static template only | New enrichment step: unconditionally set `gateway.mode`, `gateway.bind`, `gateway.port`, `gateway.controlUi.enabled` to their required values. Without this, user config could override these infrastructure constants. |
+| **(new)** trusted proxies | Not currently implemented — RFC1918 ranges come from static template only | New enrichment step: read user's `gateway.trustedProxies` (if any), append RFC1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`), deduplicate. |
+
+The model catalog remains hardcoded in `claw_models.go` — `spec.config.raw`
+provides the per-deployment escape hatch.
+
+## Decisions Summary
+
+All decisions from [spec-config-questions.md](spec-config-questions.md):
+
+| # | Question | Decision |
+|---|----------|----------|
+| Q1 | Where does user config go? | Merged into `operator.json` |
+| Q2 | `configMode` placement | Moves to `spec.config.mergeMode` |
+| Q3 | Enrichment key policies | Three-tier: always-win / append-merge / user-only |
+| Q4 | CORS enrichment | Append Route host to user's list |
+| Q5 | Model catalog interaction | Merge — catalog always present, user wins on collision |
+| Q6 | `configMapRef` | Not implemented; only `raw` for now |
+| Q7 | Seed behavior | Unchanged — seed stays as first-run fallback |
+| Q8 | Model catalog storage | Hardcoded in Go; `spec.config.raw` is the escape hatch |

--- a/docs/proposals/spec-config-questions.md
+++ b/docs/proposals/spec-config-questions.md
@@ -1,0 +1,261 @@
+# Design Questions: `spec.config`
+
+**Status:** Final — all 8 decisions resolved
+**Related:** [Design document](spec-config-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them
+one by one to form the design, then update the design document.
+
+---
+
+## Q1: Where does user config get injected?
+
+User-provided config from `spec.config.raw` needs to end up in the gateway's
+ConfigMap. Currently the ConfigMap has two config files: `operator.json`
+(operator-managed, enriched at reconcile time) and `openclaw.json` (seed for
+first run). The question is where user config fits in this two-file model.
+
+### Option A: Merge user config into `operator.json`
+
+User config is deep-merged into `operator.json` before the enrichment pipeline
+runs. `operator.json` then contains both user keys and operator keys.
+
+- **Pro:** Minimal structural change — ConfigMap keeps two files, `merge.js`
+  unchanged. User keys in `operator.json` "win" on restart (same as operator
+  keys today), which is the correct behavior for CR-declared config.
+- **Pro:** Enrichment functions can check "did the user set this key?" by
+  inspecting the config map after the user merge but before their injection.
+- **Con:** `operator.json` is no longer purely operator-managed — its name
+  becomes slightly misleading. But this is cosmetic.
+
+**Decision:** Option A — simplest change, correct precedence, keeps two-file
+model.
+
+_Considered and rejected: Option B — third file adds three-way merge complexity
+for marginal benefit. Option C — user config in seed only applies on first run,
+violating user expectations._
+
+---
+
+## Q2: Should `spec.configMode` move inside `spec.config`?
+
+Currently `spec.configMode` is a top-level field on `ClawSpec`. With the new
+`spec.config` struct, it could move inside to keep config concerns together.
+
+### Option B: Move to `spec.config.mergeMode`
+
+- **Pro:** Groups all config concerns under `spec.config`.
+- **Pro:** Pre-release API (`v1alpha1`), no real users yet — breaking changes
+  are free.
+
+**Decision:** Option B — groups config concerns cleanly, no backward compat
+cost.
+
+_Considered and rejected: Option A — keeping top-level avoids churn but leaves
+config concerns split for no reason. Option C — deprecation path unnecessary
+with no real users._
+
+---
+
+## Q3: Which enrichment keys are "always operator wins" vs "user can override"?
+
+The enrichment pipeline injects ~15 distinct keys into `operator.json`. With
+user config support, each key needs a policy: does the operator always write it
+(current behavior), or does it skip when the user already set it?
+
+The overarching principle: **operator-managed infrastructure works OOTB no
+matter what. User config adds to it, never silently disables it.** This leads
+to a three-tier model rather than a simple always-win / skip-if-set split.
+
+### Option B: Three-tier split by category
+
+**Tier 1 — Always-win (operator sets unconditionally, user can't override):**
+
+Keys driven by typed CRD fields. Operator is the sole source of truth.
+
+- `gateway.mode`, `gateway.bind`, `gateway.port`, `gateway.controlUi.enabled`
+  — infrastructure, must match pod networking
+- `gateway.auth.*`, `gateway.controlUi.dangerouslyDisableDeviceAuth`
+  — security, driven by `spec.auth`
+- `models.providers` — proxy-dependent, driven by `spec.credentials`
+- `channels.*`, `plugins.entries.<channel>` — driven by
+  `spec.credentials[].channel`
+- `mcp.servers` — driven by `spec.mcpServers`
+- `tools.web.*`, `plugins.entries.<search>` — driven by `spec.webSearch`
+
+**Tier 2 — Append/merge (operator always provides its part, user extends):**
+
+Operator infra is always present. User entries are merged or appended on top.
+
+- `gateway.controlUi.allowedOrigins` — operator always appends Route host;
+  user entries are additional origins
+- `gateway.trustedProxies` — operator always appends RFC1918 ranges; user
+  entries are additional CIDRs
+- `agents.defaults.models` — operator always merges catalog from credentials;
+  user entries win on key collision (alias, params)
+- `agents.defaults.model.primary` — operator provides catalog default; user
+  value in `spec.config.raw` wins; runtime PVC choice wins over both
+
+**Tier 3 — User-only (operator doesn't touch, user fully owns):**
+
+Keys the operator never injects. User has full control via `spec.config.raw`.
+
+- `diagnostics.*`, `session.*`, `logging.*`, `agents.list`,
+  `plugins.*` (non-declared), `skills.*`, `ui.*`, `cron.*`, `hooks.*`,
+  `browser.*`, `memory.*`, `talk.*`, `discovery.*`, `update.*`, etc.
+
+**Decision:** Option B — three-tier split. Typed CRD field drives it =
+always-win. Operator infra keys = append/merge. Everything else = user-only.
+
+_Considered and rejected: Option A — too conservative, doesn't solve
+diagnostics/session use cases. Option C — users could break proxy routing by
+overriding `models.providers`._
+
+---
+
+## Q4: CORS `allowedOrigins` — skip entirely or append Route host?
+
+When the user sets `gateway.controlUi.allowedOrigins` in `spec.config.raw`, the
+operator normally injects the auto-detected Route host into this array. Should
+the operator skip its injection (pure user control) or append the Route host to
+the user's list?
+
+### Option B: Append Route host to user's list
+
+Operator always adds the auto-detected Route host, even when the user provided
+their own origins.
+
+- **Pro:** User's custom origins work AND the default Route works. No
+  footgun.
+- **Pro:** User only needs to list *additional* origins — the Route host is
+  automatic.
+- **Pro:** Consistent with the overarching principle: operator-managed infra
+  works OOTB, user appends extra configuration.
+- **Con:** Slightly more complex logic — must deduplicate, handle missing Route.
+
+**Decision:** Option B — operator always appends Route host; user list provides
+extra origins. Infra works OOTB, user extends it.
+
+_Considered and rejected: Option A — skip-if-set risks breaking default Route
+CORS silently. Option C — opt-out flag is over-engineered for a near-zero use
+case._
+
+---
+
+## Q5: Model catalog — how does enrichment interact with user-set models?
+
+The operator injects `agents.defaults.models` (model catalog from hardcoded
+`modelCatalog`) and `agents.defaults.model.primary` into `operator.json`. When
+the user sets these keys in `spec.config.raw`, how should the enrichment
+behave?
+
+### Option C: Merge catalogs, user-set primary wins over catalog default
+
+Deep-merge the hardcoded catalog into the user's models. For the same model
+key, user's entry wins on collision. Catalog models the user didn't mention
+are added. If the user set `agents.defaults.model.primary` in
+`spec.config.raw`, use that instead of the catalog's default primary.
+
+- **Pro:** Consistent with the overarching principle: operator infra always
+  works (catalog models are always present), user extends/customizes.
+- **Pro:** Adding a new credential automatically adds its models even when
+  `spec.config.raw` is set.
+- **Pro:** User can customize specific models (rename aliases, set params)
+  while keeping auto-discovery.
+- **Pro:** Aligns with `merge.js`'s existing primary preservation logic.
+
+Primary precedence (three layers):
+1. **Runtime PVC choice** (highest) — user changes primary via UI/CLI,
+   `merge.js` preserves it across restarts
+2. **`spec.config.raw` primary** — user's CR-declared default, used on first
+   run or when no runtime choice exists
+3. **Catalog default** (lowest) — first model of first credential's catalog
+
+**Decision:** Option C — catalog always merges in (infra works OOTB), user
+entries win on collision, user-set primary wins over catalog default.
+
+_Considered and rejected: Option A — skip-if-set breaks auto-discovery from
+credentials. Option B — same as C but doesn't handle primary override._
+
+---
+
+## Q6: Do we need `configMapRef` in the initial implementation?
+
+Some operators support both inline `spec.config.raw` and external
+`spec.config.configMapRef`. Should we implement both from the start?
+
+### Option B: Only `raw`, skip `configMapRef` entirely
+
+- **Pro:** Simpler implementation. Inline raw covers 90% of use cases.
+- **Pro:** No speculative API surface — add `configMapRef` later if needed.
+
+**Decision:** Option B — only `raw`. No `configMapRef` field in the CRD at all.
+Can be added later if there's real demand.
+
+_Considered and rejected: Option A — extra complexity for GitOps/large configs
+that aren't needed yet. Option C — poor DX, high friction for simple config._
+
+---
+
+## Q7: What happens to the `openclaw.json` seed when `spec.config.raw` is set?
+
+The seed `openclaw.json` in the ConfigMap provides first-run defaults:
+`agents.list` (default agent) and `agents.defaults.workspace`. When the user
+provides `spec.config.raw`, should the seed change?
+
+### Option A: Seed stays as-is
+
+User raw config goes into `operator.json`. The seed `openclaw.json` remains
+unchanged regardless of `spec.config`.
+
+- **Pro:** Clean separation: seed = first-run defaults (default agent,
+  workspace path), operator.json = current desired state (operator +
+  user keys).
+- **Pro:** If the user sets `agents.list` in `spec.config.raw`, it goes into
+  `operator.json` and will overwrite the seed's `agents.list` on every
+  restart. This is correct — the user explicitly declared their agent list.
+
+**Decision:** Option A — seed stays unchanged, user config goes into
+`operator.json`.
+
+_Considered and rejected: Option B — replacing the seed breaks merge model
+precedence and loses default agent if user omits `agents.list`. Option C —
+merging into seed means user config only applies on first run._
+
+---
+
+## Q8: Should the model catalog remain hardcoded in Go?
+
+The model catalog in `claw_models.go` maps provider names to known models. With
+`spec.config.raw`, users can add/override models directly. Should the hardcoded
+catalog change?
+
+### Option A: Keep hardcoded catalog (status quo)
+
+- **Pro:** Zero-config experience for supported providers. Add a Google
+  credential → get Gemini models in the picker automatically.
+- **Pro:** Hardcoded catalog provides OOTB defaults (consistent with our
+  principle); `spec.config.raw` is the escape hatch. Users can always add
+  any model via `spec.config.raw`:
+  ```yaml
+  spec:
+    config:
+      raw:
+        agents:
+          defaults:
+            models:
+              openrouter/qwen3-14b:
+                alias: Qwen 3 14B
+  ```
+  Per Q5 decision, these merge with the catalog — catalog models are always
+  present, user entries are added on top and win on collision.
+- **Con:** Updating the OOTB catalog defaults (e.g., when Google releases a
+  new model) requires an operator release. But individual deployments are
+  never blocked — they add models via `spec.config.raw`.
+
+**Decision:** Option A — keep hardcoded catalog for OOTB defaults,
+`spec.config.raw` for per-deployment customization.
+
+_Considered and rejected: Option B — ConfigMap-based catalog adds operational
+complexity for ~15 entries that change infrequently. Option C — removing the
+catalog breaks zero-config experience._


### PR DESCRIPTION
- Design for spec.config.raw field accepting arbitrary openclaw.json configuration without per-feature typed CRD fields
- Three-tier enrichment model: always-win / append-merge / user-only
- spec.configMode moves to spec.config.mergeMode (breaking, pre-release)
- All 8 design questions resolved with decisions documented
- Function-by-function implementation plan for enrichment changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design proposal documentation for the new `spec.config` configuration feature, including enrichment flow specifications, configuration merge policies, operator behavior requirements, and resolved design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->