### PR TITLE
docs: document OpenAI quickstart and companion provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,29 @@ oc create namespace $NS
 
 ### 3. Create a Credential Secret
 
+#### Google Gemini
+
+Get your API key from [Google AI Studio](https://aistudio.google.com/apikey).
+
 ```sh
 oc create secret generic gemini-api-key \
   --from-literal=api-key=YOUR_GEMINI_API_KEY \
   -n $NS
 ```
 
-Get your API key from [Google AI Studio](https://aistudio.google.com/apikey).
+#### OpenAI
+
+Get your API key from the [OpenAI Platform](https://platform.openai.com/api-keys).
+
+```sh
+oc create secret generic openai-api-key \
+  --from-literal=api-key=YOUR_OPENAI_API_KEY \
+  -n $NS
+```
 
 ### 4. Create a Claw Instance
+
+#### Google Gemini
 
 Apply the sample CR, or use the inline version below:
 
@@ -163,7 +177,28 @@ spec:
 EOF
 ```
 
-For known providers (`google`, `anthropic`), the operator infers `domain` and `apiKey` automatically. For other LLM providers, messaging channels, MCP servers, and more, see the [User Guide](docs/user-guide.md).
+#### OpenAI
+
+```sh
+oc apply -f - <<EOF
+apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+  namespace: $NS
+spec:
+  credentials:
+    - name: openai
+      type: bearer
+      secretRef:
+        - name: openai-api-key
+          key: api-key
+      provider: openai
+      domain: "api.openai.com"
+EOF
+```
+
+For known providers (`google`, `anthropic`), the operator infers `domain` and `apiKey` automatically. For `openai` and `xai`, you must provide a `domain` since they use `type: bearer`. For other LLM providers, messaging channels, MCP servers, and more, see the [User Guide](docs/user-guide.md).
 
 Wait for it to become ready and get the URL and gateway token:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,8 @@ The proxy sits between the gateway and external APIs, injecting credentials into
 
 **Vertex AI path**: credentials with `type: gcp` and a non-google `provider` (e.g., anthropic) use the native Vertex AI SDK rather than gateway routing. The operator creates a stub ADC (Application Default Credentials) ConfigMap so google-auth-library can bootstrap, and the proxy intercepts token refresh requests to vend real tokens.
 
+**Companion providers**: OpenClaw sometimes routes models through internal provider names that differ from the user-facing provider. For example, GPT-5.x models (gpt-5.5, gpt-5.4, gpt-5.4-mini) are routed through an internal `openai-codex` provider rather than `openai`. The `companionProviders` map in `claw_providers.go` handles this: when `injectProviders` creates a provider entry, it also creates entries for any companions with the same `baseUrl` and placeholder API key. This ensures the proxy handles credential injection for all models without requiring users to configure additional providers. Companion keys are checked for collisions with the same error path as primary providers.
+
 ## NetworkPolicy and Egress Rules
 
 The operator creates three NetworkPolicies per instance: `{instance}-ingress` (gateway ingress from OpenShift routers), `{instance}-egress` (gateway egress to proxy + DNS), and `{instance}-proxy-egress` (proxy egress to HTTPS + DNS). These enforce a defense-in-depth posture where the gateway can only reach external services through the proxy.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -116,6 +116,8 @@ spec:
 EOF
 ```
 
+> **GPT-5.x models:** OpenClaw routes newer GPT models (gpt-5.5, gpt-5.4, gpt-5.4-mini) through an internal provider called `openai-codex`. The operator handles this automatically — when you configure an `openai` credential, a companion `openai-codex` provider entry is created with the same endpoint and credentials. No additional configuration is needed.
+
 ### xAI (Grok)
 
 Uses the xAI API with a bearer token.


### PR DESCRIPTION
Adds OpenAI alongside Gemini in the Quick Start guide (sections 3 and 4), covering credential secret creation and Claw CR
   examples with `type: bearer` and explicit `domain`
   - **User Guide**: Adds a note under the OpenAI section explaining that
   GPT-5.x models are automatically handled via the companion `openai-codex`
   provider
   - **Architecture**: Documents the companion providers mechanism under
   Credential System Design

   ## Test plan

   Verified end-to-end by following the updated README instructions on a
   clean ROSA cluster

  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenAI credential setup instructions and expanded configuration examples
  * Documented automatic routing of GPT-5.x models when using OpenAI credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->