### PR TITLE
docs: add workspace/skills design proposal and resource limits

### DIFF
--- a/docs/proposals/workspace-and-skills-design.md
+++ b/docs/proposals/workspace-and-skills-design.md
@@ -1,0 +1,286 @@
+# Workspace Files and Skills Injection
+
+**Status:** Final
+
+---
+
+## Overview
+
+Add `spec.workspace` and `spec.skills` to the Claw CR, enabling operators to
+declaratively seed workspace files (IDENTITY.md, AGENTS.md overrides) and custom
+skills (enterprise-specific SKILL.md files) onto the PVC without `oc exec`.
+
+This eliminates the manual file-copy steps from demo and onboarding scripts,
+and enables GitOps workflows for workspace content.
+
+---
+
+## Design Principles
+
+1. **Extend existing mechanisms** — reuse the proven `merge.js` seeding patterns
+   (`seedIfMissing`, `copyAlways`) rather than inventing new file delivery.
+
+2. **Existing ConfigMap as transport** — files travel to the pod via the existing
+   gateway ConfigMap using prefixed keys. No new volumes or resources.
+
+3. **Clear ownership semantics** — workspace files are user-owned (seeded once,
+   never touched again). Skills are operator-managed (overwritten every restart).
+
+4. **Size-conscious** — ConfigMaps have a 1MB total limit. Inline content in the
+   CR is appropriate for typical use cases (small markdown files). ConfigMapRef
+   can be added later as an extension if needed.
+
+5. **Backward compatible** — no workspace or skill seeding by default. Existing
+   CRs produce identical behavior.
+
+---
+
+## Architecture
+
+### Current file seeding flow
+
+```
+ConfigMap keys          merge.js            PVC destination
+─────────────          ────────            ───────────────
+operator.json    ──▶  deep-merge      ──▶  openclaw.json
+openclaw.json    ──▶  (seed)
+AGENTS.md        ──▶  seedIfMissing   ──▶  workspace/AGENTS.md
+PLATFORM.md      ──▶  copyAlways      ──▶  workspace/skills/platform/SKILL.md
+KUBERNETES.md    ──▶  copyAlways      ──▶  workspace/skills/kubernetes/SKILL.md
+```
+
+### Extended flow (this design)
+
+```
+ConfigMap keys              merge.js                PVC destination
+─────────────              ────────                ───────────────
+(existing keys)            (unchanged)             (unchanged)
+_ws_IDENTITY.md      ──▶  seedIfMissing   ──▶  workspace/IDENTITY.md
+_ws_AGENTS.md        ──▶  seedIfMissing   ──▶  workspace/AGENTS.md
+_skill_quote-builder ──▶  copyAlways      ──▶  workspace/skills/quote-builder/SKILL.md
+_skill_compliance    ──▶  copyAlways      ──▶  workspace/skills/compliance/SKILL.md
+```
+
+### Key conventions
+
+- `_ws_<path>` → `seedIfMissing` to `workspace/<path>`
+- `_skill_<name>` → `copyAlways` to `workspace/skills/<name>/SKILL.md`
+- Slashes in paths encoded as `--` (e.g., `_ws_docs--README.md` → `workspace/docs/README.md`)
+
+### Data flow
+
+```
+                   ┌─────────────────────────────────────────┐
+                   │  Reconciler                              │
+                   │                                          │
+spec.workspace ──▶ │  injectWorkspaceFiles(objects, instance) │
+spec.skills    ──▶ │  injectSkillFiles(objects, instance)     │
+                   │                                          │
+                   │  Writes _ws_/_skill_ keys into ConfigMap  │
+                   └──────────────────────┬──────────────────┘
+                                          │
+                                          ▼
+                   ┌──────────────────────────────────────────┐
+                   │  init-config (merge.js)                   │
+                   │                                           │
+                   │  For each _ws_* key → seedIfMissing       │
+                   │  For each _skill_* key → copyAlways       │
+                   └──────────────────────────────────────────┘
+```
+
+---
+
+## CRD Changes
+
+### `spec.workspace`
+
+```yaml
+spec:
+  workspace:
+    # Skip the OpenClaw bootstrap questionnaire on first use.
+    # Default: false.
+    skipBootstrap: true
+
+    # Files to seed into the workspace directory.
+    # Map keys are file paths relative to workspace/.
+    # Content is seeded once (seedIfMissing) — user edits are preserved.
+    files:
+      IDENTITY.md: |
+        # Identity
+        Name: Demo User
+        Creature: An octopus
+      AGENTS.md: |
+        ## Enterprise assistant
+        You are a FantaCo enterprise assistant...
+```
+
+### `spec.skills`
+
+```yaml
+spec:
+  # Operator-managed skills. Map keys are skill directory names.
+  # Content is always overwritten on pod restart (copyAlways).
+  skills:
+    quote-builder: |
+      ---
+      name: quote-builder
+      description: Build customer quotes using the pricing API
+      ---
+      # Quote Builder
+      Use the pricing MCP server to generate quotes...
+    compliance: |
+      ---
+      name: compliance
+      description: Corporate compliance guidelines
+      ---
+      # Compliance
+      Always follow FantaCo policy...
+```
+
+### Go types
+
+```go
+// WorkspaceSpec configures workspace file seeding.
+type WorkspaceSpec struct {
+    // SkipBootstrap suppresses the OpenClaw first-run questionnaire.
+    // Default: false.
+    // +optional
+    SkipBootstrap bool `json:"skipBootstrap,omitempty"`
+
+    // Files maps workspace-relative paths to file content.
+    // Each file is seeded once (seedIfMissing) — user edits via the
+    // OpenClaw UI are preserved across restarts.
+    // +optional
+    Files map[string]string `json:"files,omitempty"`
+}
+```
+
+`spec.skills` is `map[string]string` directly on `ClawSpec`:
+
+```go
+// Skills maps skill names to SKILL.md content. Each entry creates
+// workspace/skills/<name>/SKILL.md, overwritten on every pod restart
+// (operator-managed).
+// +optional
+Skills map[string]string `json:"skills,omitempty"`
+```
+
+---
+
+## Implementation Plan
+
+Single PR. Steps are ordered by dependency but ship together.
+
+1. Add `WorkspaceSpec` to `api/v1alpha1/claw_types.go`; add
+   `Workspace *WorkspaceSpec` and `Skills map[string]string` to `ClawSpec`;
+   run `make manifests generate`
+2. Add validation helpers — reject empty/absolute/traversal paths, `--` in
+   names, conflicts with built-in skills (`platform`, `kubernetes`)
+3. Add `injectWorkspaceFiles(objects, instance)` — validate, encode paths
+   with `--`, write `_ws_<encoded-path>` keys into the gateway ConfigMap
+4. Add `injectSkillFiles(objects, instance)` — validate, write `_skill_<name>`
+   keys into the gateway ConfigMap
+5. Add `injectSkipBootstrap(config, instance)` — set
+   `agents.defaults.skipBootstrap: true` in operator.json when enabled
+6. Wire steps 3-5 into `enrichConfigAndNetworkPolicy()` pipeline
+7. Extend merge.js: iterate `_ws_*` keys (seedIfMissing) **before** static
+   seeds; iterate `_skill_*` keys (copyAlways); guard existing static
+   `seedIfMissing(AGENTS.md)` with an existence check
+8. Unit tests for injection functions and validation
+9. Integration tests (envtest — keys appear in ConfigMap after reconcile)
+10. Update user guide with "Workspace Files" and "Skills" sections
+
+**Note:** `stampGatewayConfigHash` already hashes all ConfigMap data keys —
+new `_ws_`/`_skill_` keys trigger pod rollouts automatically with no changes.
+
+---
+
+## Interaction with existing features
+
+| Feature | Interaction |
+|---------|-------------|
+| `spec.config.raw` | Independent — workspace files are PVC content, not openclaw.json |
+| `spec.plugins` | Independent — plugins are npm packages; skills are markdown files |
+| Existing `AGENTS.md` seed | User's `spec.workspace.files.AGENTS.md` overrides the built-in seed. merge.js processes `_ws_*` keys FIRST, then runs the static `seedIfMissing(AGENTS.md)`. Since the destination already exists after `_ws_AGENTS.md` is seeded, the static seed is a no-op. |
+| Existing platform/kubernetes skills | Coexist — operator-injected skills use `PLATFORM.md`/`KUBERNETES.md` keys; user skills use `_skill_` prefix |
+| Config hash / rollout | Automatic — any workspace/skill change triggers pod restart |
+
+---
+
+## Validation
+
+The controller rejects the CR (condition = `Ready=False`) if:
+
+- A workspace file path is empty, absolute, or contains `..` (directory traversal)
+- A workspace file path conflicts with operator-managed paths (e.g., `skills/platform/SKILL.md`)
+- A skill name is empty or contains `/` (names are directory components, not paths)
+- A skill name conflicts with built-in operator skills (`platform`, `kubernetes`)
+- A workspace file path or skill name contains `--` (reserved as the slash encoding
+  delimiter — filenames with literal `--` are unsupported)
+
+These checks run in the controller before writing ConfigMap keys, producing clear
+status messages (e.g., `workspace file path "../../etc/passwd" is invalid: must not
+contain ".."`)
+
+---
+
+## ConfigMap size budget
+
+| Content | Approximate size |
+|---------|-----------------|
+| Existing keys (operator.json, merge.js, PLATFORM.md, etc.) | ~30KB |
+| Typical workspace files (IDENTITY.md, AGENTS.md) | ~2-5KB |
+| Typical skills (2-3 enterprise skills) | ~5-15KB |
+| **Total** | **~40-50KB** |
+| **Remaining budget** | **~950KB** |
+
+Well within the 1MB ConfigMap limit for typical use cases.
+
+---
+
+## Example CR
+
+```yaml
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: demo-instance
+spec:
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+      provider: google
+  config:
+    raw:
+      agents:
+        defaults:
+          model:
+            primary: google/gemini-2.5-pro
+  workspace:
+    skipBootstrap: true
+    files:
+      IDENTITY.md: |
+        # Identity
+        - Name: Demo User
+        - Role: Enterprise Developer
+        - Company: FantaCo
+      AGENTS.md: |
+        ## FantaCo Enterprise Assistant
+        You are a FantaCo enterprise assistant with access to
+        internal APIs and compliance guidelines.
+  skills:
+    quote-builder: |
+      ---
+      name: quote-builder
+      description: Build customer quotes using the pricing API
+      ---
+      # Quote Builder
+      Connect to the pricing MCP server and generate quotes...
+  plugins:
+    - "@openclaw/diagnostics-otel"
+  metrics:
+    enabled: true
+```

--- a/docs/proposals/workspace-and-skills-questions.md
+++ b/docs/proposals/workspace-and-skills-questions.md
@@ -1,0 +1,184 @@
+# Workspace and Skills — Design Questions
+
+**Status:** Resolved — all decisions made
+**Related:** [Design document](workspace-and-skills-design.md)
+
+Each question has options with trade-offs and a recommendation. Go through them
+one by one to form the design, then update the design document.
+
+### Reference projects
+
+| Project | Workspace API | Skills API | Delivery |
+|---------|--------------|------------|----------|
+| **Upstream openclaw-operator** | `spec.workspace.initialFiles` (inline map) + `configMapRef` | `spec.skills` ([]string: ClawHub/npm/pack:) | Separate `{name}-workspace` ConfigMap → init `[ -f ] \|\| cp` |
+| **openclaw-installer** | Host dirs → ConfigMap → init `cp` | Host `skills/` dir → ConfigMap → init `cp -r` | ConfigMaps + init container |
+| **NemoClaw** | `skipBootstrap` + entrypoint seeds templates | SSH `skill install` post-create | Image bake + entrypoint + SSH |
+| **OpenShell** | `--upload .` / `sandbox cp` (no framework) | None (agent-runtime concern) | Upload/cp via SSH |
+
+Key upstream choices:
+- All workspace files are **seed-once** (no per-file strategy in CRD)
+- `initialFiles` is an inline `map[string]string` (path → content)
+- External ConfigMapRef is additive (lower priority than inline)
+- Operator-injected files (`ENVIRONMENT.md`, `BOOTSTRAP.md`) always overwrite
+  but are NOT declared in the CRD — they are implicit
+- `skipBootstrap` is application config, not a CRD field
+- Skills use a separate mechanism (init container for ClawHub/npm; GitHub
+  resolution for `pack:` into workspace CM)
+
+---
+
+## Q1: How do users provide file content?
+
+Users need to supply content for workspace files and skills. The content needs to
+reach the gateway ConfigMap so merge.js can seed it to the PVC.
+
+### Option A: Inline only (`content` field in CR)
+
+```yaml
+spec:
+  workspace:
+    files:
+      IDENTITY.md: |
+        # Identity
+        Name: Demo User
+      AGENTS.md: |
+        ## Enterprise assistant
+        ...
+```
+
+- **Pro:** Simplest UX — everything in one CR, no external resources to manage
+- **Pro:** Works immediately, no need to pre-create ConfigMaps
+- **Pro:** GitOps-friendly — full state in one resource
+- **Pro:** Upstream uses `initialFiles` as inline map — proven pattern
+- **Con:** CR size limit (1MB for etcd object). Large content could push limits
+- **Con:** `oc get claw instance -o yaml` output gets noisy with embedded content
+- **Con:** No sharing between instances — each CR carries its own copy
+
+**Decision:** Option A — inline map only for v1. Simple, proven by upstream,
+sufficient for our use cases (small markdown files). ConfigMapRef can be added
+later as a non-breaking extension.
+
+_Considered and rejected: Option B ConfigMapRef only (extra resource management,
+RBAC complexity), Option C both (over-engineering for v1)._
+
+---
+
+## Q2: Workspace file ownership — seedIfMissing or copyAlways?
+
+When a user specifies a workspace file like `IDENTITY.md`, should the operator
+overwrite it on every pod restart or only seed it once?
+
+### Option D: `seedIfMissing` default; `copyAlways` only for skills
+
+- **Pro:** Simple mental model: workspace = user-owned, skills = operator-owned
+- **Pro:** Matches existing operator patterns (AGENTS.md = seed, PLATFORM.md = always)
+- **Pro:** Matches upstream (all workspace files are seed-once)
+- **Pro:** No new CRD fields for strategy
+
+**Decision:** Option D — fixed strategy per field type. `spec.workspace.files`
+always uses `seedIfMissing` (user-owned after first seed). `spec.skills` always
+uses `copyAlways` (operator-managed). Clear mental model, no per-file config.
+
+_Considered and rejected: Option A seedIfMissing-only (same outcome but doesn't
+address skills), Option B copyAlways (wipes user edits), Option C per-file
+strategy (unnecessary CRD complexity)._
+
+---
+
+## Q3: Skills API shape — inline map, list of objects, or different mechanism?
+
+Skills are always operator-managed (`copyAlways`). Each skill becomes
+`workspace/skills/<name>/SKILL.md`. The question is the CRD shape.
+
+### Option A: Inline map (name → content)
+
+```yaml
+spec:
+  skills:
+    quote-builder: |
+      ---
+      name: quote-builder
+      description: Build customer quotes using the pricing API
+      ---
+      # Quote Builder
+      ...
+```
+
+- **Pro:** Simplest — same shape as `spec.workspace.files` (map[string]string)
+- **Pro:** Name is the map key, content is the value
+- **Pro:** Skills are typically small markdown (1-5KB)
+
+**Decision:** Option A — inline map. Map key = skill directory name, value =
+SKILL.md content. Same shape as `spec.workspace.files`, minimal CRD surface.
+Skills use `copyAlways` (per Q2), distinct from workspace `seedIfMissing`.
+
+_Considered and rejected: Option B list of objects (unnecessary verbosity),
+Option C reuse workspace.files (wrong ownership semantics — skills need
+copyAlways)._
+
+---
+
+## Q4: How are workspace/skill files keyed in the ConfigMap?
+
+The controller writes file content into the gateway ConfigMap. merge.js needs a
+convention to distinguish workspace files from skills and from existing keys.
+
+### Option B: Prefix convention with path encoding
+
+Encode slashes as `--` (matching upstream's `SkillPackCMKey()`):
+
+```
+_ws_IDENTITY.md        → seedIfMissing → workspace/IDENTITY.md
+_ws_docs--README.md    → seedIfMissing → workspace/docs/README.md
+_skill_quote-builder   → copyAlways    → workspace/skills/quote-builder/SKILL.md
+```
+
+- **Pro:** Self-describing — no separate manifest needed
+- **Pro:** Simpler merge.js (one pass, prefix filter)
+- **Pro:** Matches upstream `--` path encoding convention
+- **Pro:** Prefix determines strategy (`_ws_` = seedIfMissing, `_skill_` = copyAlways)
+
+**Decision:** Option B — self-describing prefixed keys. `_ws_` prefix for
+workspace files (seedIfMissing), `_skill_` prefix for skills (copyAlways).
+Slashes in paths encoded as `--`. One-pass iteration in merge.js, no manifest.
+
+_Considered and rejected: Option A JSON manifest (unnecessary two-step
+indirection), Option C separate ConfigMap (over-engineering for 3-5 files)._
+
+---
+
+## Q5: Should `skipBootstrap` be a dedicated CR field?
+
+OpenClaw prompts new users with a bootstrap questionnaire on first use. For
+demos, this should be skipped. The config key is
+`agents.defaults.skipBootstrap: true`.
+
+### Option A: Dedicated field (`spec.workspace.skipBootstrap`)
+
+```yaml
+spec:
+  workspace:
+    skipBootstrap: true
+```
+
+- **Pro:** Discoverable in CRD docs and `oc explain`
+- **Pro:** Clear intent — pairs naturally with workspace file seeding
+- **Pro:** Upstream has a similar field (`spec.workspace.bootstrap.enabled`)
+
+**Decision:** Option A — dedicated field on `spec.workspace`. Since we're
+already adding `spec.workspace` as a new struct, including `skipBootstrap` there
+is natural and discoverable. Users setting up workspace files almost always want
+to skip bootstrap too — having it right next to `files` makes the connection
+obvious.
+
+_Considered and rejected: Option B spec.config.raw (less discoverable, users
+won't know the config key), Option C auto-infer from IDENTITY.md (too magical,
+non-obvious relationship)._
+
+---
+
+## Q6: Same ConfigMap or separate volume for workspace content?
+
+**Moot — already decided by Q4.** The Q4 decision to use `_ws_`/`_skill_`
+prefixed keys implies using the existing gateway ConfigMap. No separate
+ConfigMap or volume needed.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1249,3 +1249,25 @@ Changing the plugin list triggers a pod rollout (the operator includes the plugi
 ### Limitations
 
 Removing a plugin from `spec.plugins` prevents it from being installed on new pods but does **not** uninstall it from the existing PVC. To fully remove a plugin, either delete the PVC (the operator will recreate it) or manually remove the plugin files.
+
+---
+
+## Operator Resource Limits
+
+The operator controller itself has no resource limits set by default. On OpenShift (OLM installs), configure limits via the `Subscription` CR:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: claw-operator
+spec:
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 500m
+      requests:
+        memory: 128Mi
+        cpu: 50m
+```


### PR DESCRIPTION
- Design doc for spec.workspace and spec.skills (inline map, seed semantics, merge.js extension, validation rules)
- Companion questions doc with resolved decisions and upstream research
- Add Operator Resource Limits section to user guide (OLM Subscription)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Design proposals added for extending workspace file seeding and operator-managed skills management, including configuration conventions and integration strategies
  * Design decisions documented for workspace and skills configuration approaches and requirements
  * New operator resource limits guidance for OpenShift environments, including sample Subscription manifests for resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->