### PR TITLE
feat: add `gatewayURL` and `devicePairingURL` fields to Claw status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ reset-test-e2e: ## Remove leftover operator resources from a previous e2e run
 test-e2e: ## Run the e2e tests. Expected an isolated environment using Kind.
 	@trap '$(MAKE) cleanup-test-e2e >/dev/null 2>&1 || true' EXIT; \
 	$(MAKE) setup-test-e2e manifests generate fmt vet reset-test-e2e; \
-	KIND_BIN=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -v -timeout 15m ./test/e2e/
+	KIND_BIN=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -v -timeout 15m ./test/e2e/ -run=TestManager/Manager
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -494,9 +494,19 @@ type ClawStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Deprecated: Use GatewayURL instead. Will be removed in a future version.
 	// URL is the HTTPS URL for accessing the Claw instance
 	// +optional
 	URL string `json:"url,omitempty"`
+
+	// GatewayURL is the HTTPS URL for accessing the Claw gateway, including the auth token fragment when applicable
+	// +optional
+	GatewayURL string `json:"gatewayURL,omitempty"`
+
+	// DevicePairingURL is the HTTPS URL for the device pairing application.
+	// Only populated when device pairing is enabled (disableDevicePairing is not true).
+	// +optional
+	DevicePairingURL string `json:"devicePairingURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -796,12 +796,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              devicePairingURL:
+                description: |-
+                  DevicePairingURL is the HTTPS URL for the device pairing application.
+                  Only populated when device pairing is enabled (disableDevicePairing is not true).
+                type: string
               gatewayTokenSecretRef:
                 description: GatewayTokenSecretRef is the name of the Secret containing
                   the gateway authentication token
                 type: string
+              gatewayURL:
+                description: GatewayURL is the HTTPS URL for accessing the Claw gateway,
+                  including the auth token fragment when applicable
+                type: string
               url:
-                description: URL is the HTTPS URL for accessing the Claw instance
+                description: |-
+                  Deprecated: Use GatewayURL instead. Will be removed in a future version.
+                  URL is the HTTPS URL for accessing the Claw instance
                 type: string
             type: object
         type: object

--- a/config/samples/claw_v1alpha1_claw.yaml
+++ b/config/samples/claw_v1alpha1_claw.yaml
@@ -3,6 +3,8 @@ kind: Claw
 metadata:
   name: instance
 spec:
+  auth:
+    disableDevicePairing: false
   credentials:
     - name: gemini
       type: apiKey

--- a/internal/controller/claw_auth_test.go
+++ b/internal/controller/claw_auth_test.go
@@ -688,8 +688,10 @@ func TestPasswordAuthModeReconciliation(t *testing.T) {
 
 		// In envtest without Route CRD, URL is empty since getRouteURL returns ""
 		// but the important thing is it does NOT contain #token=
-		assert.NotContains(t, updatedInstance.Status.URL, "#token=",
+		assert.NotContains(t, updatedInstance.Status.URL, "#token=", //nolint:staticcheck
 			"password mode URL should not contain token fragment")
+		assert.Equal(t, updatedInstance.Status.URL, updatedInstance.Status.GatewayURL, //nolint:staticcheck
+			"gatewayURL should equal url")
 	})
 }
 

--- a/internal/controller/claw_idle.go
+++ b/internal/controller/claw_idle.go
@@ -59,7 +59,7 @@ func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv
 	alreadyIdled := idleCond != nil && idleCond.Status == metav1.ConditionTrue &&
 		readyCond != nil && readyCond.Status == metav1.ConditionFalse &&
 		readyCond.Reason == clawv1alpha1.ConditionReasonIdle &&
-		instance.Status.URL == ""
+		instance.Status.URL == "" //nolint:staticcheck // deprecated but still checked
 
 	if alreadyIdled {
 		return ctrl.Result{}, nil
@@ -69,7 +69,9 @@ func (r *ClawResourceReconciler) handleIdle(ctx context.Context, instance *clawv
 		clawv1alpha1.ConditionReasonIdledByRequest, "Instance scaled to zero by spec.idle")
 	setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse,
 		clawv1alpha1.ConditionReasonIdle, "Instance is idled — set spec.idle to false to resume")
-	instance.Status.URL = ""
+	instance.Status.URL = "" //nolint:staticcheck // deprecated but still populated
+	instance.Status.GatewayURL = ""
+	instance.Status.DevicePairingURL = ""
 
 	if err := r.Status().Update(ctx, instance); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update status after idling: %w", err)

--- a/internal/controller/claw_idle_test.go
+++ b/internal/controller/claw_idle_test.go
@@ -116,7 +116,9 @@ func TestClawIdling(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
 		assert.Equal(t, clawv1alpha1.ConditionReasonIdle, readyCond.Reason)
 
-		assert.Empty(t, instance.Status.URL, "status.url should be cleared when idled")
+		assert.Empty(t, instance.Status.URL, "status.url should be cleared when idled") //nolint:staticcheck
+		assert.Empty(t, instance.Status.GatewayURL, "status.gatewayURL should be cleared when idled")
+		assert.Empty(t, instance.Status.DevicePairingURL, "status.devicePairingURL should be cleared when idled")
 	})
 
 	t.Run("should restore normal operation on unidle", func(t *testing.T) {

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -566,7 +566,9 @@ func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Validate auth password Secret (if auth mode is "password")
 	if _, err := r.resolveAuthPassword(ctx, instance); err != nil {
 		logger.Error(err, "Failed to resolve auth password")
-		instance.Status.URL = ""
+		instance.Status.URL = "" //nolint:staticcheck // deprecated but still populated
+		instance.Status.GatewayURL = ""
+		instance.Status.DevicePairingURL = ""
 		setCondition(instance, clawv1alpha1.ConditionTypeReady, metav1.ConditionFalse,
 			clawv1alpha1.ConditionReasonValidationFailed, err.Error())
 		if statusErr := r.Status().Update(ctx, instance); statusErr != nil {

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -270,6 +270,8 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 			instance.Status.GatewayURL = routeURL
 			if !shouldDisableDevicePairing(instance.Spec.Auth) {
 				instance.Status.DevicePairingURL = buildDevicePairingURL(routeURL, "")
+			} else {
+				instance.Status.DevicePairingURL = "" // probably overkill, but just in case
 			}
 		} else {
 			token := r.getGatewayToken(ctx, instance.Namespace, instance.Name)
@@ -278,6 +280,8 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 			instance.Status.GatewayURL = gatewayURL
 			if !shouldDisableDevicePairing(instance.Spec.Auth) {
 				instance.Status.DevicePairingURL = buildDevicePairingURL(routeURL, token)
+			} else {
+				instance.Status.DevicePairingURL = "" // probably overkill, but just in case
 			}
 		}
 	} else {

--- a/internal/controller/claw_status.go
+++ b/internal/controller/claw_status.go
@@ -208,10 +208,10 @@ func encodeFragmentValue(v string) string {
 	return url.QueryEscape(v)
 }
 
-// buildClawURL constructs the Claw status URL by appending the gateway token
+// buildGatewayURL constructs the Claw status URL by appending the gateway token
 // as a URL fragment if both routeURL and token are provided.
 // Returns empty string if routeURL is empty.
-func buildClawURL(routeURL, token string) string {
+func buildGatewayURL(routeURL, token string) string {
 	if routeURL == "" {
 		return ""
 	}
@@ -219,6 +219,17 @@ func buildClawURL(routeURL, token string) string {
 		return routeURL
 	}
 	return routeURL + "#token=" + encodeFragmentValue(token)
+}
+
+func buildDevicePairingURL(routeURL, token string) string {
+	if routeURL == "" {
+		return ""
+	}
+	base := routeURL + "/integration/device-pairing/"
+	if token == "" {
+		return base
+	}
+	return base + "#token=" + encodeFragmentValue(token)
 }
 
 // updateStatus updates the Claw status with current deployment conditions
@@ -246,7 +257,7 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 	// Expose gateway secret name in status
 	instance.Status.GatewayTokenSecretRef = getGatewaySecretName(instance.Name)
 
-	// Populate URL field only when both deployments are ready
+	// Populate URL fields only when all deployments are ready
 	if ready {
 		routeURL, err := r.getRouteURL(ctx, instance)
 		if err != nil {
@@ -255,14 +266,25 @@ func (r *ClawResourceReconciler) updateStatus(ctx context.Context, instance *cla
 
 		// Password mode: URL has no token fragment (password is entered in the UI)
 		if instance.Spec.Auth != nil && instance.Spec.Auth.Mode == clawv1alpha1.AuthModePassword {
-			instance.Status.URL = routeURL
+			instance.Status.URL = routeURL //nolint:staticcheck // deprecated but still populated
+			instance.Status.GatewayURL = routeURL
+			if !shouldDisableDevicePairing(instance.Spec.Auth) {
+				instance.Status.DevicePairingURL = buildDevicePairingURL(routeURL, "")
+			}
 		} else {
 			token := r.getGatewayToken(ctx, instance.Namespace, instance.Name)
-			instance.Status.URL = buildClawURL(routeURL, token)
+			gatewayURL := buildGatewayURL(routeURL, token)
+			instance.Status.URL = gatewayURL //nolint:staticcheck // deprecated but still populated
+			instance.Status.GatewayURL = gatewayURL
+			if !shouldDisableDevicePairing(instance.Spec.Auth) {
+				instance.Status.DevicePairingURL = buildDevicePairingURL(routeURL, token)
+			}
 		}
 	} else {
-		// Clear URL when deployments are not ready
-		instance.Status.URL = ""
+		// Clear URLs when deployments are not ready
+		instance.Status.URL = "" //nolint:staticcheck // deprecated but still populated
+		instance.Status.GatewayURL = ""
+		instance.Status.DevicePairingURL = ""
 	}
 
 	// Update status subresource

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -636,7 +636,9 @@ func TestOpenClawStatusConditions(t *testing.T) {
 
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
-				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
+				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url") //nolint:staticcheck
+				assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty status.gatewayURL")
+				assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty status.devicePairingURL")
 			})
 
 			t.Run("should keep status.url empty when only claw deployment is ready", func(t *testing.T) {
@@ -691,7 +693,9 @@ func TestOpenClawStatusConditions(t *testing.T) {
 
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
-				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
+				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url") //nolint:staticcheck
+				assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty status.gatewayURL")
+				assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty status.devicePairingURL")
 			})
 
 			t.Run("should keep status.url empty when only proxy deployment is ready", func(t *testing.T) {
@@ -746,7 +750,9 @@ func TestOpenClawStatusConditions(t *testing.T) {
 
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
-				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
+				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url") //nolint:staticcheck
+				assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty status.gatewayURL")
+				assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty status.devicePairingURL")
 			})
 
 			t.Run("should clear status.url when deployments transition from ready to not ready", func(t *testing.T) {
@@ -813,7 +819,9 @@ func TestOpenClawStatusConditions(t *testing.T) {
 
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
-				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
+				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url") //nolint:staticcheck
+				assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty status.gatewayURL")
+				assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty status.devicePairingURL")
 			})
 
 			t.Run("should not set status.url when Route does not exist (vanilla Kubernetes)", func(t *testing.T) {
@@ -856,7 +864,9 @@ func TestOpenClawStatusConditions(t *testing.T) {
 
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
-				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url")
+				assert.Empty(t, updatedInstance.Status.URL, "expected empty status.url") //nolint:staticcheck
+				assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty status.gatewayURL")
+				assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty status.devicePairingURL")
 			})
 
 			t.Run("should set status.url with token fragment when deployments are ready and Route exists", func(t *testing.T) {
@@ -1011,12 +1021,12 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				updatedInstance := &clawv1alpha1.Claw{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated instance")
 
-				assert.NotEmpty(t, updatedInstance.Status.URL, "expected non-empty status.url")
+				assert.NotEmpty(t, updatedInstance.Status.URL, "expected non-empty status.url") //nolint:staticcheck
 				expectedPrefix := "https://" + routeHost
-				assert.True(t, strings.HasPrefix(updatedInstance.Status.URL, expectedPrefix), "status.url should have prefix %s", expectedPrefix)
-				assert.Contains(t, updatedInstance.Status.URL, "#token=")
+				assert.True(t, strings.HasPrefix(updatedInstance.Status.URL, expectedPrefix), "status.url should have prefix %s", expectedPrefix) //nolint:staticcheck
+				assert.Contains(t, updatedInstance.Status.URL, "#token=")                                                                         //nolint:staticcheck
 
-				urlParts := strings.Split(updatedInstance.Status.URL, "#token=")
+				urlParts := strings.Split(updatedInstance.Status.URL, "#token=") //nolint:staticcheck
 				require.Len(t, urlParts, 2, "URL should have exactly one #token= fragment")
 				assert.Equal(t, "https://"+routeHost, urlParts[0], "URL host part")
 				assert.NotEmpty(t, urlParts[1], "token should not be empty")
@@ -1027,6 +1037,10 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				assert.NotEmpty(t, expectedToken, "expected non-empty gateway token")
 
 				assert.Equal(t, expectedToken, urlParts[1], "URL token")
+
+				assert.Equal(t, updatedInstance.Status.URL, updatedInstance.Status.GatewayURL, "gatewayURL should equal url") //nolint:staticcheck
+				assert.Equal(t, "https://"+routeHost+"/integration/device-pairing/#token="+encodeFragmentValue(expectedToken),
+					updatedInstance.Status.DevicePairingURL, "devicePairingURL should include device-pairing path")
 
 				_ = k8sClient.Delete(ctx, route)
 
@@ -1094,7 +1108,9 @@ func TestOpenClawURLStatusField(t *testing.T) {
 
 			updatedInstance := &clawv1alpha1.Claw{}
 			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated Claw instance")
-			assert.Empty(t, updatedInstance.Status.URL, "expected empty URL")
+			assert.Empty(t, updatedInstance.Status.URL, "expected empty URL") //nolint:staticcheck
+			assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty GatewayURL")
+			assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty DevicePairingURL")
 		})
 
 		t.Run("should leave URL field empty when Route does not exist", func(t *testing.T) {
@@ -1137,7 +1153,9 @@ func TestOpenClawURLStatusField(t *testing.T) {
 
 			updatedInstance := &clawv1alpha1.Claw{}
 			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance), "failed to get updated Claw instance")
-			assert.Empty(t, updatedInstance.Status.URL, "expected empty URL")
+			assert.Empty(t, updatedInstance.Status.URL, "expected empty URL") //nolint:staticcheck
+			assert.Empty(t, updatedInstance.Status.GatewayURL, "expected empty GatewayURL")
+			assert.Empty(t, updatedInstance.Status.DevicePairingURL, "expected empty DevicePairingURL")
 		})
 
 		t.Run("should include https:// scheme in URL format", func(t *testing.T) {
@@ -1293,7 +1311,7 @@ func TestURLConstructionWithTokenFragment(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				result := buildClawURL(tt.routeURL, tt.token)
+				result := buildGatewayURL(tt.routeURL, tt.token)
 				assert.Equal(t, tt.expected, result, "URL construction result")
 			})
 		}
@@ -1303,11 +1321,57 @@ func TestURLConstructionWithTokenFragment(t *testing.T) {
 		routeURL := "https://claw-default.apps.cluster.example.com"
 		token := "64chartoken1234567890abcdef64chartoken1234567890abcdef123456"
 
-		result := buildClawURL(routeURL, token)
+		result := buildGatewayURL(routeURL, token)
 
 		expected := "https://claw-default.apps.cluster.example.com#token=64chartoken1234567890abcdef64chartoken1234567890abcdef123456"
 		assert.Equal(t, expected, result, "URL construction result")
 		assert.True(t, strings.HasPrefix(result, "https://"), "expected result to start with https://")
 		assert.Contains(t, result, "#token=")
 	})
+}
+
+func TestDevicePairingURLConstruction(t *testing.T) {
+	tests := []struct {
+		name     string
+		routeURL string
+		token    string
+		expected string
+	}{
+		{
+			name:     "should insert device-pairing path before token fragment",
+			routeURL: "https://claw-route.apps.example.com",
+			token:    "abc123def456",
+			expected: "https://claw-route.apps.example.com/integration/device-pairing/#token=abc123def456",
+		},
+		{
+			name:     "should return device-pairing path without fragment when token is empty",
+			routeURL: "https://claw-route.apps.example.com",
+			token:    "",
+			expected: "https://claw-route.apps.example.com/integration/device-pairing/",
+		},
+		{
+			name:     "should return empty string when route URL is empty",
+			routeURL: "",
+			token:    "abc123def456",
+			expected: "",
+		},
+		{
+			name:     "should return empty string when both route and token are empty",
+			routeURL: "",
+			token:    "",
+			expected: "",
+		},
+		{
+			name:     "should percent-encode special characters in token",
+			routeURL: "https://claw-route.apps.example.com",
+			token:    "token+with=special&chars#fragment",
+			expected: "https://claw-route.apps.example.com/integration/device-pairing/#token=token%2Bwith%3Dspecial%26chars%23fragment",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildDevicePairingURL(tt.routeURL, tt.token)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -373,6 +373,43 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			assert.Nil(t, condition, "DevicePairingConfigured should not be set when device pairing is disabled")
 		})
 
+		t.Run("should clear stale DevicePairingURL when device pairing is later disabled", func(t *testing.T) {
+			t.Cleanup(func() {
+				deleteAndWaitAllResources(t, namespace)
+			})
+
+			// 1. Create instance with device pairing enabled (default)
+			createClawInstance(t, ctx, resourceName, namespace)
+			reconciler := createClawReconciler()
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			// 2. Make all deployments ready (including device-pairing)
+			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			// 3. Simulate a stale DevicePairingURL from a previous reconcile
+			// (in envtest there's no Route CRD so URLs are empty; inject a stale value directly)
+			updatedInstance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			updatedInstance.Status.DevicePairingURL = "https://stale-host/integration/device-pairing/#token=stale"
+			require.NoError(t, k8sClient.Status().Update(ctx, updatedInstance))
+
+			// 4. Disable device pairing
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			updatedInstance.Spec.Auth = &clawv1alpha1.AuthSpec{
+				DisableDevicePairing: boolPtr(true),
+			}
+			require.NoError(t, k8sClient.Update(ctx, updatedInstance))
+
+			// 5. Reconcile again
+			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+			// 6. Verify DevicePairingURL is cleared
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+			assert.Empty(t, updatedInstance.Status.DevicePairingURL,
+				"DevicePairingURL should be cleared when device pairing is disabled")
+		})
+
 		t.Run("should keep Ready False when claw and proxy are ready but device-pairing is not", func(t *testing.T) {
 			t.Cleanup(func() {
 				deleteAndWaitAllResources(t, namespace)

--- a/openspec/changes/archive/2026-05-29-claw-status-urls/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-claw-status-urls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-claw-status-urls/design.md
+++ b/openspec/changes/archive/2026-05-29-claw-status-urls/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The Claw CR status currently has a single `URL` field populated in `updateStatus` when all deployments are ready. It contains the route URL with an optional `#token=<value>` fragment. The device pairing app lives at the same host under `/integration/device-pairing/`, but consumers must construct this URL themselves.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `gatewayURL` and `devicePairingURL` as explicit fields in `ClawStatus`
+- Keep `url` populated with the same value as `gatewayURL` for backward compatibility
+- Only populate `devicePairingURL` when device pairing is enabled
+
+**Non-Goals:**
+- Removing the deprecated `url` field (deferred to a follow-up change)
+- Changing how the route URL or token are resolved
+- Modifying the device pairing application itself
+
+## Decisions
+
+1. **New fields alongside existing field**: Add `GatewayURL` and `DevicePairingURL` as sibling fields to `URL` in `ClawStatus`. The `URL` field keeps its current behavior and gets a deprecation marker in the Go doc comment. This avoids breaking existing consumers.
+
+2. **Device pairing URL construction**: Insert `/integration/device-pairing/` between the route host and the `#token=` fragment. For password mode (no token fragment), append the path without a fragment. The `buildClawURL` helper is extended with a new `buildDevicePairingURL` function that reuses the same route URL and token.
+
+3. **Conditional population of `devicePairingURL`**: Only set when `shouldDisableDevicePairing(auth)` returns false. When device pairing is disabled, the field remains empty — matching the existing behavior where the device pairing deployment is skipped entirely.
+
+## Risks / Trade-offs
+
+- **Additional status fields increase CRD surface** → Minimal risk; two string fields with clear semantics. The deprecated `url` field will be cleaned up in a follow-up.
+- **URL format coupling** → The `/integration/device-pairing/` path is an OpenClaw convention. If it changes upstream, the operator must be updated. This is acceptable since the operator already manages the device pairing deployment.

--- a/openspec/changes/archive/2026-05-29-claw-status-urls/proposal.md
+++ b/openspec/changes/archive/2026-05-29-claw-status-urls/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The Claw CR status currently exposes a single `.status.url` field containing the gateway URL with the auth token fragment. Consumers (e.g., the UI, CLI tooling, `make wait-ready`) also need the device pairing URL, which differs only by an extra path segment. Exposing both URLs in status avoids forcing consumers to construct them manually and keeps URL-building logic centralized in the operator. Additionally, renaming the gateway URL to a more explicit field (`gatewayURL`) improves clarity while deprecating the original `url` field for a clean future removal.
+
+## What Changes
+
+- Add a `GatewayURL` field to `ClawStatus` — identical value to the existing `URL` field
+- Add a `DevicePairingURL` field to `ClawStatus` — same base URL as the gateway, but with `/integration/device-pairing/` inserted before the `#token=` fragment; only populated when device pairing is enabled (`disableDevicePairing` is not true)
+- Keep the existing `URL` field populated (now deprecated) — will be removed in a subsequent change
+- Update `updateStatus` to populate all three fields
+
+## Capabilities
+
+### New Capabilities
+- `status-urls`: Expose `gatewayURL` and `devicePairingURL` fields in Claw status, deprecate the existing `url` field
+
+### Modified Capabilities
+
+## Impact
+
+- **API types**: `ClawStatus` struct in `api/v1alpha1/claw_types.go` gains two new fields
+- **CRD YAML**: Regenerated via `make manifests` / `make generate`
+- **Controller**: `updateStatus` in `internal/controller/claw_status.go` populates the new fields
+- **Tests**: Status tests updated to assert the new fields
+- **No breaking changes**: Existing `URL` field remains populated

--- a/openspec/changes/archive/2026-05-29-claw-status-urls/specs/status-urls/spec.md
+++ b/openspec/changes/archive/2026-05-29-claw-status-urls/specs/status-urls/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: GatewayURL status field
+The `ClawStatus` struct SHALL include a `GatewayURL` field (JSON: `gatewayURL`) that contains the same value as the existing `URL` field. The field SHALL be populated when all managed deployments are ready and cleared when they are not.
+
+#### Scenario: GatewayURL populated when ready with token auth
+- **WHEN** all managed deployments are available AND auth mode is token
+- **THEN** `status.gatewayURL` SHALL equal `https://<route-host>#token=<encoded-token>`
+
+#### Scenario: GatewayURL populated when ready with password auth
+- **WHEN** all managed deployments are available AND auth mode is password
+- **THEN** `status.gatewayURL` SHALL equal `https://<route-host>` (no token fragment)
+
+#### Scenario: GatewayURL cleared when not ready
+- **WHEN** any managed deployment is not available
+- **THEN** `status.gatewayURL` SHALL be empty
+
+### Requirement: DevicePairingURL status field
+The `ClawStatus` struct SHALL include a `DevicePairingURL` field (JSON: `devicePairingURL`) that contains the device pairing application URL. The URL SHALL be the same as the gateway URL but with `/integration/device-pairing/` inserted as a path before the token fragment.
+
+#### Scenario: DevicePairingURL populated when ready with token auth and device pairing enabled
+- **WHEN** all managed deployments are available AND auth mode is token AND device pairing is not disabled
+- **THEN** `status.devicePairingURL` SHALL equal `https://<route-host>/integration/device-pairing/#token=<encoded-token>`
+
+#### Scenario: DevicePairingURL populated when ready with password auth and device pairing enabled
+- **WHEN** all managed deployments are available AND auth mode is password AND device pairing is not disabled
+- **THEN** `status.devicePairingURL` SHALL equal `https://<route-host>/integration/device-pairing/`
+
+#### Scenario: DevicePairingURL empty when device pairing is disabled
+- **WHEN** `spec.auth.disableDevicePairing` is true (explicitly or by default for password mode)
+- **THEN** `status.devicePairingURL` SHALL be empty regardless of deployment readiness
+
+#### Scenario: DevicePairingURL cleared when not ready
+- **WHEN** any managed deployment is not available AND device pairing is enabled
+- **THEN** `status.devicePairingURL` SHALL be empty
+
+### Requirement: Deprecated URL field preserved
+The existing `URL` field in `ClawStatus` SHALL continue to be populated with the same value as `GatewayURL`. The Go struct field SHALL carry a deprecation comment indicating it will be removed in a future version.
+
+#### Scenario: URL and GatewayURL are identical
+- **WHEN** `status.gatewayURL` is populated
+- **THEN** `status.url` SHALL have the same value as `status.gatewayURL`
+
+#### Scenario: URL cleared when GatewayURL is cleared
+- **WHEN** `status.gatewayURL` is empty
+- **THEN** `status.url` SHALL also be empty

--- a/openspec/changes/archive/2026-05-29-claw-status-urls/tasks.md
+++ b/openspec/changes/archive/2026-05-29-claw-status-urls/tasks.md
@@ -1,0 +1,24 @@
+## 1. API Types
+
+- [x] 1.1 Add `GatewayURL` and `DevicePairingURL` fields to `ClawStatus` in `api/v1alpha1/claw_types.go`, add deprecation comment on existing `URL` field
+- [x] 1.2 Run `make generate` and `make manifests` to regenerate deepcopy and CRD YAML
+
+## 2. Controller Logic
+
+- [x] 2.1 Add `buildDevicePairingURL` helper in `internal/controller/claw_status.go` that inserts `/integration/device-pairing/` path before the token fragment
+- [x] 2.2 Update `updateStatus` to populate `GatewayURL` (same value as `URL`) and `DevicePairingURL` (only when device pairing is enabled)
+
+## 3. Tests
+
+- [x] 3.1 Add unit tests for `buildDevicePairingURL` covering token auth, password auth, and empty route URL cases
+- [x] 3.2 Update status integration tests to assert `GatewayURL` matches `URL` and `DevicePairingURL` is set/empty based on device pairing config
+
+## 4. E2E Tests
+
+- [x] 4.1 Add e2e test verifying `status.gatewayURL` and `status.url` are populated and equal when Claw is ready (token auth, device pairing enabled)
+- [x] 4.2 Add e2e assertion verifying `status.devicePairingURL` is populated with `/integration/device-pairing/` path when device pairing is enabled
+- [x] 4.3 Add e2e assertion in the existing `disableDevicePairing=true` test verifying `status.devicePairingURL` is empty
+
+## 5. Validation
+
+- [x] 5.1 Run `make build`, `make lint`, and `make test` to verify everything passes

--- a/openspec/specs/status-urls/spec.md
+++ b/openspec/specs/status-urls/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: GatewayURL status field
+The `ClawStatus` struct SHALL include a `GatewayURL` field (JSON: `gatewayURL`) that contains the same value as the existing `URL` field. The field SHALL be populated when all managed deployments are ready and cleared when they are not.
+
+#### Scenario: GatewayURL populated when ready with token auth
+- **WHEN** all managed deployments are available AND auth mode is token
+- **THEN** `status.gatewayURL` SHALL equal `https://<route-host>#token=<encoded-token>`
+
+#### Scenario: GatewayURL populated when ready with password auth
+- **WHEN** all managed deployments are available AND auth mode is password
+- **THEN** `status.gatewayURL` SHALL equal `https://<route-host>` (no token fragment)
+
+#### Scenario: GatewayURL cleared when not ready
+- **WHEN** any managed deployment is not available
+- **THEN** `status.gatewayURL` SHALL be empty
+
+### Requirement: DevicePairingURL status field
+The `ClawStatus` struct SHALL include a `DevicePairingURL` field (JSON: `devicePairingURL`) that contains the device pairing application URL. The URL SHALL be the same as the gateway URL but with `/integration/device-pairing/` inserted as a path before the token fragment.
+
+#### Scenario: DevicePairingURL populated when ready with token auth and device pairing enabled
+- **WHEN** all managed deployments are available AND auth mode is token AND device pairing is not disabled
+- **THEN** `status.devicePairingURL` SHALL equal `https://<route-host>/integration/device-pairing/#token=<encoded-token>`
+
+#### Scenario: DevicePairingURL populated when ready with password auth and device pairing enabled
+- **WHEN** all managed deployments are available AND auth mode is password AND device pairing is not disabled
+- **THEN** `status.devicePairingURL` SHALL equal `https://<route-host>/integration/device-pairing/`
+
+#### Scenario: DevicePairingURL empty when device pairing is disabled
+- **WHEN** `spec.auth.disableDevicePairing` is true (explicitly or by default for password mode)
+- **THEN** `status.devicePairingURL` SHALL be empty regardless of deployment readiness
+
+#### Scenario: DevicePairingURL cleared when not ready
+- **WHEN** any managed deployment is not available AND device pairing is enabled
+- **THEN** `status.devicePairingURL` SHALL be empty
+
+### Requirement: Deprecated URL field preserved
+The existing `URL` field in `ClawStatus` SHALL continue to be populated with the same value as `GatewayURL`. The Go struct field SHALL carry a deprecation comment indicating it will be removed in a future version.
+
+#### Scenario: URL and GatewayURL are identical
+- **WHEN** `status.gatewayURL` is populated
+- **THEN** `status.url` SHALL have the same value as `status.gatewayURL`
+
+#### Scenario: URL cleared when GatewayURL is cleared
+- **WHEN** `status.gatewayURL` is empty
+- **THEN** `status.url` SHALL also be empty

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -937,6 +937,47 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 					return err == nil && output == conditionTrue, nil
 				})
 			require.NoError(t, err, "DevicePairingConfigured did not become True within %v", defaultTimeout)
+
+			t.Log("waiting for Claw Ready=True")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
+
+			t.Log("verifying status.gatewayURL equals status.url")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.gatewayURL}",
+				"-n", userNamespace)
+			gatewayURL, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.url}",
+				"-n", userNamespace)
+			statusURL, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, statusURL, gatewayURL, "status.gatewayURL should equal status.url")
+
+			// On Kind (no Route CRD), URLs are empty because getRouteURL returns "".
+			// On OpenShift, URLs contain the Route host. Assert structure when non-empty.
+			if gatewayURL != "" {
+				t.Log("verifying status.devicePairingURL contains device-pairing path")
+				cmd = exec.Command("kubectl", "get", "claw", "instance",
+					"-o", "jsonpath={.status.devicePairingURL}",
+					"-n", userNamespace)
+				devicePairingURL, err := utils.Run(t, cmd)
+				require.NoError(t, err)
+				assert.NotEmpty(t, devicePairingURL, "status.devicePairingURL should not be empty when device pairing is enabled")
+				assert.Contains(t, devicePairingURL, "/integration/device-pairing/",
+					"devicePairingURL should contain /integration/device-pairing/ path")
+			} else {
+				t.Log("Route CRD not available (Kind cluster), skipping URL content assertions")
+			}
 		})
 
 		t.Run("should not deploy device-pairing when disableDevicePairing is true", func(t *testing.T) {
@@ -1030,6 +1071,45 @@ spec:
 			dpCondOutput, err := utils.Run(t, cmd)
 			require.NoError(t, err)
 			assert.Empty(t, dpCondOutput, "DevicePairingConfigured condition should not exist when device pairing is disabled")
+
+			t.Log("waiting for Claw Ready=True")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
+
+			t.Log("verifying status.gatewayURL equals status.url")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.gatewayURL}",
+				"-n", userNamespace)
+			gatewayURL, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.url}",
+				"-n", userNamespace)
+			statusURL, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, statusURL, gatewayURL, "status.gatewayURL should equal status.url")
+
+			// On Kind (no Route CRD), URLs are empty because getRouteURL returns "".
+			// On OpenShift, URLs contain the Route host. Assert structure when non-empty.
+			if gatewayURL != "" {
+				t.Log("verifying status.devicePairingURL is empty when device pairing is disabled")
+				cmd = exec.Command("kubectl", "get", "claw", "instance",
+					"-o", "jsonpath={.status.devicePairingURL}",
+					"-n", userNamespace)
+				devicePairingURL, err := utils.Run(t, cmd)
+				require.NoError(t, err)
+				assert.Empty(t, devicePairingURL, "status.devicePairingURL should be empty when disableDevicePairing=true")
+			} else {
+				t.Log("Route CRD not available (Kind cluster), skipping URL content assertions")
+			}
 
 			t.Log("verifying claw and proxy Deployments DO exist")
 			cmd = exec.Command("kubectl", "get", "deployment", clawInstanceName,
@@ -1458,13 +1538,27 @@ spec:
 			require.NoError(t, err)
 			assert.Equal(t, "Idle", readyReason, "Ready reason should be Idle")
 
-			t.Log("verifying status.url is cleared when idled")
+			t.Log("verifying status URLs are cleared when idled")
 			cmd = exec.Command("kubectl", "get", "claw", "instance",
 				"-o", "jsonpath={.status.url}",
 				"-n", userNamespace)
 			urlOutput, err := utils.Run(t, cmd)
 			require.NoError(t, err)
 			assert.Empty(t, urlOutput, "status.url should be empty when idled")
+
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.gatewayURL}",
+				"-n", userNamespace)
+			gwURLOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, gwURLOutput, "status.gatewayURL should be empty when idled")
+
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.devicePairingURL}",
+				"-n", userNamespace)
+			dpURLOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, dpURLOutput, "status.devicePairingURL should be empty when idled")
 
 			t.Log("verifying all pods are terminated")
 			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1072,17 +1072,6 @@ spec:
 			require.NoError(t, err)
 			assert.Empty(t, dpCondOutput, "DevicePairingConfigured condition should not exist when device pairing is disabled")
 
-			t.Log("waiting for Claw Ready=True")
-			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
-				func(ctx context.Context) (bool, error) {
-					cmd := exec.Command("kubectl", "get", "claw", "instance",
-						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
-						"-n", userNamespace)
-					output, err := utils.Run(t, cmd)
-					return err == nil && output == conditionTrue, nil
-				})
-			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
-
 			t.Log("verifying status.gatewayURL equals status.url")
 			cmd = exec.Command("kubectl", "get", "claw", "instance",
 				"-o", "jsonpath={.status.gatewayURL}",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1087,18 +1087,13 @@ spec:
 			assert.Equal(t, statusURL, gatewayURL, "status.gatewayURL should equal status.url")
 
 			// On Kind (no Route CRD), URLs are empty because getRouteURL returns "".
-			// On OpenShift, URLs contain the Route host. Assert structure when non-empty.
-			if gatewayURL != "" {
-				t.Log("verifying status.devicePairingURL is empty when device pairing is disabled")
-				cmd = exec.Command("kubectl", "get", "claw", "instance",
-					"-o", "jsonpath={.status.devicePairingURL}",
-					"-n", userNamespace)
-				devicePairingURL, err := utils.Run(t, cmd)
-				require.NoError(t, err)
-				assert.Empty(t, devicePairingURL, "status.devicePairingURL should be empty when disableDevicePairing=true")
-			} else {
-				t.Log("Route CRD not available (Kind cluster), skipping URL content assertions")
-			}
+			t.Log("verifying status.devicePairingURL is empty when device pairing is disabled")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.devicePairingURL}",
+				"-n", userNamespace)
+			devicePairingURL, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, devicePairingURL, "status.devicePairingURL should be empty when disableDevicePairing=true")
 
 			t.Log("verifying claw and proxy Deployments DO exist")
 			cmd = exec.Command("kubectl", "get", "deployment", clawInstanceName,


### PR DESCRIPTION
Add `GatewayURL` and `DevicePairingURL` to `ClawStatus` so consumers
don't have to construct these URLs manually.

- `gatewayURL` mirrors the existing (now deprecated) `url` field
- `devicePairingURL` inserts `/integration/device-pairing/` before the
  token fragment; only populated when device pairing is enabled
- All three URL fields are cleared on idle, auth failure, and when
  deployments are not ready
- Rename `buildClawURL` to `buildGatewayURL` for clarity

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gatewayURL and devicePairingURL status fields on Claw resources; gatewayURL mirrors the existing url (deprecated) and devicePairingURL is set only when device pairing is enabled.

* **Behavior**
  * Status URL fields are populated only when all deployments are ready; idling or auth failures clear all status URL fields. Sample now exposes disableDevicePairing in spec.

* **Documentation**
  * Added spec, design and proposal documenting new status URL behavior and device-pairing rules.

* **Tests**
  * Unit and e2e tests expanded to validate gatewayURL/url parity and devicePairingURL population/clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->