### PR TITLE
chore: bump OpenClaw image to 2026.5.27-slim

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.26-slim
+    newTag: 2026.5.27-slim

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -29,7 +29,7 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
-const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.26-slim"
+const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.27-slim"
 
 func makeTestDeploymentForPlugins() []*unstructured.Unstructured {
 	dep := &unstructured.Unstructured{}


### PR DESCRIPTION
- Update kustomization.yaml image tag from 2026.5.26-slim to 2026.5.27-slim
- Update testGatewayImage constant in plugin tests to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated OpenClaw container image to version 2026.5.27-slim

<!-- end of auto-generated comment: release notes by coderabbit.ai -->