### PR TITLE
chore: bump OpenClaw image to 2026.5.26-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.22-slim
+    newTag: 2026.5.26-slim

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -29,7 +29,7 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
-const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.22-slim"
+const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.26-slim"
 
 func makeTestDeploymentForPlugins() []*unstructured.Unstructured {
 	dep := &unstructured.Unstructured{}


### PR DESCRIPTION
- Update gateway image tag in kustomization.yaml
- Update test constant to match new image tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the claw component image version to `2026.5.26-slim`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->