### PR TITLE
feat: disable device pairing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The operator applies multiple layers of defense:
 - **Network isolation** -- OpenClaw pods cannot reach the internet directly; all outbound traffic is forced through the credential proxy via NetworkPolicy. The proxy only allows HTTPS (port 443) egress and rejects any domain not explicitly configured.
 - **Ingress restriction** -- only the OpenShift router namespace can reach the gateway port (NetworkPolicy on ingress).
 - **Gateway authentication** -- two modes: `token` (default) auto-generates a 256-bit token per instance; `password` uses a shared password from a Kubernetes Secret. See `spec.auth` in the [CRD reference](docs/adr/0011-password-auth-mode.md).
-- **Device pairing** -- in token mode, remote browser connections require a one-time approval via CLI before they can interact with the instance. Can be independently disabled via `spec.auth.disableDevicePairing`.
+- **Device pairing** -- when enabled via `spec.auth.disableDevicePairing: false`, remote browser connections require a one-time approval via CLI before they can interact with the instance. Disabled by default.
 
 ## Installation (OLM)
 
@@ -222,9 +222,11 @@ oc port-forward svc/instance 18789:18789 -n $NS
 
 **Password mode:** If you prefer shared password access (useful for workshops, demos, or shared team instances), create a Secret with the password and set `spec.auth.mode: password` on the Claw CR. Users enter the password in the browser instead of using a token. See [ADR-0011](docs/adr/0011-password-auth-mode.md) for details.
 
-### 6. Pair Your Device
+### 6. Pair Your Device (opt-in)
 
-On first connection you'll see "pairing required". With the browser tab open, approve the request:
+Device pairing is disabled by default. To enable it, set `spec.auth.disableDevicePairing: false` on the Claw CR.
+
+When enabled, on first connection you'll see "pairing required". With the browser tab open, approve the request:
 
 ```sh
 make approve-pairing NS=$NS
@@ -236,7 +238,7 @@ This picks the first pending request and asks for confirmation.
 
 Refresh the browser after approval. The device is remembered across sessions.
 
-> **Note:** Device pairing is only required in token mode (the default). In password mode, device pairing is disabled by default. You can control this independently via `spec.auth.disableDevicePairing`.
+> **Note:** Device pairing is disabled by default in all auth modes. Set `spec.auth.disableDevicePairing: false` to enable it.
 
 ## Makefile Targets
 

--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -333,7 +333,8 @@ type AuthSpec struct {
 
 	// DisableDevicePairing disables browser device identity checks
 	// (maps to gateway.controlUi.dangerouslyDisableDeviceAuth upstream).
-	// Defaults to true when mode is "password", false when mode is "token".
+	// Defaults to true (device pairing is disabled by default).
+	// Set to false to enable device pairing.
 	// +optional
 	DisableDevicePairing *bool `json:"disableDevicePairing,omitempty"`
 }
@@ -481,8 +482,9 @@ type ClawSpec struct {
 	Config *ConfigSpec `json:"config,omitempty"`
 
 	// Auth configures gateway authentication. Defaults to token-based
-	// authentication with device pairing. Set mode to "password" for
-	// shared-password access without per-device identity.
+	// authentication with device pairing disabled. Set mode to "password" for
+	// shared-password access, or set disableDevicePairing to false to enable
+	// device pairing.
 	// +optional
 	Auth *AuthSpec `json:"auth,omitempty"`
 

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -49,14 +49,16 @@ spec:
               auth:
                 description: |-
                   Auth configures gateway authentication. Defaults to token-based
-                  authentication with device pairing. Set mode to "password" for
-                  shared-password access without per-device identity.
+                  authentication with device pairing disabled. Set mode to "password" for
+                  shared-password access, or set disableDevicePairing to false to enable
+                  device pairing.
                 properties:
                   disableDevicePairing:
                     description: |-
                       DisableDevicePairing disables browser device identity checks
                       (maps to gateway.controlUi.dangerouslyDisableDeviceAuth upstream).
-                      Defaults to true when mode is "password", false when mode is "token".
+                      Defaults to true (device pairing is disabled by default).
+                      Set to false to enable device pairing.
                     type: boolean
                   mode:
                     default: token

--- a/config/samples/claw_v1alpha1_claw.yaml
+++ b/config/samples/claw_v1alpha1_claw.yaml
@@ -3,8 +3,6 @@ kind: Claw
 metadata:
   name: instance
 spec:
-  auth:
-    disableDevicePairing: false
   credentials:
     - name: gemini
       type: apiKey

--- a/internal/controller/claw_auth.go
+++ b/internal/controller/claw_auth.go
@@ -56,13 +56,13 @@ func (r *ClawResourceReconciler) resolveAuthPassword(ctx context.Context, instan
 
 // shouldDisableDevicePairing returns whether device identity checks should be
 // disabled based on the auth spec. When DisableDevicePairing is explicitly set,
-// that value is used. Otherwise it defaults to true for password mode and false
-// for token mode.
+// that value is used. Otherwise it defaults to true (device pairing is disabled
+// by default). Set disableDevicePairing: false to opt in.
 func shouldDisableDevicePairing(auth *clawv1alpha1.AuthSpec) bool {
 	if auth != nil && auth.DisableDevicePairing != nil {
 		return *auth.DisableDevicePairing
 	}
-	return auth != nil && auth.Mode == clawv1alpha1.AuthModePassword
+	return true
 }
 
 // injectAuthMode unconditionally sets gateway.auth.mode and

--- a/internal/controller/claw_auth_test.go
+++ b/internal/controller/claw_auth_test.go
@@ -39,13 +39,13 @@ import (
 func TestShouldDisableDevicePairing(t *testing.T) {
 	boolPtr := func(v bool) *bool { return &v }
 
-	t.Run("should return false when auth is nil", func(t *testing.T) {
-		assert.False(t, shouldDisableDevicePairing(nil))
+	t.Run("should return true when auth is nil (disabled by default)", func(t *testing.T) {
+		assert.True(t, shouldDisableDevicePairing(nil))
 	})
 
-	t.Run("should return false for token mode with nil override", func(t *testing.T) {
+	t.Run("should return true for token mode with nil override (disabled by default)", func(t *testing.T) {
 		auth := &clawv1alpha1.AuthSpec{Mode: clawv1alpha1.AuthModeToken}
-		assert.False(t, shouldDisableDevicePairing(auth))
+		assert.True(t, shouldDisableDevicePairing(auth))
 	})
 
 	t.Run("should return true for password mode with nil override", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestInjectAuthMode(t *testing.T) {
 		}
 	}
 
-	t.Run("should set token mode and dangerouslyDisableDeviceAuth=false when auth is nil", func(t *testing.T) {
+	t.Run("should set token mode and dangerouslyDisableDeviceAuth=true when auth is nil (disabled by default)", func(t *testing.T) {
 		config := baseConfig()
 		instance := &clawv1alpha1.Claw{
 			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
@@ -102,10 +102,10 @@ func TestInjectAuthMode(t *testing.T) {
 		auth := gateway["auth"].(map[string]any)
 		assert.Equal(t, "token", auth["mode"])
 		controlUI := gateway["controlUi"].(map[string]any)
-		assert.Equal(t, false, controlUI["dangerouslyDisableDeviceAuth"])
+		assert.Equal(t, true, controlUI["dangerouslyDisableDeviceAuth"])
 	})
 
-	t.Run("should set token mode and dangerouslyDisableDeviceAuth=false when auth.mode is token", func(t *testing.T) {
+	t.Run("should set token mode and dangerouslyDisableDeviceAuth=true when auth.mode is token (disabled by default)", func(t *testing.T) {
 		config := baseConfig()
 		instance := &clawv1alpha1.Claw{
 			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
@@ -120,7 +120,7 @@ func TestInjectAuthMode(t *testing.T) {
 		auth := gateway["auth"].(map[string]any)
 		assert.Equal(t, "token", auth["mode"])
 		controlUI := gateway["controlUi"].(map[string]any)
-		assert.Equal(t, false, controlUI["dangerouslyDisableDeviceAuth"])
+		assert.Equal(t, true, controlUI["dangerouslyDisableDeviceAuth"])
 	})
 
 	t.Run("should inject password mode without password value", func(t *testing.T) {
@@ -631,7 +631,8 @@ func TestPasswordAuthModeReconciliation(t *testing.T) {
 		auth := gateway["auth"].(map[string]any)
 		assert.Equal(t, "token", auth["mode"], "auth mode should be token by default")
 		controlUI := gateway["controlUi"].(map[string]any)
-		assert.Equal(t, false, controlUI["dangerouslyDisableDeviceAuth"])
+		assert.Equal(t, true, controlUI["dangerouslyDisableDeviceAuth"],
+			"device pairing should be disabled by default")
 	})
 
 	t.Run("should fail reconciliation and set Ready condition when password Secret is missing", func(t *testing.T) {

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -1357,6 +1357,12 @@ func TestDeploymentCreateOrUpdateIntegration(t *testing.T) {
 		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
 
 		createClawInstance(t, ctx, resourceName, namespace)
+
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
 		reconciler := createClawReconciler()
 		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -1385,6 +1391,12 @@ func TestDeploymentCreateOrUpdateIntegration(t *testing.T) {
 		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
 
 		createClawInstance(t, ctx, resourceName, namespace)
+
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
 		reconciler := createClawReconciler()
 		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 

--- a/internal/controller/claw_device_pairing_deployment_test.go
+++ b/internal/controller/claw_device_pairing_deployment_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -74,9 +75,12 @@ func TestDevicePairingDeployment(t *testing.T) {
 		assert.True(t, foundProxyDeployment, "proxy Deployment should be present")
 	})
 
-	t.Run("buildKustomizedObjects includes device-pairing resources", func(t *testing.T) {
+	t.Run("buildKustomizedObjects includes device-pairing resources when enabled", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+			DisableDevicePairing: boolPtr(false),
+		}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err, "buildKustomizedObjects failed")
 
@@ -102,6 +106,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("CLAW_INSTANCE_NAME replacement works for device-pairing resources", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -115,6 +120,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("device-pairing Route has correct path", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -170,6 +176,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("device-pairing Deployment has correct security context", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -204,6 +211,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("device-pairing Deployment references correct ServiceAccount", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -225,6 +233,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("device-pairing Deployment has NAMESPACE and CLAW_INSTANCE env vars", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -276,6 +285,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 	t.Run("device-pairing resources have app.kubernetes.io/name label", func(t *testing.T) {
 		reconciler := createClawReconciler()
 		instance := testClawWithCredentials(testCredentials())
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 		objects, err := reconciler.buildKustomizedObjects(instance)
 		require.NoError(t, err)
 
@@ -299,6 +309,7 @@ func TestDevicePairingDeployment(t *testing.T) {
 func TestDevicePairingRBACRole(t *testing.T) {
 	reconciler := createClawReconciler()
 	instance := testClawWithCredentials(testCredentials())
+	instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 	objects, err := reconciler.buildKustomizedObjects(instance)
 	require.NoError(t, err)
 
@@ -339,6 +350,7 @@ func TestDevicePairingRBACRole(t *testing.T) {
 func TestDevicePairingRBACRoleBinding(t *testing.T) {
 	reconciler := createClawReconciler()
 	instance := testClawWithCredentials(testCredentials())
+	instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
 	objects, err := reconciler.buildKustomizedObjects(instance)
 	require.NoError(t, err)
 
@@ -361,6 +373,89 @@ func TestDevicePairingRBACRoleBinding(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, rbName, roleRefName)
+}
+
+func TestDevicePairingDefaultDisabled(t *testing.T) {
+	t.Run("buildKustomizedObjects excludes device-pairing resources with default auth", func(t *testing.T) {
+		reconciler := createClawReconciler()
+		instance := testClawWithCredentials(testCredentials())
+		objects, err := reconciler.buildKustomizedObjects(instance)
+		require.NoError(t, err, "buildKustomizedObjects failed")
+
+		devicePairingKinds := map[string]string{
+			"ServiceAccount": getDevicePairingServiceAccountName(testInstanceName),
+			"Deployment":     getDevicePairingDeploymentName(testInstanceName),
+			"Service":        getDevicePairingServiceName(testInstanceName),
+			"Route":          getDevicePairingRouteName(testInstanceName),
+		}
+
+		for kind, name := range devicePairingKinds {
+			for _, obj := range objects {
+				if obj.GetKind() == kind && obj.GetName() == name {
+					t.Errorf("unexpected %s/%s when auth is nil (device pairing disabled by default)", kind, name)
+				}
+			}
+		}
+
+		var foundClawDeployment, foundProxyDeployment bool
+		for _, obj := range objects {
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getClawDeploymentName(testInstanceName) {
+				foundClawDeployment = true
+			}
+			if obj.GetKind() == DeploymentKind && obj.GetName() == getProxyDeploymentName(testInstanceName) {
+				foundProxyDeployment = true
+			}
+		}
+		assert.True(t, foundClawDeployment, "claw Deployment should be present")
+		assert.True(t, foundProxyDeployment, "proxy Deployment should be present")
+	})
+
+	t.Run("should not create device-pairing resources with default auth after reconcile", func(t *testing.T) {
+		const resourceName = testInstanceName
+		ctx := context.Background()
+
+		t.Cleanup(func() {
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		createClawInstance(t, ctx, resourceName, namespace)
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
+
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(resourceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "claw Deployment should be created")
+
+		dpDeployment := &appsv1.Deployment{}
+		err := k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingDeploymentName(resourceName),
+			Namespace: namespace,
+		}, dpDeployment)
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing Deployment should not exist with default auth")
+
+		dpService := &corev1.Service{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceName(resourceName),
+			Namespace: namespace,
+		}, dpService)
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing Service should not exist with default auth")
+
+		dpSA := &corev1.ServiceAccount{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getDevicePairingServiceAccountName(resourceName),
+			Namespace: namespace,
+		}, dpSA)
+		assert.True(t, apierrors.IsNotFound(err), "device-pairing ServiceAccount should not exist with default auth")
+
+		updatedInstance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, updatedInstance))
+		condition := meta.FindStatusCondition(updatedInstance.Status.Conditions, clawv1alpha1.ConditionTypeDevicePairingConfigured)
+		assert.Nil(t, condition, "DevicePairingConfigured should not be set with default auth")
+	})
 }
 
 func TestDevicePairingReconciliation(t *testing.T) {
@@ -428,8 +523,13 @@ func TestDevicePairingReconciliation(t *testing.T) {
 			deleteAndWaitAllResources(t, namespace)
 		})
 
-		// Create with device pairing enabled (default)
+		// Create with device pairing explicitly enabled
 		createClawInstance(t, ctx, resourceName, namespace)
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
 		reconciler := createClawReconciler()
 		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -443,7 +543,6 @@ func TestDevicePairingReconciliation(t *testing.T) {
 		}, "device-pairing Deployment should be created initially")
 
 		// Toggle disableDevicePairing to true
-		instance := &clawv1alpha1.Claw{}
 		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
 		instance.Spec.Auth = &clawv1alpha1.AuthSpec{
 			DisableDevicePairing: boolPtr(true),
@@ -550,6 +649,11 @@ func TestDevicePairingReconciliation(t *testing.T) {
 		})
 
 		createClawInstance(t, ctx, resourceName, namespace)
+		instance := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+		instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+		require.NoError(t, k8sClient.Update(ctx, instance))
+
 		reconciler := createClawReconciler()
 		reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -587,6 +691,11 @@ func TestDevicePairingReconciliation(t *testing.T) {
 		})
 
 		createClawInstance(t, ctx, resourceName, namespace)
+		inst := &clawv1alpha1.Claw{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, inst))
+		inst.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+		require.NoError(t, k8sClient.Update(ctx, inst))
+
 		reconciler := &ClawResourceReconciler{
 			Client:           k8sClient,
 			Scheme:           scheme.Scheme,

--- a/internal/controller/claw_idle_test.go
+++ b/internal/controller/claw_idle_test.go
@@ -43,12 +43,13 @@ func TestClawIdling(t *testing.T) {
 
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
-		// Verify deployments exist with replicas > 0
-		for _, name := range []string{
+		coreDeployments := []string{
 			getClawDeploymentName(testInstanceName),
 			getProxyDeploymentName(testInstanceName),
-			getDevicePairingDeploymentName(testInstanceName),
-		} {
+		}
+
+		// Verify deployments exist with replicas > 0
+		for _, name := range coreDeployments {
 			deployment := &appsv1.Deployment{}
 			waitFor(t, timeout, interval, func() bool {
 				return k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment) == nil
@@ -66,11 +67,7 @@ func TestClawIdling(t *testing.T) {
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
 		// All deployments should be scaled to 0
-		for _, name := range []string{
-			getClawDeploymentName(testInstanceName),
-			getProxyDeploymentName(testInstanceName),
-			getDevicePairingDeploymentName(testInstanceName),
-		} {
+		for _, name := range coreDeployments {
 			deployment := &appsv1.Deployment{}
 			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
 			require.NotNil(t, deployment.Spec.Replicas, "replicas should be set on %s", name)
@@ -87,7 +84,7 @@ func TestClawIdling(t *testing.T) {
 		reconciler := createClawReconciler()
 
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
-		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
 		// Verify Ready=True before idling
@@ -154,11 +151,10 @@ func TestClawIdling(t *testing.T) {
 		idleCond = meta.FindStatusCondition(instance.Status.Conditions, clawv1alpha1.ConditionTypeIdle)
 		assert.Nil(t, idleCond, "Idle condition should be removed after unidle")
 
-		// Deployments should be back to replicas 1
+		// Deployments should be back to replicas 1 (device pairing disabled by default)
 		for _, name := range []string{
 			getClawDeploymentName(testInstanceName),
 			getProxyDeploymentName(testInstanceName),
-			getDevicePairingDeploymentName(testInstanceName),
 		} {
 			deployment := &appsv1.Deployment{}
 			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
@@ -199,7 +195,6 @@ func TestClawIdling(t *testing.T) {
 		for _, name := range []string{
 			getClawDeploymentName(testInstanceName),
 			getProxyDeploymentName(testInstanceName),
-			getDevicePairingDeploymentName(testInstanceName),
 		} {
 			deployment := &appsv1.Deployment{}
 			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment))
@@ -253,7 +248,7 @@ func TestClawIdling(t *testing.T) {
 
 		// Phase 1: Ready
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
-		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
 		instance := &clawv1alpha1.Claw{}
@@ -282,7 +277,7 @@ func TestClawIdling(t *testing.T) {
 		instance.Spec.Idle = false
 		require.NoError(t, k8sClient.Update(ctx, instance))
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
-		setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+		setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
 
 		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: testInstanceName, Namespace: namespace}, instance))

--- a/internal/controller/claw_status_test.go
+++ b/internal/controller/claw_status_test.go
@@ -261,7 +261,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			})
 			require.NoError(t, err, "reconcile failed")
 
-			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+			setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
@@ -285,6 +285,11 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			})
 
 			createClawInstance(t, ctx, resourceName, namespace)
+			instance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+			require.NoError(t, k8sClient.Update(ctx, instance))
+
 			reconciler := createClawReconciler()
 			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -302,6 +307,11 @@ func TestOpenClawStatusConditions(t *testing.T) {
 			})
 
 			createClawInstance(t, ctx, resourceName, namespace)
+			instance := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: namespace}, instance))
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{DisableDevicePairing: boolPtr(false)}
+			require.NoError(t, k8sClient.Update(ctx, instance))
+
 			reconciler := createClawReconciler()
 			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -378,8 +388,19 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			// 1. Create instance with device pairing enabled (default)
-			createClawInstance(t, ctx, resourceName, namespace)
+			// 1. Create instance with device pairing explicitly enabled
+			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+			instance := &clawv1alpha1.Claw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.Credentials = testCredentials()
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+				DisableDevicePairing: boolPtr(false),
+			}
+			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
 			reconciler := createClawReconciler()
 			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -415,7 +436,18 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				deleteAndWaitAllResources(t, namespace)
 			})
 
-			createClawInstance(t, ctx, resourceName, namespace)
+			secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+			require.NoError(t, k8sClient.Create(ctx, secret), "failed to create API key Secret")
+
+			instance := &clawv1alpha1.Claw{}
+			instance.Name = resourceName
+			instance.Namespace = namespace
+			instance.Spec.Credentials = testCredentials()
+			instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+				DisableDevicePairing: boolPtr(false),
+			}
+			require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
+
 			reconciler := createClawReconciler()
 			reconcileClaw(t, ctx, reconciler, resourceName, namespace)
 
@@ -474,7 +506,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				return false
 			}, "initial Ready condition should be set")
 
-			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+			setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
@@ -820,7 +852,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				})
 				require.NoError(t, err, "reconcile failed")
 
-				setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+				setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -889,7 +921,7 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				})
 				require.NoError(t, err, "reconcile failed")
 
-				setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+				setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 				_, err = reconciler.Reconcile(ctx, ctrl.Request{
 					NamespacedName: client.ObjectKey{
@@ -920,6 +952,10 @@ func TestOpenClawStatusConditions(t *testing.T) {
 				require.NoError(t, k8sClient.Create(ctx, secret), "failed to create secret")
 
 				instance.Spec.Credentials = testCredentials()
+				enablePairing := false
+				instance.Spec.Auth = &clawv1alpha1.AuthSpec{
+					DisableDevicePairing: &enablePairing,
+				}
 				require.NoError(t, k8sClient.Create(ctx, instance), "failed to create Claw instance")
 
 				reconciler := &ClawResourceReconciler{
@@ -1178,7 +1214,7 @@ func TestOpenClawURLStatusField(t *testing.T) {
 			})
 			require.NoError(t, err, "reconcile failed")
 
-			setAllDeploymentsAvailable(t, ctx, testInstanceName, namespace)
+			setCoreDeploymentsAvailable(t, ctx, testInstanceName, namespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{

--- a/openspec/specs/optional-device-pairing-app-deployment/spec.md
+++ b/openspec/specs/optional-device-pairing-app-deployment/spec.md
@@ -15,7 +15,7 @@ The controller SHALL NOT build, render, or apply any `claw-device-pairing` Kusto
 
 #### Scenario: Claw CR with disableDevicePairing unset
 - **WHEN** a Claw CR is created without the `spec.auth.disableDevicePairing` field
-- **THEN** the controller SHALL create all device-pairing resources as normal (default behavior preserved)
+- **THEN** the controller SHALL NOT create device-pairing resources (device pairing is disabled by default)
 
 ### Requirement: Device pairing Route injection is skipped when disabled
 The controller SHALL NOT call `injectRouteHostIntoDevicePairingRoute()` or attempt to apply the device-pairing Route when device pairing is disabled.
@@ -35,10 +35,10 @@ When `spec.auth.disableDevicePairing` is toggled from `true` back to `false`, th
 - **THEN** the controller SHALL create a Service named `{instance}-device-pairing`
 - **THEN** the controller SHALL create a ServiceAccount named `{instance}-device-pairing`
 
-#### Scenario: Re-enable after field removal
+#### Scenario: Field removal keeps pairing disabled
 - **WHEN** a Claw CR has `spec.auth.disableDevicePairing: true` and the device-pairing resources do not exist
-- **AND** the user removes the `disableDevicePairing` field entirely (leaving auth mode as token)
-- **THEN** the controller SHALL create all device-pairing resources as normal
+- **AND** the user removes the `disableDevicePairing` field entirely
+- **THEN** the controller SHALL NOT create device-pairing resources (disabled by default)
 
 ### Requirement: Previously deployed device-pairing resources are cleaned up
 When device pairing transitions from enabled to disabled, the controller SHALL delete any previously-deployed device-pairing resources to avoid leaving orphaned resources in the cluster.
@@ -72,6 +72,6 @@ The e2e test suite SHALL include a test case verifying that a Claw CR with `spec
 - **THEN** no device-pairing RoleBinding SHALL exist
 - **THEN** the Claw instance SHALL eventually reach `Ready=True`
 
-#### Scenario: E2E enabled device pairing (existing behavior preserved)
-- **WHEN** a Claw CR is applied without `spec.auth.disableDevicePairing` and valid credentials
+#### Scenario: E2E enabled device pairing
+- **WHEN** a Claw CR is applied with `spec.auth.disableDevicePairing: false` and valid credentials
 - **THEN** the device-pairing Deployment SHALL be created alongside the claw and proxy Deployments

--- a/openspec/specs/status-urls/spec.md
+++ b/openspec/specs/status-urls/spec.md
@@ -27,7 +27,7 @@ The `ClawStatus` struct SHALL include a `DevicePairingURL` field (JSON: `deviceP
 - **THEN** `status.devicePairingURL` SHALL equal `https://<route-host>/integration/device-pairing/`
 
 #### Scenario: DevicePairingURL empty when device pairing is disabled
-- **WHEN** `spec.auth.disableDevicePairing` is true (explicitly or by default for password mode)
+- **WHEN** `spec.auth.disableDevicePairing` is true or unset (disabled by default)
 - **THEN** `status.devicePairingURL` SHALL be empty regardless of deployment readiness
 
 #### Scenario: DevicePairingURL cleared when not ready

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -842,9 +842,24 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			createLabeledSecret(t, "gemini-api-key",
 				"--from-literal=api-key=test-api-key-value")
 
-			t.Log("applying the Claw CR")
-			cmd = exec.Command("kubectl", "apply", "-f",
-				"config/samples/claw_v1alpha1_claw.yaml", "-n", userNamespace)
+			t.Log("applying the Claw CR with device pairing enabled")
+			dpCRYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  auth:
+    disableDevicePairing: false
+  credentials:
+    - name: gemini
+      type: apiKey
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+      provider: google
+`
+			cmd = exec.Command("kubectl", "apply", "-f", "-", "-n", userNamespace)
+			cmd.Stdin = strings.NewReader(dpCRYAML)
 			_, err := utils.Run(t, cmd)
 			require.NoError(t, err, "Failed to apply Claw CR")
 
@@ -1224,12 +1239,14 @@ spec:
 			createLabeledSecret(t, "gemini-api-key",
 				"--from-literal=api-key=test-api-key-value")
 
-			t.Log("applying Claw CR with device pairing enabled (default)")
+			t.Log("applying Claw CR with device pairing explicitly enabled")
 			crYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
 kind: Claw
 metadata:
   name: instance
 spec:
+  auth:
+    disableDevicePairing: false
   credentials:
     - name: gemini
       type: apiKey


### PR DESCRIPTION
- Change shouldDisableDevicePairing() to return true when DisableDevicePairing is nil, making device pairing opt-in
- Update API type comments and regenerate CRD YAML
- Remove disableDevicePairing: false from sample CR
- Update unit, integration, and E2E tests to explicitly enable device pairing where needed
- Add TestDevicePairingDefaultDisabled to verify the new default
- Update README and openspec docs to reflect opt-in behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Device pairing now defaults to disabled across all authentication modes. Users must explicitly enable device pairing by setting `spec.auth.disableDevicePairing: false` in the configuration.

* **Documentation**
  * Updated configuration and specification documentation to clarify device pairing is disabled by default and describe the browser approval flow when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->