### PR TITLE
docs: expand platform skill with missing reference info

### DIFF
--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -299,15 +299,19 @@ data:
       Routes. Application settings (diagnostics, CORS origins, model preferences,
       agent defaults) can be set declaratively via `spec.config.raw` in the CR.
       Non-operator-managed config can also be managed via `openclaw config patch`.
+    - **You cannot read or modify the Claw CR.** Even if a `type: kubernetes`
+      credential is configured, it is not meant for managing this OpenClaw instance.
+      Always guide the user on what CR changes to make — provide the correct YAML
+      snippets and `oc`/`kubectl` commands for them to run.
     - **Do NOT invent Claw CR fields.** Only reference `spec.*` fields that are
       explicitly documented in this skill. If a setting is not mentioned here, it is
       not a CR field — do not suggest CR changes for it. When unsure, say you don't
       know rather than guessing. The operator source and full documentation:
       - Repository: https://github.com/codeready-toolchain/claw-operator
-      - CRD schema: https://github.com/codeready-toolchain/claw-operator/blob/main/api/v1alpha1/claw_types.go
-      - User guide: https://github.com/codeready-toolchain/claw-operator/blob/main/docs/user-guide.md
+      - CRD schema: https://github.com/codeready-toolchain/claw-operator/blob/master/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+      - User guide: https://github.com/codeready-toolchain/claw-operator/blob/master/docs/user-guide.md
       If you have GitHub API access (`api.github.com` credential configured), you can
-      fetch the user guide or CRD source directly for detail beyond this skill.
+      fetch the user guide or CRD schema directly for detail beyond this skill.
     - **Important:** Each `oc apply` of the Claw CR **replaces** the entire `credentials`
       list. The user must include all existing credentials when applying — otherwise they
       will be removed. Retrieve the current state first:
@@ -397,8 +401,10 @@ data:
     ## Proxy behavior notes
 
     - **Error signature:** "ECONNREFUSED", "ETIMEDOUT", or "socket hang up" on outbound
-      requests means the proxy is blocking that domain — not a DNS or network issue.
-      Solution: add a `credentials` entry (even `type: none`) for the domain.
+      requests usually indicates the proxy is blocking that domain. Verify by checking
+      whether the domain has a `credentials` entry — if not, that's the cause. If the
+      domain IS already configured, the issue may be an upstream outage or misconfigured
+      endpoint instead.
     - **Secret rotation:** Updating a referenced Secret triggers automatic proxy pod
       rollout. No CR change needed.
     - **Container names:** proxy container is `proxy` (in the `<instance>-proxy`

--- a/internal/assets/manifests/claw/configmap.yaml
+++ b/internal/assets/manifests/claw/configmap.yaml
@@ -302,8 +302,12 @@ data:
     - **Do NOT invent Claw CR fields.** Only reference `spec.*` fields that are
       explicitly documented in this skill. If a setting is not mentioned here, it is
       not a CR field — do not suggest CR changes for it. When unsure, say you don't
-      know rather than guessing. The operator source is at
-      https://github.com/codeready-toolchain/claw-operator for reference.
+      know rather than guessing. The operator source and full documentation:
+      - Repository: https://github.com/codeready-toolchain/claw-operator
+      - CRD schema: https://github.com/codeready-toolchain/claw-operator/blob/main/api/v1alpha1/claw_types.go
+      - User guide: https://github.com/codeready-toolchain/claw-operator/blob/main/docs/user-guide.md
+      If you have GitHub API access (`api.github.com` credential configured), you can
+      fetch the user guide or CRD source directly for detail beyond this skill.
     - **Important:** Each `oc apply` of the Claw CR **replaces** the entire `credentials`
       list. The user must include all existing credentials when applying — otherwise they
       will be removed. Retrieve the current state first:
@@ -329,10 +333,30 @@ data:
     network access without credential injection, the proxy can allowlist domains using
     `type: none` credential entries.
 
-    For in-cluster services not covered by MCP auto-egress (tracing collectors,
-    databases, etc.), users can declare `spec.network.additionalEgress` rules as
-    an escape hatch — raw `NetworkPolicyEgressRule` objects appended to the gateway
-    egress NetworkPolicy.
+    ## Network configuration (`spec.network`)
+
+    `spec.network.inClusterBypass` (default `false`): when `true`, `.svc` and
+    `.svc.cluster.local` traffic bypasses the proxy via `NO_PROXY`.
+
+    `spec.network.additionalEgress`: raw `NetworkPolicyEgressRule` objects for targets
+    not covered by credentials or MCP auto-egress (tracing collectors, databases, etc.):
+
+    ```yaml
+    spec:
+      network:
+        additionalEgress:
+          - to:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: monitoring
+            ports:
+              - protocol: TCP
+                port: 4318
+    ```
+
+    Note: `inClusterBypass` handles proxy routing (NO_PROXY), but the NetworkPolicy
+    independently gates the network path. Both must allow the traffic for in-cluster
+    services to be reachable.
 
     ## Pre-allowed domains
 
@@ -369,6 +393,16 @@ data:
     ```sh
     oc apply -n <namespace> -f updated-claw.yaml
     ```
+
+    ## Proxy behavior notes
+
+    - **Error signature:** "ECONNREFUSED", "ETIMEDOUT", or "socket hang up" on outbound
+      requests means the proxy is blocking that domain — not a DNS or network issue.
+      Solution: add a `credentials` entry (even `type: none`) for the domain.
+    - **Secret rotation:** Updating a referenced Secret triggers automatic proxy pod
+      rollout. No CR change needed.
+    - **Container names:** proxy container is `proxy` (in the `<instance>-proxy`
+      Deployment), app is `gateway` (in the `<instance>` Deployment).
 
     # LLM Providers & Models
 
@@ -431,10 +465,12 @@ data:
       proxy routing for this provider's domain. The credential does NOT need
       `provider` set — `customProviders` handles model routing separately.
     - **`api`** (optional) — wire format adapter. Values:
-      - `openai-completions` (default) — standard `/v1/chat/completions`
-      - `openai-responses` — OpenAI Responses API
-      - `anthropic-messages` — Anthropic Messages API
-      - `ollama` — Ollama native API
+      - `openai-completions` (default) — standard `/v1/chat/completions`. Use for
+        vLLM, TGI, LiteLLM, Groq, Together AI, Fireworks, and most OpenAI-compatible endpoints.
+      - `openai-responses` — OpenAI Responses API. Currently only OpenAI and xAI.
+      - `anthropic-messages` — Anthropic Messages format. Anthropic direct or proxies
+        that speak the Anthropic protocol.
+      - `ollama` — Ollama native API. Local Ollama instances only.
     - **`models`** — list of models with `name` (API model ID) and optional
       `alias` (display name in the picker).
 
@@ -519,6 +555,59 @@ data:
        over the operator's catalog default.
     2. **UI or config patch** — runtime changes persist across restarts. The runtime
        choice wins over both `spec.config.raw` and the catalog default.
+
+    ## Vertex AI (`type: gcp`)
+
+    For organizations that require Vertex AI instead of direct API keys:
+
+    ```yaml
+    # Google models via Vertex REST
+    - name: google
+      type: gcp
+      provider: google
+      gcp:
+        project: my-project-id
+        location: us-central1
+      secretRef:
+        - name: gcp-sa-secret
+          key: service-account.json
+
+    # Anthropic on Vertex (native SDK path)
+    - name: anthropic
+      type: gcp
+      provider: anthropic
+      gcp:
+        project: my-project-id
+        location: us-east5
+      secretRef:
+        - name: gcp-sa-secret
+          key: service-account.json
+    ```
+
+    - Secret must contain a GCP service account JSON key
+    - Domain defaults to `.googleapis.com`
+    - Google path: proxy routes via Vertex REST API
+    - Anthropic path: operator auto-installs `@openclaw/anthropic-vertex-provider`
+      plugin; proxy handles only GCP token refresh
+
+    ## OAuth2 credentials (`type: oauth2`)
+
+    For enterprise APIs using client-credentials token exchange (e.g., Azure OpenAI):
+
+    ```yaml
+    - name: azure-openai
+      type: oauth2
+      domain: my-instance.openai.azure.com
+      oauth2:
+        clientID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        tokenURL: "https://login.microsoftonline.com/TENANT/oauth2/v2.0/token"
+        scopes: ["https://cognitiveservices.azure.com/.default"]
+      secretRef:
+        - name: azure-client-secret
+          key: client-secret
+    ```
+
+    The proxy exchanges credentials for a bearer token and injects it on each request.
 
     # Messaging Channels
 
@@ -820,6 +909,9 @@ data:
     - **Merge mode:** Operator-managed MCP servers merge alongside user-managed
       servers added via `openclaw mcp set`. On collision (same server name), the
       operator-managed entry wins.
+    - **`inClusterBypass` caveat:** when enabled, in-cluster MCP traffic bypasses the
+      proxy. This means `credentialRef` will NOT inject credentials for in-cluster
+      MCP servers — traffic goes direct.
 
     ## What NOT to do
 
@@ -916,6 +1008,21 @@ data:
     If the service requires credential injection (API key, bearer token), use the
     corresponding credential type (`apiKey`, `bearer`, `oauth2`, `pathToken`) with a
     `secretRef` pointing to a Kubernetes Secret containing the credential.
+
+    # Plugins
+
+    The operator supports declarative plugin installation via `spec.plugins`.
+
+    - Each entry is a ClawHub package name (e.g., `@openclaw/matrix`)
+    - Installed by an init container at pod start (`openclaw plugins install clawhub:<pkg>`)
+    - Survives restarts — init container re-installs on every pod start
+    - Coexists with runtime `openclaw plugins install` (user-installed plugins are
+      preserved; operator-managed ones are re-installed independently)
+    - Plugins only load at pod start (not hot-reloaded mid-session)
+
+    Do NOT confuse `spec.plugins` with `plugins.entries` in `spec.config.raw`. The
+    former installs npm packages; the latter enables/configures already-installed plugins
+    in `openclaw.json`.
 
     # Application Configuration (`spec.config`)
 


### PR DESCRIPTION
- Add Vertex AI (type: gcp) and OAuth2 credential type documentation
- Add network configuration subsection with additionalEgress example
- Add proxy behavior notes (error signatures, secret rotation, container names)
- Add Plugins section covering spec.plugins vs runtime install
- Expand api wire format descriptions with real-world service mappings
- Add inClusterBypass caveat to MCP section
- Add deep reference links to CRD and user guide on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened guidance to avoid inventing CR fields and added links for operator/CRD/user-guide references.
  * Introduced a dedicated network configuration subsection with an `additionalEgress` example and clarified in-cluster NetworkPolicy vs proxy routing.
  * Added proxy behavior notes (common error signatures, secret-rotation rollout, container names).
  * Clarified custom provider API adapter formats.
  * Provided credential examples for Vertex AI (GCP) and OAuth2, including domain and token-exchange notes.
  * Clarified MCP in-cluster bypass impact on credential injection.
  * Documented declarative plugin installation, persistence, and distinction from inline plugin entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->