### PR TITLE
feat: skip device-pairing app deployment when `disableDevicePairing` is true

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,7 +10,6 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - secrets
-  - serviceaccounts
   verbs:
   - create
   - get
@@ -33,6 +32,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -48,6 +48,7 @@ rules:
   - deployments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -116,9 +117,20 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controller/claw_auth_test.go
+++ b/internal/controller/claw_auth_test.go
@@ -679,7 +679,7 @@ func TestPasswordAuthModeReconciliation(t *testing.T) {
 		reconciler := createClawReconciler()
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
-		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
 		updatedInstance := &clawv1alpha1.Claw{}

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -333,21 +334,21 @@ func TestDevicePairingReconciliation(t *testing.T) {
 			Name:      getDevicePairingDeploymentName(resourceName),
 			Namespace: namespace,
 		}, dpDeployment)
-		assert.Error(t, err, "device-pairing Deployment should not exist")
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing Deployment should not exist")
 
 		dpService := &corev1.Service{}
 		err = k8sClient.Get(ctx, client.ObjectKey{
 			Name:      getDevicePairingServiceName(resourceName),
 			Namespace: namespace,
 		}, dpService)
-		assert.Error(t, err, "device-pairing Service should not exist")
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing Service should not exist")
 
 		dpSA := &corev1.ServiceAccount{}
 		err = k8sClient.Get(ctx, client.ObjectKey{
 			Name:      getDevicePairingServiceAccountName(resourceName),
 			Namespace: namespace,
 		}, dpSA)
-		assert.Error(t, err, "device-pairing ServiceAccount should not exist")
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing ServiceAccount should not exist")
 	})
 
 	t.Run("should clean up device-pairing resources when disableDevicePairing is toggled to true", func(t *testing.T) {

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -27,9 +27,49 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
 func TestDevicePairingDeployment(t *testing.T) {
+
+	t.Run("buildKustomizedObjects excludes device-pairing resources when disableDevicePairing is true", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(true),
+		}
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err, "buildKustomizedObjects failed")
+
+		devicePairingKinds := map[string]string{
+			"ServiceAccount": getDevicePairingServiceAccountName(testInstanceName),
+			"Deployment":     getDevicePairingDeploymentName(testInstanceName),
+			"Service":        getDevicePairingServiceName(testInstanceName),
+			"Route":          getDevicePairingRouteName(testInstanceName),
+		}
+
+		for kind, name := range devicePairingKinds {
+			for _, obj := range objects {
+				if obj.GetKind() == kind && obj.GetName() == name {
+					t.Errorf("unexpected %s/%s in buildKustomizedObjects output when device pairing disabled", kind, name)
+				}
+			}
+		}
+
+		// Claw and proxy resources should still be present
+		var foundClawDeployment, foundProxyDeployment bool
+		for _, obj := range objects {
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getClawDeploymentName(testInstanceName) {
+				foundClawDeployment = true
+			}
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getProxyDeploymentName(testInstanceName) {
+				foundProxyDeployment = true
+			}
+		}
+		assert.True(t, foundClawDeployment, "claw Deployment should be present")
+		assert.True(t, foundProxyDeployment, "proxy Deployment should be present")
+	})
 
 	t.Run("buildKustomizedObjects includes device-pairing resources", func(t *testing.T) {
 		reconciler := createClawReconciler()
@@ -254,6 +294,102 @@ func TestDevicePairingDeployment(t *testing.T) {
 }
 
 func TestDevicePairingReconciliation(t *testing.T) {
+
+	t.Run("should not create device-pairing resources when disableDevicePairing is true", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = resourceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = testCredentials()
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(true),
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		// Core resources should exist
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(resourceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "claw Deployment should be created")
+
+		// Device-pairing resources should NOT exist
+		dpDeployment := &appsv1.Deployment{}
+		err := k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingDeploymentName(resourceName),
+			Namespace: namespace,
+		}, dpDeployment)
+		assert.Error(t, err, "device-pairing Deployment should not exist")
+
+		dpService := &corev1.Service{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceName(resourceName),
+			Namespace: namespace,
+		}, dpService)
+		assert.Error(t, err, "device-pairing Service should not exist")
+
+		dpSA := &corev1.ServiceAccount{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceAccountName(resourceName),
+			Namespace: namespace,
+		}, dpSA)
+		assert.Error(t, err, "device-pairing ServiceAccount should not exist")
+	})
+
+	t.Run("should clean up device-pairing resources when disableDevicePairing is toggled to true", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		// Create with device pairing enabled (default)
+		createClawInstance(t, ctx, resourceName, namespace)
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		// Verify device-pairing resources were created
+		dpDeployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingDeploymentName(resourceName),
+				Namespace: namespace,
+			}, dpDeployment) == nil
+		}, "device-pairing Deployment should be created initially")
+
+		// Toggle disableDevicePairing to true
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(true),
+		}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		// Device-pairing resources should be cleaned up
+		waitFor(t, timeout, interval, func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingDeploymentName(resourceName),
+				Namespace: namespace,
+			}, dpDeployment)
+			return err != nil
+		}, "device-pairing Deployment should be deleted after disabling")
+	})
 
 	t.Run("should create device-pairing resources after reconcile", func(t *testing.T) {
 		const resourceName = testInstanceName

--- a/internal/controller/claw_idle.go
+++ b/internal/controller/claw_idle.go
@@ -43,7 +43,9 @@ func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv
 	deploymentNames := []string{
 		getClawDeploymentName(instance.Name),
 		getProxyDeploymentName(instance.Name),
-		getDevicePairingDeploymentName(instance.Name),
+	}
+	if !shouldDisableDevicePairing(instance.Spec.Auth) {
+		deploymentNames = append(deploymentNames, getDevicePairingDeploymentName(instance.Name))
 	}
 
 	for _, name := range deploymentNames {

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -390,14 +391,14 @@ type ClawResourceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile manages the complete lifecycle of resources for Claw instances
 func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocyclo
@@ -426,6 +427,13 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		meta.RemoveStatusCondition(&instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
 		if err := r.Status().Update(ctx, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to persist Idle condition removal: %w", err)
+		}
+	}
+
+	// Clean up device-pairing resources if device pairing is now disabled
+	if shouldDisableDevicePairing(instance.Spec.Auth) {
+		if err := r.cleanupDevicePairingResources(ctx, instance); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clean up device-pairing resources: %w", err)
 		}
 	}
 
@@ -517,12 +525,13 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 		}
 
-		// Inject Claw Route host into device-pairing Route and apply it
-		if err := injectRouteHostIntoDevicePairingRoute(objects, routeHost, instance.Name); err != nil {
-			return ctrl.Result{}, err
-		}
-		if _, err := r.applyRouteByName(ctx, objects, instance, getDevicePairingRouteName(instance.Name)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to apply device-pairing Route: %w", err)
+		if !shouldDisableDevicePairing(instance.Spec.Auth) {
+			if err := injectRouteHostIntoDevicePairingRoute(objects, routeHost, instance.Name); err != nil {
+				return ctrl.Result{}, err
+			}
+			if _, err := r.applyRouteByName(ctx, objects, instance, getDevicePairingRouteName(instance.Name)); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to apply device-pairing Route: %w", err)
+			}
 		}
 	} else {
 		// Route CRD not registered - proceed with localhost fallback
@@ -897,22 +906,24 @@ func (r *ClawResourceReconciler) buildKustomizedObjects(instance *clawv1alpha1.C
 		"manifests/claw-proxy/network-policies.yaml": readEmbeddedFile("manifests/claw-proxy/network-policies.yaml"),
 	}
 
-	// Device pairing component manifests
-	devicePairingManifests := map[string][]byte{
-		"manifests/claw-device-pairing/kustomization.yaml":  readEmbeddedFile("manifests/claw-device-pairing/kustomization.yaml"),
-		"manifests/claw-device-pairing/serviceaccount.yaml": readEmbeddedFile("manifests/claw-device-pairing/serviceaccount.yaml"),
-		"manifests/claw-device-pairing/clusterrole.yaml":    readEmbeddedFile("manifests/claw-device-pairing/clusterrole.yaml"),
-		"manifests/claw-device-pairing/rolebinding.yaml":    readEmbeddedFile("manifests/claw-device-pairing/rolebinding.yaml"),
-		"manifests/claw-device-pairing/deployment.yaml":     readEmbeddedFile("manifests/claw-device-pairing/deployment.yaml"),
-		"manifests/claw-device-pairing/service.yaml":        readEmbeddedFile("manifests/claw-device-pairing/service.yaml"),
-		"manifests/claw-device-pairing/route.yaml":          readEmbeddedFile("manifests/claw-device-pairing/route.yaml"),
-	}
-
 	// Write all files to in-memory filesystem
-	allManifests := make(map[string][]byte, len(clawManifests)+len(proxyManifests)+len(devicePairingManifests))
+	allManifests := make(map[string][]byte, len(clawManifests)+len(proxyManifests))
 	maps.Copy(allManifests, clawManifests)
 	maps.Copy(allManifests, proxyManifests)
-	maps.Copy(allManifests, devicePairingManifests)
+
+	devicePairingEnabled := !shouldDisableDevicePairing(instance.Spec.Auth)
+	if devicePairingEnabled {
+		devicePairingManifests := map[string][]byte{
+			"manifests/claw-device-pairing/kustomization.yaml":  readEmbeddedFile("manifests/claw-device-pairing/kustomization.yaml"),
+			"manifests/claw-device-pairing/serviceaccount.yaml": readEmbeddedFile("manifests/claw-device-pairing/serviceaccount.yaml"),
+			"manifests/claw-device-pairing/clusterrole.yaml":    readEmbeddedFile("manifests/claw-device-pairing/clusterrole.yaml"),
+			"manifests/claw-device-pairing/rolebinding.yaml":    readEmbeddedFile("manifests/claw-device-pairing/rolebinding.yaml"),
+			"manifests/claw-device-pairing/deployment.yaml":     readEmbeddedFile("manifests/claw-device-pairing/deployment.yaml"),
+			"manifests/claw-device-pairing/service.yaml":        readEmbeddedFile("manifests/claw-device-pairing/service.yaml"),
+			"manifests/claw-device-pairing/route.yaml":          readEmbeddedFile("manifests/claw-device-pairing/route.yaml"),
+		}
+		maps.Copy(allManifests, devicePairingManifests)
+	}
 
 	for path, content := range allManifests {
 		replaced := bytes.ReplaceAll(content, []byte("CLAW_INSTANCE_NAME"), []byte(instance.Name))
@@ -933,15 +944,16 @@ func (r *ClawResourceReconciler) buildKustomizedObjects(instance *clawv1alpha1.C
 		return nil, err
 	}
 
-	// Build device pairing component
-	devicePairingObjects, err := r.buildKustomizeFromPath(fs, "manifests/claw-device-pairing")
-	if err != nil {
-		return nil, err
-	}
-
 	// Merge all object lists
 	allObjects := append(clawObjects, proxyObjects...)
-	allObjects = append(allObjects, devicePairingObjects...)
+
+	if devicePairingEnabled {
+		devicePairingObjects, err := r.buildKustomizeFromPath(fs, "manifests/claw-device-pairing")
+		if err != nil {
+			return nil, err
+		}
+		allObjects = append(allObjects, devicePairingObjects...)
+	}
 
 	// Inject instance labels into selectors for multi-instance discrimination
 	if err := injectInstanceLabels(allObjects, instance.Name); err != nil {
@@ -1006,6 +1018,62 @@ func (r *ClawResourceReconciler) applyRouteByName(ctx context.Context, objects [
 
 func getDevicePairingRouteName(instanceName string) string {
 	return instanceName + "-device-pairing"
+}
+
+func getDevicePairingRoleBindingName(instanceName string) string {
+	return instanceName + "-device-pairing"
+}
+
+func (r *ClawResourceReconciler) cleanupDevicePairingResources(ctx context.Context, instance *clawv1alpha1.Claw) error {
+	logger := log.FromContext(ctx)
+	name := instance.Name
+	ns := instance.Namespace
+
+	resources := []client.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: getDevicePairingDeploymentName(name), Namespace: ns}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: getDevicePairingServiceName(name), Namespace: ns}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: getDevicePairingServiceAccountName(name), Namespace: ns}},
+		newDevicePairingRouteUnstructured(name, ns),
+		newDevicePairingRoleBindingUnstructured(name, ns),
+	}
+
+	for _, obj := range resources {
+		if err := r.Delete(ctx, obj); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				continue
+			}
+			return fmt.Errorf("failed to delete device-pairing resource %s/%s: %w",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+		}
+		logger.Info("Deleted device-pairing resource",
+			"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"name", obj.GetName())
+	}
+	return nil
+}
+
+func newDevicePairingRouteUnstructured(instanceName, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "route.openshift.io",
+		Version: "v1",
+		Kind:    RouteKind,
+	})
+	u.SetName(getDevicePairingRouteName(instanceName))
+	u.SetNamespace(ns)
+	return u
+}
+
+func newDevicePairingRoleBindingUnstructured(instanceName, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "rbac.authorization.k8s.io",
+		Version: "v1",
+		Kind:    "RoleBinding",
+	})
+	u.SetName(getDevicePairingRoleBindingName(instanceName))
+	u.SetNamespace(ns)
+	return u
 }
 
 func isClusterScoped(obj *unstructured.Unstructured) bool {

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -59,12 +59,15 @@ func (r *ClawResourceReconciler) getDeploymentAvailableStatus(ctx context.Contex
 	return false, nil
 }
 
-// checkDeploymentsReady checks if all managed Deployments (claw, claw-proxy, claw-device-pairing) are ready
-func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, namespace, instanceName string) (bool, []string, error) {
+// checkDeploymentsReady checks if all managed Deployments are ready.
+// When device pairing is disabled, the device-pairing Deployment is excluded.
+func (r *ClawResourceReconciler) checkDeploymentsReady(ctx context.Context, namespace, instanceName string, auth *clawv1alpha1.AuthSpec) (bool, []string, error) {
 	deployNames := []string{
 		getClawDeploymentName(instanceName),
 		getProxyDeploymentName(instanceName),
-		getDevicePairingDeploymentName(instanceName),
+	}
+	if !shouldDisableDevicePairing(auth) {
+		deployNames = append(deployNames, getDevicePairingDeploymentName(instanceName))
 	}
 
 	var pending []string
@@ -221,7 +224,7 @@ func buildClawURL(routeURL, token string) string {
 // updateStatus updates the Claw status with current deployment conditions
 func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *clawv1alpha1.Claw) error {
 	// check deployment readiness
-	ready, pending, err := r.checkDeploymentsReady(ctx, instance.Namespace, instance.Name)
+	ready, pending, err := r.checkDeploymentsReady(ctx, instance.Namespace, instance.Name, instance.Spec.Auth)
 	if err != nil {
 		return fmt.Errorf("failed to check deployment readiness: %w", err)
 	}
@@ -229,12 +232,15 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 	// Set Ready condition
 	setReadyCondition(instance, ready, pending)
 
-	// Set DevicePairingConfigured condition — derived from the pending list above to avoid a duplicate API call
-	dpReady := !slices.Contains(pending, getDevicePairingDeploymentName(instance.Name))
-	if dpReady {
-		setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionTrue, clawv1alpha1.ConditionReasonConfigured, "Device pairing deployment is available")
+	if shouldDisableDevicePairing(instance.Spec.Auth) {
+		meta.RemoveStatusCondition(&instance.Status.Conditions, clawv1alpha1.ConditionTypeDevicePairingConfigured)
 	} else {
-		setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonProvisioning, "Waiting for device pairing deployment to become ready")
+		dpReady := !slices.Contains(pending, getDevicePairingDeploymentName(instance.Name))
+		if dpReady {
+			setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionTrue, clawv1alpha1.ConditionReasonConfigured, "Device pairing deployment is available")
+		} else {
+			setCondition(instance, clawv1alpha1.ConditionTypeDevicePairingConfigured, metav1.ConditionFalse, clawv1alpha1.ConditionReasonProvisioning, "Waiting for device pairing deployment to become ready")
+		}
 	}
 
 	// Expose gateway secret name in status

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -311,6 +311,63 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			assert.Equal(t, clawv1alpha1.ConditionReasonConfigured, condition.Reason)
 		})
 
+		t.Run("should set Ready True when claw and proxy are ready and device-pairing is disabled", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+			instance := &clawv1alpha1.Claw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.Credentials = testCredentials()
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+				DisableDevicePairing: boolPtr(true),
+			}
+			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			setDeploymentAvailable(t, ctx, getClawDeploymentName(testInstanceName), namespace)
+			setDeploymentAvailable(t, ctx, getProxyDeploymentName(testInstanceName), namespace)
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeReady)
+			require.NotNil(t, condition)
+			assert.Equal(t, metav1.ConditionTrue, condition.Status, "Ready should be True when claw+proxy are ready and device-pairing is disabled")
+		})
+
+		t.Run("should not set DevicePairingConfigured when device-pairing is disabled", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+			instance := &clawv1alpha1.Claw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.Credentials = testCredentials()
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+				DisableDevicePairing: boolPtr(true),
+			}
+			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeDevicePairingConfigured)
+			assert.Nil(t, condition, "DevicePairingConfigured should not be set when device pairing is disabled")
+		})
+
 		t.Run("should keep Ready False when claw and proxy are ready but device-pairing is not", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -372,6 +372,13 @@ func setAllDeploymentsAvailable(t *testing.T, ctx context.Context, instanceName,
 	setDeploymentAvailable(t, ctx, getDevicePairingDeploymentName(instanceName), namespace)
 }
 
+// setCoreDeploymentsAvailable marks claw and claw-proxy Deployments as available (no device-pairing).
+func setCoreDeploymentsAvailable(t *testing.T, ctx context.Context, instanceName, namespace string) { //nolint:unparam
+	t.Helper()
+	setDeploymentAvailable(t, ctx, getClawDeploymentName(instanceName), namespace)
+	setDeploymentAvailable(t, ctx, getProxyDeploymentName(instanceName), namespace)
+}
+
 // reconcileClaw performs a reconciliation for the given Claw resource.
 func reconcileClaw(t *testing.T, ctx context.Context, reconciler *ClawResourceReconciler, name, namespace string) {
 	t.Helper()

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/design.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The claw-operator currently always deploys the device-pairing application (Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, Route) as part of the Kustomize build in `buildKustomizedObjects()`. The `spec.auth.disableDevicePairing` field already exists and controls whether the gateway's `dangerouslyDisableDeviceAuth` config flag is set, but it does not affect whether the device-pairing app itself is deployed. When device pairing is disabled, the app runs uselessly.
+
+The controller's three-phase reconciliation builds all Kustomize components (claw, claw-proxy, claw-device-pairing) into a single `[]*unstructured.Unstructured` slice. Device-pairing resources are woven into several post-build steps: route host injection, status condition checking, idle scaling, and cleanup.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Skip building and applying device-pairing Kustomize component when `shouldDisableDevicePairing()` returns `true`
+- Clean up previously-deployed device-pairing resources when a user toggles `disableDevicePairing` from `false` to `true`
+- Adapt status conditions so the `Ready` condition does not block on a deployment that was intentionally not created
+- Adapt idle handling to skip the device-pairing deployment when it doesn't exist
+- Add e2e test coverage for the disabled-device-pairing scenario
+
+**Non-Goals:**
+
+- Changing the behavior of the `ClawDevicePairingRequest` controller — it already handles missing pods gracefully
+- Adding a finalizer or additional CRD fields
+- Changing the default behavior (device pairing enabled by default)
+
+## Decisions
+
+### 1. Conditionally build Kustomize component
+
+**Decision**: In `buildKustomizedObjects()`, skip adding device-pairing manifests to the in-memory filesystem and skip building the `claw-device-pairing` Kustomize component when device pairing is disabled.
+
+**Rationale**: This is the earliest point where resources can be excluded. By not including them in the rendered objects slice, all downstream code (route injection, apply, status) naturally has fewer objects to process. The alternative — building them and filtering later — would require more changes and is harder to reason about.
+
+**Approach**: Pass the `*Claw` instance (or a `bool`) to `buildKustomizedObjects()` so it can conditionally skip the device-pairing component. The existing `shouldDisableDevicePairing()` function determines the flag.
+
+### 2. Skip device-pairing Route injection when disabled
+
+**Decision**: Guard the `injectRouteHostIntoDevicePairingRoute()` call and the subsequent `applyRouteByName()` call with the same `shouldDisableDevicePairing()` check.
+
+**Rationale**: If device-pairing objects are not in the slice, `injectRouteHostIntoDevicePairingRoute()` will return an error ("Route not found in rendered manifests"). Rather than making that function tolerate missing routes (which would hide real bugs when pairing is enabled), we skip the call entirely.
+
+### 3. Conditional status condition and deployment readiness
+
+**Decision**: In `checkDeploymentsReady()` and `updateStatus()`, conditionally exclude the device-pairing deployment from the readiness check and skip setting the `DevicePairingConfigured` condition.
+
+**Rationale**: If the deployment is intentionally not created, checking its readiness would permanently block the `Ready` condition. The `DevicePairingConfigured` condition is meaningless when pairing is disabled — setting it would be confusing. We'll pass the Claw instance (or relevant auth info) to these functions so they can adjust.
+
+When device pairing transitions from enabled to disabled, we should also remove the `DevicePairingConfigured` condition from the status to keep conditions clean.
+
+### 4. Cleanup of previously-deployed resources
+
+**Decision**: When `shouldDisableDevicePairing()` is `true`, delete any existing device-pairing resources (Deployment, Service, ServiceAccount, RoleBinding, Route) that were created by a previous reconcile where pairing was enabled.
+
+**Rationale**: Leaving orphaned resources wastes cluster resources and could cause confusion. Since all device-pairing resources have owner references pointing to the Claw CR, we could rely on garbage collection if we deleted the owner ref — but explicitly deleting is cleaner and gives immediate feedback. We'll delete by name using the existing naming helpers (`getDevicePairingDeploymentName`, etc.).
+
+**Approach**: Add a `cleanupDevicePairingResources()` function that attempts to delete each device-pairing resource. NotFound errors are ignored (idempotent). This runs early in the reconcile loop when `shouldDisableDevicePairing()` is `true`.
+
+### 5. Conditional idle scaling
+
+**Decision**: In `handleIdle()`, skip the device-pairing deployment when `shouldDisableDevicePairing()` is `true`.
+
+**Rationale**: Attempting to scale a non-existent deployment would cause an error. The idle handler lists deployment names to scale; we conditionally exclude the device-pairing deployment name.
+
+### 6. E2E test approach
+
+**Decision**: Add e2e test cases that create a Claw CR with `spec.auth.disableDevicePairing: true` and verify that device-pairing resources (Deployment, Service, ServiceAccount) are not created, while verifying the Claw instance reaches Ready state.
+
+**Rationale**: E2e tests validate the full reconciliation loop including Kustomize rendering, server-side apply, and status updates — all of which are affected by this change.
+
+## Risks / Trade-offs
+
+- **[Risk] ClusterRole/ClusterRoleBinding not namespaced** → These are cluster-scoped resources with owner references. Deletion requires special handling (no namespace). The existing cleanup in `suite_test.go` already handles this pattern — follow the same approach.
+- **[Risk] Race between disable toggle and in-flight pairing requests** → If a user disables pairing while a `ClawDevicePairingRequest` is being processed, the pairing request controller may try to exec into a pod that no longer exists. Mitigation: the pairing request controller already handles pod-not-found gracefully with condition updates. This is acceptable.
+- **[Trade-off] Explicit deletion vs. relying on GC** → We choose explicit deletion for immediate cleanup rather than waiting for garbage collection. This adds code but provides predictable behavior.

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/proposal.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+When `spec.auth.disableDevicePairing` is `true`, the device pairing app serves no purpose — browser device identity checks are disabled, so no pairing requests will ever be issued. Deploying the device-pairing Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, and Route wastes cluster resources and adds unnecessary attack surface.
+
+## What Changes
+
+- When `spec.auth.disableDevicePairing` is explicitly `true`, skip rendering and applying all `claw-device-pairing` Kustomize component resources (Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, Route).
+- When `spec.auth.disableDevicePairing` is `false` or unset, deploy the device-pairing app as today (default behavior preserved).
+- When device pairing is disabled, clean up any previously-deployed device-pairing resources (handles the transition from enabled → disabled).
+- Adapt status conditions: skip the `DevicePairingConfigured` condition check when device pairing is disabled. The `Ready` condition should not depend on a deployment that was intentionally skipped.
+- Adapt idle handling: skip scaling the device-pairing Deployment to zero when device pairing is disabled.
+- Add e2e tests covering both the enabled and disabled device-pairing scenarios.
+
+## Capabilities
+
+### New Capabilities
+
+- `optional-device-pairing-app-deployment`: Conditional deployment of the device-pairing application based on `spec.auth.disableDevicePairing`. Covers resource lifecycle (skip deploy, cleanup on disable), status condition adaptation, and idle handling.
+
+### Modified Capabilities
+
+- `device-pairing-deployment`: The device-pairing Deployment is now conditionally deployed. Existing spec requirements still apply when pairing is enabled; they are skipped when disabled.
+- `status-conditions`: The `DevicePairingConfigured` condition behavior changes — it should not be set (or should be removed) when device pairing is disabled, to avoid blocking the `Ready` condition.
+
+## Impact
+
+- **Controller code** (`internal/controller/`): `claw_resource_controller.go` (manifest rendering, route injection), `claw_status.go` (deployment readiness checks, condition setting), `claw_idle.go` (deployment scaling).
+- **Unit tests**: `claw_device_pairing_deployment_test.go`, `claw_status_test.go`, `claw_idle_test.go`, `suite_test.go` (cleanup and helper functions need to be conditional).
+- **E2E tests** (`test/e2e/`): New test cases for the disabled-device-pairing scenario.
+- **No API changes**: The `DisableDevicePairing` field already exists in `api/v1alpha1/claw_types.go`. No CRD regeneration needed.

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/device-pairing-deployment/spec.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/device-pairing-deployment/spec.md
@@ -1,15 +1,15 @@
 ## MODIFIED Requirements
 
 ### Requirement: Device pairing manifests exist as embedded Kustomize directory
-The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, ClusterRole, RoleBinding, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
 
 #### Scenario: Kustomize directory structure
 - **WHEN** examining `internal/assets/manifests/claw-device-pairing/`
-- **THEN** it SHALL contain `kustomization.yaml`, `serviceaccount.yaml`, `deployment.yaml`, `service.yaml`, and `route.yaml`
+- **THEN** it SHALL contain `kustomization.yaml`, `serviceaccount.yaml`, `clusterrole.yaml`, `rolebinding.yaml`, `deployment.yaml`, `service.yaml`, and `route.yaml`
 
 #### Scenario: Kustomization references all resources
 - **WHEN** examining `kustomization.yaml`
-- **THEN** it SHALL list all four resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+- **THEN** it SHALL list all six resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
 
 #### Scenario: Manifests excluded from build when device pairing disabled
 - **WHEN** `shouldDisableDevicePairing()` returns `true`

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/device-pairing-deployment/spec.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/device-pairing-deployment/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Device pairing manifests exist as embedded Kustomize directory
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
+
+#### Scenario: Kustomize directory structure
+- **WHEN** examining `internal/assets/manifests/claw-device-pairing/`
+- **THEN** it SHALL contain `kustomization.yaml`, `serviceaccount.yaml`, `deployment.yaml`, `service.yaml`, and `route.yaml`
+
+#### Scenario: Kustomization references all resources
+- **WHEN** examining `kustomization.yaml`
+- **THEN** it SHALL list all four resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+
+#### Scenario: Manifests excluded from build when device pairing disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the `buildKustomizedObjects()` function SHALL NOT include `claw-device-pairing` manifests in the in-memory filesystem
+- **THEN** the returned objects slice SHALL NOT contain any device-pairing resources

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/optional-device-pairing-app-deployment/spec.md
@@ -32,7 +32,7 @@ When device pairing transitions from enabled to disabled, the controller SHALL d
 
 #### Scenario: Cleanup on disable toggle
 - **WHEN** a Claw CR previously had device pairing enabled (resources exist) and `spec.auth.disableDevicePairing` is changed to `true`
-- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, RoleBinding, and Route
+- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, and Route
 - **THEN** NotFound errors during deletion SHALL be silently ignored (idempotent)
 
 #### Scenario: Cleanup is idempotent

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/optional-device-pairing-app-deployment/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Device pairing resources are skipped when disabled
+The controller SHALL NOT build, render, or apply any `claw-device-pairing` Kustomize component resources (Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, Route) when `shouldDisableDevicePairing()` returns `true`.
+
+#### Scenario: Claw CR with disableDevicePairing true
+- **WHEN** a Claw CR is created with `spec.auth.disableDevicePairing: true`
+- **THEN** the controller SHALL NOT create a Deployment named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a Service named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a ServiceAccount named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a Route named `{instance}-device-pairing`
+- **THEN** the Claw instance SHALL reach `Ready=True` without the device-pairing deployment
+
+#### Scenario: Claw CR with disableDevicePairing false
+- **WHEN** a Claw CR is created with `spec.auth.disableDevicePairing: false`
+- **THEN** the controller SHALL create all device-pairing resources as normal
+
+#### Scenario: Claw CR with disableDevicePairing unset
+- **WHEN** a Claw CR is created without the `spec.auth.disableDevicePairing` field
+- **THEN** the controller SHALL create all device-pairing resources as normal (default behavior preserved)
+
+### Requirement: Device pairing Route injection is skipped when disabled
+The controller SHALL NOT call `injectRouteHostIntoDevicePairingRoute()` or attempt to apply the device-pairing Route when device pairing is disabled.
+
+#### Scenario: No Route injection when disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and the Claw Route host has been resolved
+- **THEN** the controller SHALL skip the `injectRouteHostIntoDevicePairingRoute()` call
+- **THEN** the controller SHALL skip the `applyRouteByName()` call for the device-pairing Route
+
+### Requirement: Previously deployed device-pairing resources are cleaned up
+When device pairing transitions from enabled to disabled, the controller SHALL delete any previously-deployed device-pairing resources to avoid leaving orphaned resources in the cluster.
+
+#### Scenario: Cleanup on disable toggle
+- **WHEN** a Claw CR previously had device pairing enabled (resources exist) and `spec.auth.disableDevicePairing` is changed to `true`
+- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, RoleBinding, and Route
+- **THEN** NotFound errors during deletion SHALL be silently ignored (idempotent)
+
+#### Scenario: Cleanup is idempotent
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and no device-pairing resources exist
+- **THEN** the cleanup SHALL complete without errors
+
+### Requirement: Idle scaling skips device-pairing when disabled
+The `handleIdle()` function SHALL NOT attempt to scale the device-pairing Deployment to zero when device pairing is disabled.
+
+#### Scenario: Idle with device pairing disabled
+- **WHEN** `spec.idle` is `true` and `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL only scale the claw and proxy Deployments to zero
+- **THEN** the controller SHALL NOT attempt to scale `{instance}-device-pairing`
+
+### Requirement: E2E test covers disabled device pairing
+The e2e test suite SHALL include a test case verifying that a Claw CR with `spec.auth.disableDevicePairing: true` does not create device-pairing resources and reaches the Ready state.
+
+#### Scenario: E2E disabled device pairing
+- **WHEN** a Claw CR is applied with `spec.auth.disableDevicePairing: true` and valid credentials
+- **THEN** the claw and proxy Deployments SHALL be created
+- **THEN** no device-pairing Deployment SHALL exist
+- **THEN** no device-pairing Service SHALL exist
+- **THEN** no device-pairing ServiceAccount SHALL exist
+- **THEN** the Claw instance SHALL eventually reach `Ready=True`
+
+#### Scenario: E2E enabled device pairing (existing behavior preserved)
+- **WHEN** a Claw CR is applied without `spec.auth.disableDevicePairing` and valid credentials
+- **THEN** the device-pairing Deployment SHALL be created alongside the claw and proxy Deployments

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/status-conditions/spec.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/specs/status-conditions/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Ready condition indicates overall readiness
+The controller SHALL maintain a Ready condition type to indicate whether the Claw instance is ready for use. When device pairing is disabled, the Ready condition SHALL NOT depend on the device-pairing Deployment.
+
+#### Scenario: Ready condition set to False during provisioning
+- **WHEN** a Claw instance named 'instance' is created
+- **THEN** the controller SHALL set Ready condition with status=False, reason=Provisioning, message describing deployment progress
+
+#### Scenario: Ready condition set to True when ready (device pairing enabled)
+- **WHEN** the claw, proxy, and device-pairing Deployments all have Available=True status
+- **THEN** the controller SHALL set Ready condition with status=True, reason=Ready
+
+#### Scenario: Ready condition set to True when ready (device pairing disabled)
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and the claw and proxy Deployments have Available=True status
+- **THEN** the controller SHALL set Ready condition with status=True, reason=Ready
+- **THEN** the controller SHALL NOT check the device-pairing Deployment status
+
+#### Scenario: DevicePairingConfigured condition omitted when disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL NOT set the `DevicePairingConfigured` condition
+- **THEN** if a `DevicePairingConfigured` condition previously existed, the controller SHALL remove it from the status conditions
+
+### Requirement: Controller checks Deployment status conditions
+The controller SHALL read the Available condition from managed Deployments to determine readiness. The set of managed Deployments SHALL vary based on whether device pairing is enabled.
+
+#### Scenario: Deployments checked when device pairing enabled
+- **WHEN** `shouldDisableDevicePairing()` returns `false`
+- **THEN** the controller SHALL check readiness of claw, proxy, and device-pairing Deployments
+
+#### Scenario: Deployments checked when device pairing disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL check readiness of only the claw and proxy Deployments
+- **THEN** the controller SHALL NOT attempt to fetch the device-pairing Deployment status

--- a/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/tasks.md
+++ b/openspec/changes/archive/2026-05-28-optional-device-pairing-deployment/tasks.md
@@ -1,0 +1,35 @@
+## 1. Conditional Kustomize Build
+
+- [x] 1.1 Modify `buildKustomizedObjects()` to accept the Claw instance (or `disableDevicePairing` bool) and conditionally skip adding `claw-device-pairing` manifests to the in-memory filesystem and building the device-pairing Kustomize component
+- [x] 1.2 Update the call site in `Reconcile()` to pass the required parameter to `buildKustomizedObjects()`
+
+## 2. Skip Device-Pairing Route Injection
+
+- [x] 2.1 Guard the `injectRouteHostIntoDevicePairingRoute()` and `applyRouteByName()` calls for the device-pairing Route with a `shouldDisableDevicePairing()` check in the reconcile loop
+
+## 3. Cleanup Previously-Deployed Resources
+
+- [x] 3.1 Add a `cleanupDevicePairingResources()` function that deletes Deployment, Service, ServiceAccount, RoleBinding, and Route for device-pairing by name, ignoring NotFound errors
+- [x] 3.2 Call `cleanupDevicePairingResources()` early in the reconcile loop when `shouldDisableDevicePairing()` returns `true`
+
+## 4. Status Condition Adaptation
+
+- [x] 4.1 Modify `checkDeploymentsReady()` to accept a flag or auth spec and exclude the device-pairing Deployment from the readiness check when device pairing is disabled
+- [x] 4.2 Modify `updateStatus()` to skip setting the `DevicePairingConfigured` condition and remove it from existing conditions when device pairing is disabled
+
+## 5. Idle Scaling Adaptation
+
+- [x] 5.1 Modify `handleIdle()` to conditionally exclude the device-pairing Deployment from the list of deployments to scale to zero when device pairing is disabled
+
+## 6. Unit Tests
+
+- [x] 6.1 Add unit tests in `claw_resource_controller_test.go` or `claw_device_pairing_deployment_test.go` verifying that `buildKustomizedObjects()` excludes device-pairing resources when `disableDevicePairing` is true
+- [x] 6.2 Add unit tests verifying that `checkDeploymentsReady()` does not check the device-pairing Deployment when disabled
+- [x] 6.3 Add unit tests verifying that status conditions omit `DevicePairingConfigured` when device pairing is disabled
+- [x] 6.4 Update existing tests in `suite_test.go` helpers (`cleanupResources`, `setAllDeploymentsAvailable`) to handle the conditional presence of device-pairing resources
+- [x] 6.5 Run `make test` and ensure all existing and new tests pass
+
+## 7. E2E Tests
+
+- [x] 7.1 Add an e2e test case that creates a Claw CR with `spec.auth.disableDevicePairing: true` and verifies device-pairing Deployment/Service/ServiceAccount are not created, while the Claw reaches Ready state
+- [x] 7.2 Verify the existing e2e test (device pairing enabled by default) still passes as a regression check

--- a/openspec/specs/device-pairing-deployment/spec.md
+++ b/openspec/specs/device-pairing-deployment/spec.md
@@ -1,5 +1,5 @@
 ### Requirement: Device pairing manifests exist as embedded Kustomize directory
-The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route.
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
 
 #### Scenario: Kustomize directory structure
 - **WHEN** examining `internal/assets/manifests/claw-device-pairing/`
@@ -8,6 +8,11 @@ The system SHALL include a `claw-device-pairing` directory under `internal/asset
 #### Scenario: Kustomization references all resources
 - **WHEN** examining `kustomization.yaml`
 - **THEN** it SHALL list all four resource files and apply the `app.kubernetes.io/name: claw-device-pairing` label via the Kustomize `labels` directive
+
+#### Scenario: Manifests excluded from build when device pairing disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the `buildKustomizedObjects()` function SHALL NOT include `claw-device-pairing` manifests in the in-memory filesystem
+- **THEN** the returned objects slice SHALL NOT contain any device-pairing resources
 
 ### Requirement: Device pairing resources use CLAW_INSTANCE_NAME naming
 All device-pairing resource names SHALL use the `CLAW_INSTANCE_NAME-device-pairing` template, which is replaced with the actual Claw CR name at build time by the existing `bytes.ReplaceAll` in `buildKustomizedObjects()`.

--- a/openspec/specs/device-pairing-deployment/spec.md
+++ b/openspec/specs/device-pairing-deployment/spec.md
@@ -1,5 +1,5 @@
 ### Requirement: Device pairing manifests exist as embedded Kustomize directory
-The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
+The system SHALL include a `claw-device-pairing` directory under `internal/assets/manifests/` containing a `kustomization.yaml` and resource YAML files for ServiceAccount, ClusterRole, RoleBinding, Deployment, Service, and Route. The controller SHALL only include these manifests in the Kustomize build when device pairing is enabled (`shouldDisableDevicePairing()` returns `false`).
 
 #### Scenario: Kustomize directory structure
 - **WHEN** examining `internal/assets/manifests/claw-device-pairing/`

--- a/openspec/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/specs/optional-device-pairing-app-deployment/spec.md
@@ -1,0 +1,61 @@
+### Requirement: Device pairing resources are skipped when disabled
+The controller SHALL NOT build, render, or apply any `claw-device-pairing` Kustomize component resources (Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, Route) when `shouldDisableDevicePairing()` returns `true`.
+
+#### Scenario: Claw CR with disableDevicePairing true
+- **WHEN** a Claw CR is created with `spec.auth.disableDevicePairing: true`
+- **THEN** the controller SHALL NOT create a Deployment named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a Service named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a ServiceAccount named `{instance}-device-pairing`
+- **THEN** the controller SHALL NOT create a Route named `{instance}-device-pairing`
+- **THEN** the Claw instance SHALL reach `Ready=True` without the device-pairing deployment
+
+#### Scenario: Claw CR with disableDevicePairing false
+- **WHEN** a Claw CR is created with `spec.auth.disableDevicePairing: false`
+- **THEN** the controller SHALL create all device-pairing resources as normal
+
+#### Scenario: Claw CR with disableDevicePairing unset
+- **WHEN** a Claw CR is created without the `spec.auth.disableDevicePairing` field
+- **THEN** the controller SHALL create all device-pairing resources as normal (default behavior preserved)
+
+### Requirement: Device pairing Route injection is skipped when disabled
+The controller SHALL NOT call `injectRouteHostIntoDevicePairingRoute()` or attempt to apply the device-pairing Route when device pairing is disabled.
+
+#### Scenario: No Route injection when disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and the Claw Route host has been resolved
+- **THEN** the controller SHALL skip the `injectRouteHostIntoDevicePairingRoute()` call
+- **THEN** the controller SHALL skip the `applyRouteByName()` call for the device-pairing Route
+
+### Requirement: Previously deployed device-pairing resources are cleaned up
+When device pairing transitions from enabled to disabled, the controller SHALL delete any previously-deployed device-pairing resources to avoid leaving orphaned resources in the cluster.
+
+#### Scenario: Cleanup on disable toggle
+- **WHEN** a Claw CR previously had device pairing enabled (resources exist) and `spec.auth.disableDevicePairing` is changed to `true`
+- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, RoleBinding, and Route
+- **THEN** NotFound errors during deletion SHALL be silently ignored (idempotent)
+
+#### Scenario: Cleanup is idempotent
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and no device-pairing resources exist
+- **THEN** the cleanup SHALL complete without errors
+
+### Requirement: Idle scaling skips device-pairing when disabled
+The `handleIdle()` function SHALL NOT attempt to scale the device-pairing Deployment to zero when device pairing is disabled.
+
+#### Scenario: Idle with device pairing disabled
+- **WHEN** `spec.idle` is `true` and `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL only scale the claw and proxy Deployments to zero
+- **THEN** the controller SHALL NOT attempt to scale `{instance}-device-pairing`
+
+### Requirement: E2E test covers disabled device pairing
+The e2e test suite SHALL include a test case verifying that a Claw CR with `spec.auth.disableDevicePairing: true` does not create device-pairing resources and reaches the Ready state.
+
+#### Scenario: E2E disabled device pairing
+- **WHEN** a Claw CR is applied with `spec.auth.disableDevicePairing: true` and valid credentials
+- **THEN** the claw and proxy Deployments SHALL be created
+- **THEN** no device-pairing Deployment SHALL exist
+- **THEN** no device-pairing Service SHALL exist
+- **THEN** no device-pairing ServiceAccount SHALL exist
+- **THEN** the Claw instance SHALL eventually reach `Ready=True`
+
+#### Scenario: E2E enabled device pairing (existing behavior preserved)
+- **WHEN** a Claw CR is applied without `spec.auth.disableDevicePairing` and valid credentials
+- **THEN** the device-pairing Deployment SHALL be created alongside the claw and proxy Deployments

--- a/openspec/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/specs/optional-device-pairing-app-deployment/spec.md
@@ -54,6 +54,7 @@ The e2e test suite SHALL include a test case verifying that a Claw CR with `spec
 - **THEN** no device-pairing Deployment SHALL exist
 - **THEN** no device-pairing Service SHALL exist
 - **THEN** no device-pairing ServiceAccount SHALL exist
+- **THEN** no device-pairing RoleBinding SHALL exist
 - **THEN** the Claw instance SHALL eventually reach `Ready=True`
 
 #### Scenario: E2E enabled device pairing (existing behavior preserved)

--- a/openspec/specs/status-conditions/spec.md
+++ b/openspec/specs/status-conditions/spec.md
@@ -15,15 +15,25 @@ The ClawStatus struct SHALL include a Conditions field of type []metav1.Conditio
 - **THEN** the status.conditions field SHALL be present in the OpenAPI schema
 
 ### Requirement: Ready condition indicates overall readiness
-The controller SHALL maintain a Ready condition type to indicate whether the Claw instance is ready for use.
+The controller SHALL maintain a Ready condition type to indicate whether the Claw instance is ready for use. When device pairing is disabled, the Ready condition SHALL NOT depend on the device-pairing Deployment.
 
 #### Scenario: Ready condition set to False during provisioning
 - **WHEN** a Claw instance named 'instance' is created
 - **THEN** the controller SHALL set Ready condition with status=False, reason=Provisioning, message describing deployment progress
 
-#### Scenario: Ready condition set to True when ready
-- **WHEN** both openclaw and openclaw-proxy Deployments have Available=True status
-- **THEN** the controller SHALL set Ready condition with status=True, reason=Ready, message confirming both deployments are ready
+#### Scenario: Ready condition set to True when ready (device pairing enabled)
+- **WHEN** the claw, proxy, and device-pairing Deployments all have Available=True status
+- **THEN** the controller SHALL set Ready condition with status=True, reason=Ready
+
+#### Scenario: Ready condition set to True when ready (device pairing disabled)
+- **WHEN** `shouldDisableDevicePairing()` returns `true` and the claw and proxy Deployments have Available=True status
+- **THEN** the controller SHALL set Ready condition with status=True, reason=Ready
+- **THEN** the controller SHALL NOT check the device-pairing Deployment status
+
+#### Scenario: DevicePairingConfigured condition omitted when disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL NOT set the `DevicePairingConfigured` condition
+- **THEN** if a `DevicePairingConfigured` condition previously existed, the controller SHALL remove it from the status conditions
 
 #### Scenario: Ready condition remains False if any deployment not ready
 - **WHEN** either openclaw or openclaw-proxy Deployment has Available condition not equal to True
@@ -56,7 +66,16 @@ The controller SHALL maintain a ProxyConfigured condition type to indicate wheth
 - **THEN** the controller SHALL set ProxyConfigured condition with status=False, reason=ConfigFailed, message describing the failure
 
 ### Requirement: Controller checks Deployment status conditions
-The controller SHALL read the Available condition from both openclaw and openclaw-proxy Deployment status to determine readiness.
+The controller SHALL read the Available condition from managed Deployments to determine readiness. The set of managed Deployments SHALL vary based on whether device pairing is enabled.
+
+#### Scenario: Deployments checked when device pairing enabled
+- **WHEN** `shouldDisableDevicePairing()` returns `false`
+- **THEN** the controller SHALL check readiness of claw, proxy, and device-pairing Deployments
+
+#### Scenario: Deployments checked when device pairing disabled
+- **WHEN** `shouldDisableDevicePairing()` returns `true`
+- **THEN** the controller SHALL check readiness of only the claw and proxy Deployments
+- **THEN** the controller SHALL NOT attempt to fetch the device-pairing Deployment status
 
 #### Scenario: Fetch openclaw Deployment status
 - **WHEN** updating Claw status conditions

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1019,19 +1019,29 @@ spec:
 			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
 				"-n", userNamespace)
 			_, err = utils.Run(t, cmd)
-			assert.Error(t, err, "device-pairing Deployment should not exist when disableDevicePairing=true")
+			require.Error(t, err, "device-pairing Deployment should not exist when disableDevicePairing=true")
+			assert.Contains(t, err.Error(), "not found", "device-pairing Deployment error should be NotFound")
 
 			t.Log("verifying device-pairing Service does NOT exist")
 			cmd = exec.Command("kubectl", "get", "service", devicePairingServiceName,
 				"-n", userNamespace)
 			_, err = utils.Run(t, cmd)
-			assert.Error(t, err, "device-pairing Service should not exist when disableDevicePairing=true")
+			require.Error(t, err, "device-pairing Service should not exist when disableDevicePairing=true")
+			assert.Contains(t, err.Error(), "not found", "device-pairing Service error should be NotFound")
 
 			t.Log("verifying device-pairing ServiceAccount does NOT exist")
 			cmd = exec.Command("kubectl", "get", "serviceaccount", devicePairingSAName,
 				"-n", userNamespace)
 			_, err = utils.Run(t, cmd)
-			assert.Error(t, err, "device-pairing ServiceAccount should not exist when disableDevicePairing=true")
+			require.Error(t, err, "device-pairing ServiceAccount should not exist when disableDevicePairing=true")
+			assert.Contains(t, err.Error(), "not found", "device-pairing ServiceAccount error should be NotFound")
+
+			t.Log("verifying device-pairing RoleBinding does NOT exist")
+			cmd = exec.Command("kubectl", "get", "rolebinding", devicePairingSAName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.Error(t, err, "device-pairing RoleBinding should not exist when disableDevicePairing=true")
+			assert.Contains(t, err.Error(), "not found", "device-pairing RoleBinding error should be NotFound")
 
 			t.Log("verifying DevicePairingConfigured condition is absent")
 			cmd = exec.Command("kubectl", "get", "claw", "instance",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -959,6 +959,100 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err, "DevicePairingConfigured did not become True within %v", defaultTimeout)
 		})
 
+		t.Run("should not deploy device-pairing when disableDevicePairing is true", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create Secret")
+
+			t.Log("applying Claw CR with disableDevicePairing=true")
+			crYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  auth:
+    disableDevicePairing: true
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+      provider: google
+`
+			crFile := filepath.Join("/tmp", "claw-e2e-no-device-pairing.yaml")
+			err = os.WriteFile(crFile, []byte(crYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready=True")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
+
+			t.Log("verifying device-pairing Deployment does NOT exist")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			assert.Error(t, err, "device-pairing Deployment should not exist when disableDevicePairing=true")
+
+			t.Log("verifying device-pairing Service does NOT exist")
+			cmd = exec.Command("kubectl", "get", "service", devicePairingServiceName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			assert.Error(t, err, "device-pairing Service should not exist when disableDevicePairing=true")
+
+			t.Log("verifying device-pairing ServiceAccount does NOT exist")
+			cmd = exec.Command("kubectl", "get", "serviceaccount", devicePairingSAName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			assert.Error(t, err, "device-pairing ServiceAccount should not exist when disableDevicePairing=true")
+
+			t.Log("verifying DevicePairingConfigured condition is absent")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.conditions[?(@.type=='DevicePairingConfigured')].status}",
+				"-n", userNamespace)
+			dpCondOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, dpCondOutput, "DevicePairingConfigured condition should not exist when device pairing is disabled")
+
+			t.Log("verifying claw and proxy Deployments DO exist")
+			cmd = exec.Command("kubectl", "get", "deployment", clawInstanceName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "claw Deployment should exist")
+
+			cmd = exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "proxy Deployment should exist")
+		})
+
 		t.Run("should reject Claw CR with password mode but no passwordSecretRef", func(t *testing.T) {
 			t.Cleanup(func() { collectDebugInfo(t) })
 


### PR DESCRIPTION
When `spec.auth.disableDevicePairing` is `true`, the operator now skips
building and applying all `claw-device-pairing` Kustomize resources
(Deployment, Service, ServiceAccount, RoleBinding, Route). Previously
deployed device-pairing resources are cleaned up via
`cleanupDevicePairingResources()`. Status conditions, deployment
readiness checks, and idle scaling are adapted to exclude the
device-pairing Deployment when disabled. RBAC roles updated with
`delete` verb for deployments, serviceaccounts, and rolebindings.

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional device-pairing toggle to disable the device-pairing deployment and related resources.

* **Improvements**
  * Status logic updated so readiness excludes device-pairing when disabled; idle-scaling skips device-pairing when disabled.
  * RBAC updated to allow safe cleanup and deletion of device-pairing resources when toggled off.

* **Tests**
  * Added unit and e2e tests covering enable/disable transitions and readiness behavior.

* **Documentation**
  * Added design, specs, and task docs for optional device-pairing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->