### PR TITLE
feat: add Gemini 3.5 Flash to model catalog

### DIFF
--- a/docs/adr/0013-spec-config.md
+++ b/docs/adr/0013-spec-config.md
@@ -116,7 +116,7 @@ spec:
       agents:
         defaults:
           model:
-            primary: google/gemini-3-flash-preview
+            primary: google/gemini-3.5-flash
           models:
             openrouter/qwen3-14b:
               alias: Qwen 3 14B

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1058,7 +1058,7 @@ spec:
       agents:
         defaults:
           model:
-            primary: google/gemini-3-flash-preview
+            primary: google/gemini-3.5-flash
           models:
             openrouter/qwen3-14b:
               alias: Qwen 3 14B

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -274,7 +274,7 @@ data:
     The model picker list is dynamically generated from the providers configured in the
     Claw CR `spec.credentials`. Each credential with a `provider` field contributes its
     known models to the picker. Models appear as `{provider}/{model-name}` (e.g.,
-    `google/gemini-3-flash-preview`, `anthropic/claude-sonnet-4-6`).
+    `google/gemini-3.5-flash`, `anthropic/claude-sonnet-4-6`).
 
     Supported providers with automatic model catalogs: `google`, `anthropic`, `openai`, `xai`.
     Meta-providers like `openrouter` do not have a hardcoded catalog — users can add
@@ -770,7 +770,7 @@ data:
           agents:
             defaults:
               model:
-                primary: google/gemini-3-flash-preview
+                primary: google/gemini-3.5-flash
               models:
                 openrouter/qwen3-14b:
                   alias: Qwen 3 14B

--- a/internal/controller/claw_config_test.go
+++ b/internal/controller/claw_config_test.go
@@ -421,7 +421,7 @@ func TestSpecConfigRawIntegration(t *testing.T) {
 										"model": {"primary": "openrouter/qwen3-14b"},
 										"models": {
 											"openrouter/qwen3-14b": {"alias": "Qwen 3 14B"},
-											"google/gemini-3-flash-preview": {"alias": "My Flash"}
+											"google/gemini-3.5-flash": {"alias": "My Flash"}
 										}
 									}
 								}
@@ -442,7 +442,7 @@ func TestSpecConfigRawIntegration(t *testing.T) {
 
 		assert.Contains(t, models, "openrouter/qwen3-14b",
 			"user-added model should be present")
-		flash := models["google/gemini-3-flash-preview"].(map[string]any)
+		flash := models["google/gemini-3.5-flash"].(map[string]any)
 		assert.Equal(t, "My Flash", flash["alias"],
 			"user alias should win over catalog alias")
 		assert.Contains(t, models, "google/gemini-3.1-pro-preview",

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -275,9 +275,9 @@ func TestInjectModelCatalog(t *testing.T) {
 
 		models := config["agents"].(map[string]any)["defaults"].(map[string]any)["models"].(map[string]any)
 		assert.Len(t, models, len(modelCatalog["google"]))
-		assert.Contains(t, models, "google/gemini-3-flash-preview")
-		entry := models["google/gemini-3-flash-preview"].(map[string]any)
-		assert.Equal(t, "Gemini 3 Flash", entry["alias"])
+		assert.Contains(t, models, "google/gemini-3.5-flash")
+		entry := models["google/gemini-3.5-flash"].(map[string]any)
+		assert.Equal(t, "Gemini 3.5 Flash", entry["alias"])
 	})
 
 	t.Run("multiple providers emit models for each", func(t *testing.T) {
@@ -292,7 +292,7 @@ func TestInjectModelCatalog(t *testing.T) {
 		models := config["agents"].(map[string]any)["defaults"].(map[string]any)["models"].(map[string]any)
 		expectedCount := len(modelCatalog["google"]) + len(modelCatalog["anthropic"])
 		assert.Len(t, models, expectedCount)
-		assert.Contains(t, models, "google/gemini-3-flash-preview")
+		assert.Contains(t, models, "google/gemini-3.5-flash")
 		assert.Contains(t, models, "anthropic/claude-sonnet-4-6")
 	})
 
@@ -341,7 +341,7 @@ func TestInjectModelCatalog(t *testing.T) {
 		injectModelCatalog(config, testClawWithCredentials(credentials))
 
 		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
-		assert.Equal(t, "google/gemini-3-flash-preview", model["primary"])
+		assert.Equal(t, "google/gemini-3.5-flash", model["primary"])
 	})
 
 	t.Run("primary set from first provider with catalog", func(t *testing.T) {
@@ -401,7 +401,7 @@ func TestInjectModelCatalog(t *testing.T) {
 			"agents": map[string]any{
 				"defaults": map[string]any{
 					"models": map[string]any{
-						"google/gemini-3-flash-preview": map[string]any{"alias": "My Custom Alias"},
+						"google/gemini-3.5-flash": map[string]any{"alias": "My Custom Alias"},
 					},
 				},
 			},
@@ -413,7 +413,7 @@ func TestInjectModelCatalog(t *testing.T) {
 		injectModelCatalog(config, testClawWithCredentials(credentials))
 
 		models := config["agents"].(map[string]any)["defaults"].(map[string]any)["models"].(map[string]any)
-		entry := models["google/gemini-3-flash-preview"].(map[string]any)
+		entry := models["google/gemini-3.5-flash"].(map[string]any)
 		assert.Equal(t, "My Custom Alias", entry["alias"])
 		assert.Len(t, models, len(modelCatalog["google"]))
 	})
@@ -456,7 +456,7 @@ func TestInjectModelCatalog(t *testing.T) {
 
 		models := config["agents"].(map[string]any)["defaults"].(map[string]any)["models"].(map[string]any)
 		assert.Len(t, models, len(modelCatalog["google"]))
-		assert.Contains(t, models, "google/gemini-3-flash-preview")
+		assert.Contains(t, models, "google/gemini-3.5-flash")
 		assert.Contains(t, models, "google/gemini-3.1-flash-lite")
 		proEntry := models["google/gemini-3.1-pro-preview"].(map[string]any)
 		assert.Equal(t, "My Pro Override", proEntry["alias"])
@@ -579,9 +579,9 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 
 		catalogModels, hasModels := defaults["models"].(map[string]any)
 		require.True(t, hasModels, "operator.json should contain agents.defaults.models")
-		assert.Contains(t, catalogModels, "google/gemini-3-flash-preview", "should have google model from catalog")
+		assert.Contains(t, catalogModels, "google/gemini-3.5-flash", "should have google model from catalog")
 
 		model := defaults["model"].(map[string]any)
-		assert.Equal(t, "google/gemini-3-flash-preview", model["primary"], "primary should be first google model")
+		assert.Equal(t, "google/gemini-3.5-flash", model["primary"], "primary should be first google model")
 	})
 }

--- a/internal/controller/claw_merge_test.go
+++ b/internal/controller/claw_merge_test.go
@@ -189,7 +189,7 @@ func TestMergeJS(t *testing.T) {
 				"defaults": {
 					"model": { "primary": "anthropic-vertex/claude-sonnet-4-6" },
 					"models": {
-						"google/gemini-3-flash-preview": { "alias": "Gemini Flash" }
+						"google/gemini-3.5-flash": { "alias": "Gemini Flash" }
 					},
 					"workspace": "~/.openclaw/workspace"
 				},
@@ -326,7 +326,7 @@ func TestMergeJS(t *testing.T) {
 	t.Run("primary preserved on restart", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3-flash-preview"}, "models": {"google/gemini-3-flash-preview": {"alias": "Gemini 3 Flash"}}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"}}}}
 		}`
 		pvcJSON := `{
 			"agents": {"defaults": {"model": {"primary": "anthropic/claude-opus-4-7"}, "workspace": "~/.openclaw/workspace"}}
@@ -342,21 +342,21 @@ func TestMergeJS(t *testing.T) {
 	t.Run("primary set on first run", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3-flash-preview"}, "models": {"google/gemini-3-flash-preview": {"alias": "Gemini 3 Flash"}}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"}}}}
 		}`
 
 		result := runMergeJS(t, mergeTestSetup{operatorJSON: operatorJSON})
 
 		primary, hasPrimary := nestedValue(result.config, "agents.defaults.model.primary")
 		assert.True(t, hasPrimary, "should have primary model on first run")
-		assert.Equal(t, "google/gemini-3-flash-preview", primary, "operator's primary should be used on first run")
+		assert.Equal(t, "google/gemini-3.5-flash", primary, "operator's primary should be used on first run")
 	})
 
 	t.Run("primary preserved even when models change", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3-flash-preview"}, "models": {
-				"google/gemini-3-flash-preview": {"alias": "Gemini 3 Flash"},
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {
+				"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"},
 				"google/gemini-3.1-pro-preview": {"alias": "Gemini 3.1 Pro"}
 			}}}
 		}`
@@ -375,14 +375,14 @@ func TestMergeJS(t *testing.T) {
 		models, hasModels := nestedValue(result.config, "agents.defaults.models")
 		assert.True(t, hasModels)
 		modelsMap := models.(map[string]any)
-		assert.Contains(t, modelsMap, "google/gemini-3-flash-preview", "new operator models should be merged in")
+		assert.Contains(t, modelsMap, "google/gemini-3.5-flash", "new operator models should be merged in")
 		assert.Contains(t, modelsMap, "google/gemini-3.1-pro-preview", "new operator models should be merged in")
 	})
 
 	t.Run("primary not preserved in overwrite mode", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3-flash-preview"}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}}}
 		}`
 		pvcJSON := `{
 			"agents": {"defaults": {"model": {"primary": "anthropic/claude-opus-4-7"}}}
@@ -392,7 +392,7 @@ func TestMergeJS(t *testing.T) {
 
 		primary, hasPrimary := nestedValue(result.config, "agents.defaults.model.primary")
 		assert.True(t, hasPrimary)
-		assert.Equal(t, "google/gemini-3-flash-preview", primary, "overwrite mode should reset to operator's primary")
+		assert.Equal(t, "google/gemini-3.5-flash", primary, "overwrite mode should reset to operator's primary")
 	})
 
 	t.Run("workspace file seeded on first run", func(t *testing.T) {

--- a/internal/controller/claw_models.go
+++ b/internal/controller/claw_models.go
@@ -29,6 +29,7 @@ type modelEntry struct {
 // Providers not in this map (e.g., "openrouter") are silently skipped.
 var modelCatalog = map[string][]modelEntry{
 	"google": {
+		{Name: "gemini-3.5-flash", Alias: "Gemini 3.5 Flash"},
 		{Name: "gemini-3-flash-preview", Alias: "Gemini 3 Flash"},
 		{Name: "gemini-3.1-pro-preview", Alias: "Gemini 3.1 Pro"},
 		{Name: "gemini-3.1-flash-lite", Alias: "Gemini 3.1 Flash Lite"},


### PR DESCRIPTION
- Add gemini-3.5-flash as the default Google model (GA, released May 19)
- Keep gemini-3-flash-preview as a secondary option (cheaper, still live)
- Update PLATFORM.md examples to reference the new default
- Update tests to match new catalog ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configurations and user guide to reference Google Gemini 3.5 Flash as the default model.

* **Configuration**
  * Updated default model selection and supported model catalog to use the latest Gemini model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->