### PR TITLE
fix: deep-merge metrics config into user diagnostics.otel

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1135,7 +1135,7 @@ EOF
 
 This single field (`spec.metrics.enabled: true`) triggers the operator to:
 
-1. Inject `diagnostics.otel.metrics: true` and `diagnostics.otel.endpoint: "http://localhost:4318"` into the gateway config
+1. Inject `diagnostics.otel.metrics: true` and the sidecar OTLP endpoint into the gateway config
 2. Add an OTel Collector sidecar container to the gateway pod
 3. Add a `metrics` port (9464) to the Service
 4. Open the NetworkPolicy for scraping from monitoring namespaces
@@ -1200,9 +1200,42 @@ curl http://localhost:9464/metrics
 
 You should see Prometheus-format metrics from the OpenClaw gateway.
 
-### User-provided diagnostics config
+### Combining metrics with external tracing
 
-If you configure `diagnostics.otel` in `spec.config.raw`, the operator will not override your settings. This allows advanced users to point OTLP to a custom endpoint or configure additional telemetry options while still using the operator-managed sidecar for Prometheus export.
+When you configure `diagnostics.otel` in `spec.config.raw` alongside `spec.metrics.enabled: true`, the operator deep-merges the sidecar-specific keys (`metrics` and `metricsEndpoint`) into your config without overwriting your settings. This lets you send traces to an external backend (e.g., Langfuse, MLflow) while Prometheus metrics flow through the sidecar automatically:
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+  plugins:
+    - "@openclaw/diagnostics-otel"
+  config:
+    raw:
+      diagnostics:
+        otel:
+          enabled: true
+          endpoint: http://langfuse.observability.svc:3000/api/public/otel/v1/traces
+          traces: true
+          captureContent:
+            inputMessages: true
+            outputMessages: true
+      plugins:
+        entries:
+          diagnostics-otel:
+            enabled: true
+  networkPolicy:
+    allowedEgress:
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: observability
+        ports:
+          - port: 3000
+            protocol: TCP
+```
+
+The operator injects `metrics: true` and `metricsEndpoint: "http://localhost:4318"` (pointing to the sidecar) only if you haven't set them yourself. Your `endpoint` routes traces to Langfuse; the injected `metricsEndpoint` routes metrics to the sidecar for Prometheus scraping. If you set `metrics: false` explicitly, the operator respects it.
 
 ## Network Policy
 

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -760,8 +760,11 @@ data:
     - `agents.defaults.model.primary` — user value wins over catalog default
 
     **User-only (operator never touches — full user control):**
-    - `diagnostics.*`, `session.*`, `logging.*`, `plugins.*` (non-declared),
-      `skills.*`, `ui.*`, `cron.*`, `hooks.*`, `browser.*`, `memory.*`, etc.
+    - `diagnostics.*` (except: when `spec.metrics` is enabled, the operator
+      injects `diagnostics.otel.metrics` and `diagnostics.otel.metricsEndpoint`
+      if not already set by the user), `session.*`, `logging.*`,
+      `plugins.*` (non-declared), `skills.*`, `ui.*`, `cron.*`, `hooks.*`,
+      `browser.*`, `memory.*`, etc.
 
     ## Example
 

--- a/internal/controller/claw_metrics.go
+++ b/internal/controller/claw_metrics.go
@@ -176,8 +176,11 @@ service:
 	return fmt.Errorf("ConfigMap %q not found in manifests", configMapName)
 }
 
-// injectMetricsConfig injects diagnostics.otel.metrics and endpoint into the
-// operator.json config map. Only sets if user hasn't already configured diagnostics.otel.
+// injectMetricsConfig injects diagnostics.otel config for the OTel Collector
+// sidecar. When the user hasn't set diagnostics.otel, it injects the base
+// endpoint. When the user has their own diagnostics.otel (e.g., for tracing
+// to Langfuse), it deep-merges only the sidecar-specific keys (metrics +
+// metricsEndpoint) so both paths work simultaneously.
 func injectMetricsConfig(config map[string]any, instance *clawv1alpha1.Claw) {
 	if !metricsEnabled(instance) {
 		return
@@ -189,13 +192,20 @@ func injectMetricsConfig(config map[string]any, instance *clawv1alpha1.Claw) {
 		config["diagnostics"] = diagnostics
 	}
 
-	if _, exists := diagnostics["otel"]; exists {
+	otel, _ := diagnostics["otel"].(map[string]any)
+	if otel == nil {
+		diagnostics["otel"] = map[string]any{
+			"metrics":  true,
+			"endpoint": "http://localhost:4318",
+		}
 		return
 	}
 
-	diagnostics["otel"] = map[string]any{
-		"metrics":  true,
-		"endpoint": "http://localhost:4318",
+	if _, set := otel["metrics"]; !set {
+		otel["metrics"] = true
+	}
+	if _, set := otel["metricsEndpoint"]; !set {
+		otel["metricsEndpoint"] = "http://localhost:4318"
 	}
 }
 

--- a/internal/controller/claw_metrics_test.go
+++ b/internal/controller/claw_metrics_test.go
@@ -275,14 +275,14 @@ func TestInjectMetricsConfig(t *testing.T) {
 		assert.Equal(t, "http://localhost:4318", otel["endpoint"])
 	})
 
-	t.Run("should not override user-configured diagnostics.otel", func(t *testing.T) {
+	t.Run("should deep-merge sidecar keys into user-configured diagnostics.otel", func(t *testing.T) {
 		config := map[string]any{
 			"gateway": map[string]any{},
 			"diagnostics": map[string]any{
 				"otel": map[string]any{
-					"metrics":  true,
-					"endpoint": "http://custom:4318",
-					"tracing":  true,
+					"enabled":  true,
+					"endpoint": "http://langfuse.svc:3000/api/public/otel/v1/traces",
+					"traces":   true,
 				},
 			},
 		}
@@ -292,8 +292,54 @@ func TestInjectMetricsConfig(t *testing.T) {
 
 		diagnostics := config["diagnostics"].(map[string]any)
 		otel := diagnostics["otel"].(map[string]any)
-		assert.Equal(t, "http://custom:4318", otel["endpoint"])
-		assert.Equal(t, true, otel["tracing"])
+		assert.Equal(t, "http://langfuse.svc:3000/api/public/otel/v1/traces", otel["endpoint"],
+			"user endpoint should be preserved")
+		assert.Equal(t, true, otel["traces"], "user traces should be preserved")
+		assert.Equal(t, true, otel["enabled"], "user enabled should be preserved")
+		assert.Equal(t, true, otel["metrics"], "metrics should be injected")
+		assert.Equal(t, "http://localhost:4318", otel["metricsEndpoint"],
+			"metricsEndpoint should be injected for sidecar")
+	})
+
+	t.Run("should not override user-set metricsEndpoint", func(t *testing.T) {
+		config := map[string]any{
+			"gateway": map[string]any{},
+			"diagnostics": map[string]any{
+				"otel": map[string]any{
+					"enabled":         true,
+					"metricsEndpoint": "http://custom-collector:4318",
+				},
+			},
+		}
+		instance := testClawWithMetrics(true, nil)
+
+		injectMetricsConfig(config, instance)
+
+		otel := config["diagnostics"].(map[string]any)["otel"].(map[string]any)
+		assert.Equal(t, "http://custom-collector:4318", otel["metricsEndpoint"],
+			"user metricsEndpoint should not be overridden")
+		assert.Equal(t, true, otel["metrics"], "metrics should be injected when absent")
+	})
+
+	t.Run("should not override user-set metrics false", func(t *testing.T) {
+		config := map[string]any{
+			"gateway": map[string]any{},
+			"diagnostics": map[string]any{
+				"otel": map[string]any{
+					"enabled": true,
+					"metrics": false,
+				},
+			},
+		}
+		instance := testClawWithMetrics(true, nil)
+
+		injectMetricsConfig(config, instance)
+
+		otel := config["diagnostics"].(map[string]any)["otel"].(map[string]any)
+		assert.Equal(t, false, otel["metrics"],
+			"user metrics:false should be respected")
+		assert.Equal(t, "http://localhost:4318", otel["metricsEndpoint"],
+			"metricsEndpoint should still be injected")
 	})
 
 	t.Run("should be no-op when metrics not enabled", func(t *testing.T) {
@@ -542,6 +588,33 @@ func TestInjectMetricsConfigJSONRoundTrip(t *testing.T) {
 		otel := diagnostics["otel"].(map[string]any)
 		assert.Equal(t, true, otel["metrics"])
 		assert.Equal(t, "http://localhost:4318", otel["endpoint"])
+	})
+
+	t.Run("should produce valid JSON after deep-merge into user config", func(t *testing.T) {
+		operatorJSON := `{
+			"gateway": {"port": 18789},
+			"diagnostics": {"otel": {"enabled": true, "endpoint": "http://langfuse:3000/otel", "traces": true}}
+		}`
+
+		var config map[string]any
+		require.NoError(t, json.Unmarshal([]byte(operatorJSON), &config))
+
+		instance := testClawWithMetrics(true, nil)
+		injectMetricsConfig(config, instance)
+
+		result, err := json.Marshal(config)
+		require.NoError(t, err)
+
+		var roundTripped map[string]any
+		require.NoError(t, json.Unmarshal(result, &roundTripped))
+
+		diagnostics := roundTripped["diagnostics"].(map[string]any)
+		otel := diagnostics["otel"].(map[string]any)
+		assert.Equal(t, true, otel["enabled"], "user enabled preserved")
+		assert.Equal(t, "http://langfuse:3000/otel", otel["endpoint"], "user endpoint preserved")
+		assert.Equal(t, true, otel["traces"], "user traces preserved")
+		assert.Equal(t, true, otel["metrics"], "metrics injected")
+		assert.Equal(t, "http://localhost:4318", otel["metricsEndpoint"], "metricsEndpoint injected")
 	})
 }
 
@@ -826,7 +899,7 @@ func TestMetricsIntegration(t *testing.T) {
 		t.Fatal("otel-collector sidecar not found in deployment")
 	})
 
-	t.Run("should preserve user diagnostics.otel config from spec.config.raw", func(t *testing.T) {
+	t.Run("should deep-merge sidecar keys into user diagnostics.otel from spec.config.raw", func(t *testing.T) {
 		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
 
 		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
@@ -840,7 +913,7 @@ func TestMetricsIntegration(t *testing.T) {
 		instance.Spec.Config = &clawv1alpha1.ConfigSpec{
 			Raw: &clawv1alpha1.RawConfig{
 				RawExtension: runtime.RawExtension{
-					Raw: []byte(`{"diagnostics":{"otel":{"metrics":true,"endpoint":"http://custom-collector:4318","tracing":true}}}`),
+					Raw: []byte(`{"diagnostics":{"otel":{"enabled":true,"endpoint":"http://langfuse.svc:3000/api/public/otel/v1/traces","traces":true}}}`),
 				},
 			},
 		}
@@ -864,10 +937,14 @@ func TestMetricsIntegration(t *testing.T) {
 		require.True(t, ok)
 		otel, ok := diagnostics["otel"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "http://custom-collector:4318", otel["endpoint"],
+		assert.Equal(t, "http://langfuse.svc:3000/api/public/otel/v1/traces", otel["endpoint"],
 			"user-configured endpoint should be preserved")
-		assert.Equal(t, true, otel["tracing"],
-			"user-configured tracing should be preserved")
+		assert.Equal(t, true, otel["traces"],
+			"user-configured traces should be preserved")
+		assert.Equal(t, true, otel["metrics"],
+			"operator should inject metrics: true")
+		assert.Equal(t, "http://localhost:4318", otel["metricsEndpoint"],
+			"operator should inject metricsEndpoint for sidecar")
 	})
 
 	// Must be last: installing/deleting a CRD at runtime invalidates the discovery cache


### PR DESCRIPTION
- injectMetricsConfig now fills metrics + metricsEndpoint into existing user diagnostics.otel instead of skipping entirely, so combined Prometheus metrics and external tracing (e.g. Langfuse) works OOTB
- Backward compatible: no-user-config path unchanged (sets endpoint)
- User-set metrics:false and custom metricsEndpoint are respected
- Update user guide with combined metrics+tracing example
- Note diagnostics.otel exception in PLATFORM.md config tiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metrics configuration guide with clarified behavior for OpenTelemetry metrics and sidecar endpoint injection.
  * Added guidance for combining Prometheus metrics with external tracing configurations.

* **New Features**
  * Operator now injects OpenTelemetry metrics settings while respecting and preserving existing user-provided tracing and logging configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->