### PR TITLE
chore: bump OpenClaw image to 2026.5.28

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.5.27-slim
+    newTag: 2026.5.28

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -29,7 +29,7 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
-const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.27-slim"
+const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.5.28"
 
 func makeTestDeploymentForPlugins() []*unstructured.Unstructured {
 	dep := &unstructured.Unstructured{}


### PR DESCRIPTION
- Upgrade from 2026.5.27-slim to 2026.5.28
- Drop -slim suffix (both tags resolve to the same image digest)
- Update test constant to match new tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version to 2026.5.28
  * Updated test configurations for version compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->