### PR TITLE
fix: include ClusterRole in device-pairing cleanup and add toggle tests

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -117,16 +117,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - rolebindings
   verbs:
   - create

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -392,6 +392,86 @@ func TestDevicePairingReconciliation(t *testing.T) {
 		}, "device-pairing Deployment should be deleted after disabling")
 	})
 
+	t.Run("should recreate device-pairing resources when toggled back to false", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+		instance := &clawv1alpha1.Claw{}
+		instance.Name = resourceName
+		instance.Namespace = namespace
+		instance.Spec.Credentials = testCredentials()
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(true),
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		// Verify device-pairing resources do NOT exist
+		dpDeployment := &appsv1.Deployment{}
+		err := k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingDeploymentName(resourceName),
+			Namespace: namespace,
+		}, dpDeployment)
+		assert.True(t, apierrors.IsNotFound(err),
+			"device-pairing Deployment should not exist when disabled")
+
+		dpService := &corev1.Service{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceName(resourceName),
+			Namespace: namespace,
+		}, dpService)
+		assert.True(t, apierrors.IsNotFound(err),
+			"device-pairing Service should not exist when disabled")
+
+		dpSA := &corev1.ServiceAccount{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceAccountName(resourceName),
+			Namespace: namespace,
+		}, dpSA)
+		assert.True(t, apierrors.IsNotFound(err),
+			"device-pairing ServiceAccount should not exist when disabled")
+
+		// Toggle disableDevicePairing to false
+		require.NoError(t, k8sClient.Get(ctx,
+			client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(false),
+		}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		// Verify device-pairing resources ARE now created
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingDeploymentName(resourceName),
+				Namespace: namespace,
+			}, dpDeployment) == nil
+		}, "device-pairing Deployment should be created after re-enabling")
+
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingServiceName(resourceName),
+				Namespace: namespace,
+			}, dpService) == nil
+		}, "device-pairing Service should be created after re-enabling")
+
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getDevicePairingServiceAccountName(resourceName),
+				Namespace: namespace,
+			}, dpSA) == nil
+		}, "device-pairing ServiceAccount should be created after re-enabling")
+	})
+
 	t.Run("should create device-pairing resources after reconcile", func(t *testing.T) {
 		const resourceName = testInstanceName
 		ctx := context.Background()

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -423,6 +423,7 @@ type ClawResourceReconciler struct {
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile manages the complete lifecycle of resources for Claw instances
 func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocyclo
@@ -1059,6 +1060,7 @@ func (r *ClawResourceReconciler) cleanupDevicePairingResources(ctx context.Conte
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: getDevicePairingServiceAccountName(name), Namespace: ns}},
 		newDevicePairingRouteUnstructured(name, ns),
 		newDevicePairingRoleBindingUnstructured(name, ns),
+		newDevicePairingClusterRoleUnstructured(name),
 	}
 
 	for _, obj := range resources {
@@ -1097,6 +1099,17 @@ func newDevicePairingRoleBindingUnstructured(instanceName, ns string) *unstructu
 	})
 	u.SetName(getDevicePairingRoleBindingName(instanceName))
 	u.SetNamespace(ns)
+	return u
+}
+
+func newDevicePairingClusterRoleUnstructured(instanceName string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "rbac.authorization.k8s.io",
+		Version: "v1",
+		Kind:    ClusterRoleKind,
+	})
+	u.SetName(instanceName + "-device-pairing")
 	return u
 }
 

--- a/openspec/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/specs/optional-device-pairing-app-deployment/spec.md
@@ -25,12 +25,27 @@ The controller SHALL NOT call `injectRouteHostIntoDevicePairingRoute()` or attem
 - **THEN** the controller SHALL skip the `injectRouteHostIntoDevicePairingRoute()` call
 - **THEN** the controller SHALL skip the `applyRouteByName()` call for the device-pairing Route
 
+### Requirement: Device pairing resources are recreated when re-enabled
+When `spec.auth.disableDevicePairing` is toggled from `true` back to `false`, the controller SHALL recreate all device-pairing resources through the normal Kustomize build and server-side apply flow.
+
+#### Scenario: Re-enable device pairing after disable
+- **WHEN** a Claw CR has `spec.auth.disableDevicePairing: true` and the device-pairing resources do not exist
+- **AND** the user patches `spec.auth.disableDevicePairing` to `false`
+- **THEN** the controller SHALL create a Deployment named `{instance}-device-pairing`
+- **THEN** the controller SHALL create a Service named `{instance}-device-pairing`
+- **THEN** the controller SHALL create a ServiceAccount named `{instance}-device-pairing`
+
+#### Scenario: Re-enable after field removal
+- **WHEN** a Claw CR has `spec.auth.disableDevicePairing: true` and the device-pairing resources do not exist
+- **AND** the user removes the `disableDevicePairing` field entirely (leaving auth mode as token)
+- **THEN** the controller SHALL create all device-pairing resources as normal
+
 ### Requirement: Previously deployed device-pairing resources are cleaned up
 When device pairing transitions from enabled to disabled, the controller SHALL delete any previously-deployed device-pairing resources to avoid leaving orphaned resources in the cluster.
 
 #### Scenario: Cleanup on disable toggle
 - **WHEN** a Claw CR previously had device pairing enabled (resources exist) and `spec.auth.disableDevicePairing` is changed to `true`
-- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, RoleBinding, and Route
+- **THEN** the controller SHALL delete the device-pairing Deployment, Service, ServiceAccount, ClusterRole, RoleBinding, and Route
 - **THEN** NotFound errors during deletion SHALL be silently ignored (idempotent)
 
 #### Scenario: Cleanup is idempotent

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1043,6 +1043,205 @@ spec:
 			require.NoError(t, err, "proxy Deployment should exist")
 		})
 
+		t.Run("should recreate device-pairing when disableDevicePairing toggled to false", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			createLabeledSecret(t, "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value")
+
+			t.Log("applying Claw CR with disableDevicePairing=true")
+			crYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  auth:
+    disableDevicePairing: true
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+      provider: google
+`
+			crFile := filepath.Join("/tmp", "claw-e2e-dp-reenable.yaml")
+			err := os.WriteFile(crFile, []byte(crYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready=True with device pairing disabled")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True within %v", extendedTimeout)
+
+			t.Log("verifying device-pairing Deployment does NOT exist")
+			cmd = exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.Error(t, err, "device-pairing Deployment should not exist when disableDevicePairing=true")
+
+			t.Log("patching disableDevicePairing to false")
+			cmd = exec.Command("kubectl", "patch", "claw", "instance",
+				"--type=merge", "-p", `{"spec":{"auth":{"disableDevicePairing":false}}}`,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to patch disableDevicePairing to false")
+
+			t.Log("waiting for device-pairing Deployment to be created")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+						"-n", userNamespace)
+					_, err := utils.Run(t, cmd)
+					return err == nil, nil
+				})
+			require.NoError(t, err, "device-pairing Deployment was not created after re-enabling")
+
+			t.Log("verifying device-pairing Service exists")
+			cmd = exec.Command("kubectl", "get", "service", devicePairingServiceName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "device-pairing Service should exist after re-enabling")
+
+			t.Log("verifying device-pairing ServiceAccount exists")
+			cmd = exec.Command("kubectl", "get", "serviceaccount", devicePairingSAName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "device-pairing ServiceAccount should exist after re-enabling")
+
+			t.Log("verifying DevicePairingConfigured condition becomes True")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='DevicePairingConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "DevicePairingConfigured did not become True after re-enabling")
+		})
+
+		t.Run("should clean up device-pairing resources when disableDevicePairing is toggled to true", func(t *testing.T) {
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			createLabeledSecret(t, "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value")
+
+			t.Log("applying Claw CR with device pairing enabled (default)")
+			crYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+      provider: google
+`
+			crFile := filepath.Join("/tmp", "claw-e2e-dp-disable.yaml")
+			err := os.WriteFile(crFile, []byte(crYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for device-pairing Deployment to be created")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+						"-n", userNamespace)
+					_, err := utils.Run(t, cmd)
+					return err == nil, nil
+				})
+			require.NoError(t, err, "device-pairing Deployment should be created initially")
+
+			t.Log("patching disableDevicePairing to true")
+			cmd = exec.Command("kubectl", "patch", "claw", "instance",
+				"--type=merge", "-p", `{"spec":{"auth":{"disableDevicePairing":true}}}`,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to patch disableDevicePairing to true")
+
+			t.Log("waiting for device-pairing Deployment to be deleted")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "deployment", devicePairingDeploymentName,
+						"-n", userNamespace)
+					_, err := utils.Run(t, cmd)
+					return err != nil, nil
+				})
+			require.NoError(t, err, "device-pairing Deployment was not deleted after disabling")
+
+			t.Log("verifying device-pairing Service is gone")
+			cmd = exec.Command("kubectl", "get", "service", devicePairingServiceName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.Error(t, err, "device-pairing Service should not exist after disabling")
+
+			t.Log("verifying device-pairing ServiceAccount is gone")
+			cmd = exec.Command("kubectl", "get", "serviceaccount", devicePairingSAName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.Error(t, err, "device-pairing ServiceAccount should not exist after disabling")
+
+			t.Log("verifying DevicePairingConfigured condition is absent")
+			cmd = exec.Command("kubectl", "get", "claw", "instance",
+				"-o", "jsonpath={.status.conditions[?(@.type=='DevicePairingConfigured')].status}",
+				"-n", userNamespace)
+			dpCondOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Empty(t, dpCondOutput, "DevicePairingConfigured condition should be absent after disabling")
+
+			t.Log("verifying claw and proxy Deployments still exist")
+			cmd = exec.Command("kubectl", "get", "deployment", clawInstanceName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "claw Deployment should still exist")
+
+			cmd = exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+				"-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "proxy Deployment should still exist")
+		})
+
 		t.Run("should reject Claw CR with password mode but no passwordSecretRef", func(t *testing.T) {
 			t.Cleanup(func() { collectDebugInfo(t) })
 


### PR DESCRIPTION
Add `newDevicePairingClusterRoleUnstructured` helper and include the
ClusterRole in `cleanupDevicePairingResources` to prevent orphaned
cluster-scoped resources when device pairing is disabled.

Add integration test for the disable→enable toggle path and e2e tests
for both toggle directions (`disableDevicePairing` true→false and
false→true).

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device-pairing resources are reliably recreated when re-enabled; cleanup now also removes the cluster-scoped device-pairing role to ensure full teardown.

* **Tests**
  * Added end-to-end and reconciliation tests covering toggling device-pairing off and back on.

* **Documentation**
  * Spec updated to clarify expected behavior when device-pairing is disabled and later re-enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->