### PR TITLE
fix: disable misleading update check banner in OpenClaw UI

### DIFF
--- a/internal/controller/claw_config.go
+++ b/internal/controller/claw_config.go
@@ -133,6 +133,13 @@ func enforceInfrastructureKeys(config map[string]any) {
 	ensureNestedMap(gateway, configKeyControlUI)["enabled"] = true
 }
 
+// disableUpdateCheck prevents the gateway from showing the misleading
+// "update available" banner. The operator pins the container image, so
+// users cannot self-update via the OpenClaw UI.
+func disableUpdateCheck(config map[string]any) {
+	setNestedValue(config, false, "update", "checkOnStart")
+}
+
 // enforceTrustedProxies appends the required RFC1918 ranges to any user-provided
 // trustedProxies, deduplicating entries.
 func enforceTrustedProxies(config map[string]any) {

--- a/internal/controller/claw_config_test.go
+++ b/internal/controller/claw_config_test.go
@@ -280,6 +280,32 @@ func TestEnforceTrustedProxies(t *testing.T) {
 	})
 }
 
+// --- disableUpdateCheck unit tests ---
+
+func TestDisableUpdateCheck(t *testing.T) {
+	t.Run("sets checkOnStart false on empty config", func(t *testing.T) {
+		config := map[string]any{}
+		disableUpdateCheck(config)
+
+		update := config["update"].(map[string]any)
+		assert.Equal(t, false, update["checkOnStart"])
+	})
+
+	t.Run("overrides user-set checkOnStart true", func(t *testing.T) {
+		config := map[string]any{
+			"update": map[string]any{
+				"checkOnStart": true,
+				"channel":      "stable",
+			},
+		}
+		disableUpdateCheck(config)
+
+		update := config["update"].(map[string]any)
+		assert.Equal(t, false, update["checkOnStart"])
+		assert.Equal(t, "stable", update["channel"], "non-target keys preserved")
+	})
+}
+
 // --- spec.config.raw full pipeline integration tests ---
 
 func TestSpecConfigRawIntegration(t *testing.T) {
@@ -508,8 +534,46 @@ func TestSpecConfigRawIntegration(t *testing.T) {
 		assert.Contains(t, proxies, "10.0.0.0/8")
 		assert.Contains(t, proxies, "172.16.0.0/12")
 
+		update := config["update"].(map[string]any)
+		assert.Equal(t, false, update["checkOnStart"],
+			"update.checkOnStart should be disabled by default")
+
 		models := config["models"].(map[string]any)
 		assert.NotNil(t, models["providers"])
+	})
+
+	t.Run("update check is disabled even if user enables it", func(t *testing.T) {
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
+			Spec: clawv1alpha1.ClawSpec{
+				Credentials: testCredentials(),
+				Config: &clawv1alpha1.ConfigSpec{
+					Raw: &clawv1alpha1.RawConfig{
+						RawExtension: runtime.RawExtension{
+							Raw: []byte(`{
+								"update": {"checkOnStart": true, "channel": "beta"}
+							}`),
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		config := getReconciled(t, ctx)
+		update := config["update"].(map[string]any)
+		assert.Equal(t, false, update["checkOnStart"],
+			"update.checkOnStart is always-win false")
+		assert.Equal(t, "beta", update["channel"],
+			"non-enforced update keys are preserved")
 	})
 
 	t.Run("user plugin entries for non-declared keys are preserved", func(t *testing.T) {

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -722,6 +722,7 @@ func (r *ClawResourceReconciler) enrichConfigAndNetworkPolicy(
 
 	enforceInfrastructureKeys(config)
 	enforceTrustedProxies(config)
+	disableUpdateCheck(config)
 	injectRouteHost(config, routeHost)
 	injectAuthMode(config, instance)
 	if err := injectProviders(config, instance); err != nil {


### PR DESCRIPTION
- Set update.checkOnStart to false as an always-win enforced key
- The operator pins the container image, so users cannot self-update via the OpenClaw UI — the banner was misleading
- Preserves other user-provided update config keys (e.g. channel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update check notifications are now disabled by default, preventing unnecessary "update available" banners from appearing on startup.

* **Tests**
  * Added comprehensive test coverage validating update check configuration behavior and override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->