### PR TITLE
feat: add model fallback chain and default to Gemini 3.1 Pro

### DIFF
--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -99,12 +99,18 @@ data:
         console.warn("[init-config] existing openclaw.json is invalid JSON; falling back to seed");
       }
       const savedPrimary = base?.agents?.defaults?.model?.primary;
+      const savedFallbacks = base?.agents?.defaults?.model?.fallbacks;
       const merged = deepMerge(base, ops);
-      if (savedPrimary) {
+      if (savedPrimary || savedFallbacks) {
         merged.agents = merged.agents || {};
         merged.agents.defaults = merged.agents.defaults || {};
         merged.agents.defaults.model = merged.agents.defaults.model || {};
-        merged.agents.defaults.model.primary = savedPrimary;
+        if (savedPrimary) {
+          merged.agents.defaults.model.primary = savedPrimary;
+        }
+        if (savedFallbacks) {
+          merged.agents.defaults.model.fallbacks = savedFallbacks;
+        }
       }
       fs.writeFileSync(pvcPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
       console.log("[init-config] merged operator.json into existing openclaw.json");

--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -341,7 +341,7 @@ func TestInjectModelCatalog(t *testing.T) {
 		injectModelCatalog(config, testClawWithCredentials(credentials))
 
 		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
-		assert.Equal(t, "google/gemini-3.5-flash", model["primary"])
+		assert.Equal(t, "google/gemini-3.1-pro-preview", model["primary"])
 	})
 
 	t.Run("primary set from first provider with catalog", func(t *testing.T) {
@@ -436,6 +436,83 @@ func TestInjectModelCatalog(t *testing.T) {
 
 		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
 		assert.Equal(t, "anthropic/claude-sonnet-4-6", model["primary"])
+	})
+
+	t.Run("fallbacks set from remaining catalog models", func(t *testing.T) {
+		config := map[string]any{"models": map[string]any{"providers": map[string]any{}}}
+		credentials := []clawv1alpha1.CredentialSpec{
+			{Name: "gemini", Type: clawv1alpha1.CredentialTypeAPIKey, Provider: "google", Domain: "generativelanguage.googleapis.com"},
+		}
+
+		injectModelCatalog(config, testClawWithCredentials(credentials))
+
+		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
+		fallbacks, ok := model["fallbacks"].([]any)
+		require.True(t, ok, "fallbacks should be set")
+		require.Len(t, fallbacks, len(modelCatalog["google"])-1, "fallbacks should contain all non-primary models")
+		assert.Equal(t, "google/"+modelCatalog["google"][1].Name, fallbacks[0])
+		assert.Equal(t, "google/"+modelCatalog["google"][2].Name, fallbacks[1])
+		assert.Equal(t, "google/"+modelCatalog["google"][3].Name, fallbacks[2])
+	})
+
+	t.Run("fallbacks use same provider as primary", func(t *testing.T) {
+		config := map[string]any{"models": map[string]any{"providers": map[string]any{}}}
+		credentials := []clawv1alpha1.CredentialSpec{
+			{Name: "gemini", Type: clawv1alpha1.CredentialTypeAPIKey, Provider: "google", Domain: "generativelanguage.googleapis.com"},
+			{Name: "claude", Type: clawv1alpha1.CredentialTypeBearer, Provider: "anthropic", Domain: "api.anthropic.com"},
+		}
+
+		injectModelCatalog(config, testClawWithCredentials(credentials))
+
+		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
+		fallbacks, ok := model["fallbacks"].([]any)
+		require.True(t, ok)
+		for _, f := range fallbacks {
+			assert.Contains(t, f.(string), "google/", "fallbacks should only contain models from the primary provider")
+		}
+	})
+
+	t.Run("vertex credential fallbacks use provider-vertex prefix", func(t *testing.T) {
+		config := map[string]any{"models": map[string]any{"providers": map[string]any{}}}
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name: "claude-vertex", Type: clawv1alpha1.CredentialTypeGCP, Provider: "anthropic",
+				Domain: ".googleapis.com", GCP: &clawv1alpha1.GCPConfig{Project: "my-project", Location: "us-east5"},
+			},
+		}
+
+		injectModelCatalog(config, testClawWithCredentials(credentials))
+
+		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
+		assert.Equal(t, "anthropic-vertex/"+modelCatalog["anthropic"][0].Name, model["primary"])
+		fallbacks, ok := model["fallbacks"].([]any)
+		require.True(t, ok, "fallbacks should be set for vertex credentials")
+		for _, f := range fallbacks {
+			assert.Contains(t, f.(string), "anthropic-vertex/",
+				"vertex fallbacks must use the provider-vertex prefix")
+		}
+	})
+
+	t.Run("user fallbacks win over catalog default", func(t *testing.T) {
+		config := map[string]any{
+			"agents": map[string]any{
+				"defaults": map[string]any{
+					"model": map[string]any{
+						"fallbacks": []any{"anthropic/claude-sonnet-4-6"},
+					},
+				},
+			},
+		}
+		credentials := []clawv1alpha1.CredentialSpec{
+			{Name: "gemini", Type: clawv1alpha1.CredentialTypeAPIKey, Provider: "google", Domain: "generativelanguage.googleapis.com"},
+		}
+
+		injectModelCatalog(config, testClawWithCredentials(credentials))
+
+		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
+		fallbacks := model["fallbacks"].([]any)
+		require.Len(t, fallbacks, 1)
+		assert.Equal(t, "anthropic/claude-sonnet-4-6", fallbacks[0])
 	})
 
 	t.Run("catalog fills gaps when user has some models", func(t *testing.T) {
@@ -579,9 +656,12 @@ func TestOpenClawDynamicProviders(t *testing.T) {
 
 		catalogModels, hasModels := defaults["models"].(map[string]any)
 		require.True(t, hasModels, "operator.json should contain agents.defaults.models")
-		assert.Contains(t, catalogModels, "google/gemini-3.5-flash", "should have google model from catalog")
+		assert.Contains(t, catalogModels, "google/gemini-3.1-pro-preview", "should have google model from catalog")
 
 		model := defaults["model"].(map[string]any)
-		assert.Equal(t, "google/gemini-3.5-flash", model["primary"], "primary should be first google model")
+		assert.Equal(t, "google/gemini-3.1-pro-preview", model["primary"], "primary should be first google model")
+		fallbacks, ok := model["fallbacks"].([]any)
+		assert.True(t, ok, "fallbacks should be set")
+		assert.NotEmpty(t, fallbacks, "fallbacks should contain remaining catalog models")
 	})
 }

--- a/internal/controller/claw_merge_test.go
+++ b/internal/controller/claw_merge_test.go
@@ -326,7 +326,7 @@ func TestMergeJS(t *testing.T) {
 	t.Run("primary preserved on restart", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"}}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["google/gemini-3-flash-preview"]}, "models": {"google/gemini-3.1-pro-preview": {"alias": "Gemini 3.1 Pro"}}}}
 		}`
 		pvcJSON := `{
 			"agents": {"defaults": {"model": {"primary": "anthropic/claude-opus-4-7"}, "workspace": "~/.openclaw/workspace"}}
@@ -342,22 +342,28 @@ func TestMergeJS(t *testing.T) {
 	t.Run("primary set on first run", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"}}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["google/gemini-3-flash-preview"]}, "models": {"google/gemini-3.1-pro-preview": {"alias": "Gemini 3.1 Pro"}}}}
 		}`
 
 		result := runMergeJS(t, mergeTestSetup{operatorJSON: operatorJSON})
 
 		primary, hasPrimary := nestedValue(result.config, "agents.defaults.model.primary")
 		assert.True(t, hasPrimary, "should have primary model on first run")
-		assert.Equal(t, "google/gemini-3.5-flash", primary, "operator's primary should be used on first run")
+		assert.Equal(t, "google/gemini-3.1-pro-preview", primary, "operator's primary should be used on first run")
+
+		fallbacks, hasFallbacks := nestedValue(result.config, "agents.defaults.model.fallbacks")
+		assert.True(t, hasFallbacks, "should have fallbacks on first run")
+		fbSlice := fallbacks.([]any)
+		require.Len(t, fbSlice, 1)
+		assert.Equal(t, "google/gemini-3-flash-preview", fbSlice[0], "operator's fallbacks should be used on first run")
 	})
 
 	t.Run("primary preserved even when models change", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}, "models": {
-				"google/gemini-3.5-flash": {"alias": "Gemini 3.5 Flash"},
-				"google/gemini-3.1-pro-preview": {"alias": "Gemini 3.1 Pro"}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["google/gemini-3-flash-preview"]}, "models": {
+				"google/gemini-3.1-pro-preview": {"alias": "Gemini 3.1 Pro"},
+				"google/gemini-3-flash-preview": {"alias": "Gemini 3 Flash"}
 			}}}
 		}`
 		pvcJSON := `{
@@ -375,14 +381,14 @@ func TestMergeJS(t *testing.T) {
 		models, hasModels := nestedValue(result.config, "agents.defaults.models")
 		assert.True(t, hasModels)
 		modelsMap := models.(map[string]any)
-		assert.Contains(t, modelsMap, "google/gemini-3.5-flash", "new operator models should be merged in")
 		assert.Contains(t, modelsMap, "google/gemini-3.1-pro-preview", "new operator models should be merged in")
+		assert.Contains(t, modelsMap, "google/gemini-3-flash-preview", "new operator models should be merged in")
 	})
 
 	t.Run("primary not preserved in overwrite mode", func(t *testing.T) {
 		operatorJSON := `{
 			"gateway": {"port": 18789},
-			"agents": {"defaults": {"model": {"primary": "google/gemini-3.5-flash"}}}
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview"}}}
 		}`
 		pvcJSON := `{
 			"agents": {"defaults": {"model": {"primary": "anthropic/claude-opus-4-7"}}}
@@ -392,7 +398,43 @@ func TestMergeJS(t *testing.T) {
 
 		primary, hasPrimary := nestedValue(result.config, "agents.defaults.model.primary")
 		assert.True(t, hasPrimary)
-		assert.Equal(t, "google/gemini-3.5-flash", primary, "overwrite mode should reset to operator's primary")
+		assert.Equal(t, "google/gemini-3.1-pro-preview", primary, "overwrite mode should reset to operator's primary")
+	})
+
+	t.Run("fallbacks preserved on restart", func(t *testing.T) {
+		operatorJSON := `{
+			"gateway": {"port": 18789},
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["google/gemini-3-flash-preview", "google/gemini-3.5-flash"]}}}
+		}`
+		pvcJSON := `{
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["anthropic/claude-sonnet-4-6"]}}}
+		}`
+
+		result := runMergeJS(t, mergeTestSetup{operatorJSON: operatorJSON, pvcJSON: pvcJSON})
+
+		fallbacks, hasFallbacks := nestedValue(result.config, "agents.defaults.model.fallbacks")
+		assert.True(t, hasFallbacks, "should have fallbacks")
+		fbSlice := fallbacks.([]any)
+		require.Len(t, fbSlice, 1)
+		assert.Equal(t, "anthropic/claude-sonnet-4-6", fbSlice[0], "user's fallbacks should be preserved on restart")
+	})
+
+	t.Run("fallbacks not preserved in overwrite mode", func(t *testing.T) {
+		operatorJSON := `{
+			"gateway": {"port": 18789},
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["google/gemini-3-flash-preview"]}}}
+		}`
+		pvcJSON := `{
+			"agents": {"defaults": {"model": {"primary": "google/gemini-3.1-pro-preview", "fallbacks": ["anthropic/claude-sonnet-4-6"]}}}
+		}`
+
+		result := runMergeJS(t, mergeTestSetup{operatorJSON: operatorJSON, pvcJSON: pvcJSON, configMode: "overwrite"})
+
+		fallbacks, hasFallbacks := nestedValue(result.config, "agents.defaults.model.fallbacks")
+		assert.True(t, hasFallbacks)
+		fbSlice := fallbacks.([]any)
+		require.Len(t, fbSlice, 1)
+		assert.Equal(t, "google/gemini-3-flash-preview", fbSlice[0], "overwrite mode should reset to operator's fallbacks")
 	})
 
 	t.Run("workspace file seeded on first run", func(t *testing.T) {

--- a/internal/controller/claw_models.go
+++ b/internal/controller/claw_models.go
@@ -24,14 +24,15 @@ type modelEntry struct {
 
 // modelCatalog maps logical provider names to their known models.
 // Order matters: the first model becomes the default primary when this provider
-// is the first configured credential in the Claw CR. Lead with the best
-// cost/performance model, not the most expensive.
+// is the first configured credential in the Claw CR, and remaining models
+// become the fallback chain. Lead with the most stable, production-ready
+// model rather than the newest or cheapest.
 // Providers not in this map (e.g., "openrouter") are silently skipped.
 var modelCatalog = map[string][]modelEntry{
 	"google": {
-		{Name: "gemini-3.5-flash", Alias: "Gemini 3.5 Flash"},
-		{Name: "gemini-3-flash-preview", Alias: "Gemini 3 Flash"},
 		{Name: "gemini-3.1-pro-preview", Alias: "Gemini 3.1 Pro"},
+		{Name: "gemini-3-flash-preview", Alias: "Gemini 3 Flash"},
+		{Name: "gemini-3.5-flash", Alias: "Gemini 3.5 Flash"},
 		{Name: "gemini-3.1-flash-lite", Alias: "Gemini 3.1 Flash Lite"},
 	},
 	"anthropic": {

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -1086,12 +1086,13 @@ func injectProviders(config map[string]any, instance *clawv1alpha1.Claw) error {
 }
 
 // injectModelCatalog merges the hardcoded model catalog into
-// agents.defaults.models. Catalog entries fill gaps; user entries from
-// spec.config.raw win on collision. For primary: user value wins over
-// catalog default.
+// agents.defaults.models and sets the default primary + fallback chain.
+// Catalog entries fill gaps; user entries from spec.config.raw win on
+// collision. For primary and fallbacks: user values win over catalog defaults.
 func injectModelCatalog(config map[string]any, instance *clawv1alpha1.Claw) {
 	catalogModels := map[string]any{}
 	var catalogPrimary string
+	var catalogFallbacks []string
 
 	for _, cred := range instance.Spec.Credentials {
 		if cred.Provider == "" || cred.Type == clawv1alpha1.CredentialTypePathToken {
@@ -1118,6 +1119,9 @@ func injectModelCatalog(config map[string]any, instance *clawv1alpha1.Claw) {
 
 		if catalogPrimary == "" {
 			catalogPrimary = providerKey + "/" + catalog[0].Name
+			for _, m := range catalog[1:] {
+				catalogFallbacks = append(catalogFallbacks, providerKey+"/"+m.Name)
+			}
 		}
 	}
 
@@ -1144,6 +1148,13 @@ func injectModelCatalog(config map[string]any, instance *clawv1alpha1.Claw) {
 	}
 	if existing, _ := modelMap["primary"].(string); existing == "" {
 		modelMap["primary"] = catalogPrimary
+	}
+	if _, hasFallbacks := modelMap["fallbacks"]; !hasFallbacks && len(catalogFallbacks) > 0 {
+		fallbacksAny := make([]any, len(catalogFallbacks))
+		for i, f := range catalogFallbacks {
+			fallbacksAny[i] = f
+		}
+		modelMap["fallbacks"] = fallbacksAny
 	}
 	defaults["model"] = modelMap
 }


### PR DESCRIPTION
- Change default Google model from gemini-3.5-flash to gemini-3.1-pro-preview for stability (3.5 Flash experiencing load-related 503s)
- Inject remaining catalog models as fallback chain so the gateway automatically tries alternatives on 503/timeout/rate-limit errors
- Preserve user-configured fallbacks across pod restarts in merge.js
- User-set primary and fallbacks via spec.config.raw take precedence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model fallback configuration support for improved resilience when primary models are unavailable.

* **Improvements**
  * Model configurations now persist correctly during system restarts.
  * Updated default model selection prioritization to favor more stable, production-ready models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->