### PR TITLE
fix: replace cluster CA with proxy CA in sanitized kubeconfig

### DIFF
--- a/internal/controller/claw_credentials.go
+++ b/internal/controller/claw_credentials.go
@@ -425,6 +425,10 @@ func parseServerURL(server string) (string, string, error) {
 // sanitizeKubeconfig replaces all user tokens with a placeholder and swaps
 // the cluster CA with the proxy CA so that oc/kubectl trusts the MITM proxy.
 func sanitizeKubeconfig(rawBytes []byte, proxyCACert []byte) ([]byte, error) {
+	if len(proxyCACert) == 0 {
+		return nil, fmt.Errorf("proxy CA certificate is empty, cannot sanitize kubeconfig")
+	}
+
 	cfg, err := clientcmd.Load(rawBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kubeconfig for sanitization: %w", err)
@@ -450,7 +454,7 @@ func sanitizeKubeconfig(rawBytes []byte, proxyCACert []byte) ([]byte, error) {
 
 // applySanitizedKubeconfig creates or updates the sanitized kubeconfig ConfigMap
 // for the gateway pod. Only created when a kubernetes credential is present.
-func (r *ClawResourceReconciler) applySanitizedKubeconfig(ctx context.Context, instance *clawv1alpha1.Claw, resolvedCreds []resolvedCredential) error {
+func (r *ClawResourceReconciler) applySanitizedKubeconfig(ctx context.Context, instance *clawv1alpha1.Claw, resolvedCreds []resolvedCredential, proxyCACert []byte) error {
 	configMapName := getKubeConfigMapName(instance.Name)
 	var kd *kubeconfigData
 	for i := range resolvedCreds {
@@ -469,13 +473,6 @@ func (r *ClawResourceReconciler) applySanitizedKubeconfig(ctx context.Context, i
 	}
 
 	logger := log.FromContext(ctx)
-
-	caSecret := &corev1.Secret{}
-	caSecretName := getProxyCAConfigMapName(instance.Name)
-	if err := r.Get(ctx, client.ObjectKey{Name: caSecretName, Namespace: instance.Namespace}, caSecret); err != nil {
-		return fmt.Errorf("failed to read proxy CA secret %q: %w", caSecretName, err)
-	}
-	proxyCACert := caSecret.Data["ca.crt"]
 
 	sanitized, err := sanitizeKubeconfig(kd.RawBytes, proxyCACert)
 	if err != nil {

--- a/internal/controller/claw_credentials.go
+++ b/internal/controller/claw_credentials.go
@@ -422,9 +422,9 @@ func parseServerURL(server string) (string, string, error) {
 	return hostname, port, nil
 }
 
-// sanitizeKubeconfig replaces all user tokens with a placeholder and returns
-// the sanitized kubeconfig YAML bytes.
-func sanitizeKubeconfig(rawBytes []byte) ([]byte, error) {
+// sanitizeKubeconfig replaces all user tokens with a placeholder and swaps
+// the cluster CA with the proxy CA so that oc/kubectl trusts the MITM proxy.
+func sanitizeKubeconfig(rawBytes []byte, proxyCACert []byte) ([]byte, error) {
 	cfg, err := clientcmd.Load(rawBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kubeconfig for sanitization: %w", err)
@@ -438,6 +438,11 @@ func sanitizeKubeconfig(rawBytes []byte) ([]byte, error) {
 			authInfo.TokenFile = ""
 			authInfo.Token = "proxy-managed-token"
 		}
+	}
+
+	for _, cluster := range cfg.Clusters {
+		cluster.CertificateAuthorityData = proxyCACert
+		cluster.InsecureSkipTLSVerify = false
 	}
 
 	return clientcmd.Write(*cfg)
@@ -465,7 +470,14 @@ func (r *ClawResourceReconciler) applySanitizedKubeconfig(ctx context.Context, i
 
 	logger := log.FromContext(ctx)
 
-	sanitized, err := sanitizeKubeconfig(kd.RawBytes)
+	caSecret := &corev1.Secret{}
+	caSecretName := getProxyCAConfigMapName(instance.Name)
+	if err := r.Get(ctx, client.ObjectKey{Name: caSecretName, Namespace: instance.Namespace}, caSecret); err != nil {
+		return fmt.Errorf("failed to read proxy CA secret %q: %w", caSecretName, err)
+	}
+	proxyCACert := caSecret.Data["ca.crt"]
+
+	sanitized, err := sanitizeKubeconfig(kd.RawBytes, proxyCACert)
 	if err != nil {
 		return fmt.Errorf("failed to sanitize kubeconfig: %w", err)
 	}

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -397,6 +397,23 @@ func TestSanitizeKubeconfig(t *testing.T) {
 		assert.False(t, result.Clusters["prod"].InsecureSkipTLSVerify)
 		assert.Equal(t, testProxyCAPEM, result.Clusters["prod"].CertificateAuthorityData)
 	})
+
+	t.Run("should reject empty proxy CA cert", func(t *testing.T) {
+		data := buildTestKubeconfig(t,
+			map[string]string{"prod": "https://api.example.com:6443"},
+			map[string]string{"admin": "my-token"},
+			map[string][2]string{"ctx": {"prod", "admin"}},
+			"ctx",
+		)
+
+		_, err := sanitizeKubeconfig(data, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy CA certificate is empty")
+
+		_, err = sanitizeKubeconfig(data, []byte{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy CA certificate is empty")
+	})
 }
 
 // --- injectKubePortsIntoNetworkPolicy tests ---

--- a/internal/controller/claw_kubernetes_test.go
+++ b/internal/controller/claw_kubernetes_test.go
@@ -270,6 +270,9 @@ func TestParseAndValidateKubeconfig(t *testing.T) {
 // --- sanitizeKubeconfig tests ---
 
 func TestSanitizeKubeconfig(t *testing.T) {
+	testProxyCAPEM := []byte("-----BEGIN CERTIFICATE-----\nTESTUFJPWFlDQQ==\n-----END CERTIFICATE-----\n")
+	originalClusterCA := []byte("-----BEGIN CERTIFICATE-----\nT1JJR0lOQUxDQQ==\n-----END CERTIFICATE-----\n")
+
 	t.Run("should replace tokens with placeholder", func(t *testing.T) {
 		data := buildTestKubeconfig(t,
 			map[string]string{"prod": "https://api.example.com:6443"},
@@ -278,7 +281,7 @@ func TestSanitizeKubeconfig(t *testing.T) {
 			"ctx",
 		)
 
-		sanitized, err := sanitizeKubeconfig(data)
+		sanitized, err := sanitizeKubeconfig(data, testProxyCAPEM)
 		require.NoError(t, err)
 
 		cfg, err := clientcmd.Load(sanitized)
@@ -308,7 +311,7 @@ func TestSanitizeKubeconfig(t *testing.T) {
 			"prod-ctx",
 		)
 
-		sanitized, err := sanitizeKubeconfig(data)
+		sanitized, err := sanitizeKubeconfig(data, testProxyCAPEM)
 		require.NoError(t, err)
 
 		cfg, err := clientcmd.Load(sanitized)
@@ -317,6 +320,82 @@ func TestSanitizeKubeconfig(t *testing.T) {
 		assert.Equal(t, "proxy-managed-token", cfg.AuthInfos["staging-admin"].Token)
 		assert.NotContains(t, string(sanitized), "prod-secret-token")
 		assert.NotContains(t, string(sanitized), "staging-secret-token")
+	})
+
+	t.Run("should replace cluster CA with proxy CA", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["prod"] = &clientcmdapi.Cluster{
+			Server:                   "https://api.example.com:6443",
+			CertificateAuthorityData: originalClusterCA,
+		}
+		cfg.AuthInfos["admin"] = &clientcmdapi.AuthInfo{Token: "my-token"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "prod", AuthInfo: "admin"}
+		cfg.CurrentContext = "ctx"
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		sanitized, err := sanitizeKubeconfig(data, testProxyCAPEM)
+		require.NoError(t, err)
+
+		result, err := clientcmd.Load(sanitized)
+		require.NoError(t, err)
+
+		assert.Equal(t, testProxyCAPEM, result.Clusters["prod"].CertificateAuthorityData)
+		assert.NotContains(t, string(sanitized), string(originalClusterCA))
+		assert.False(t, result.Clusters["prod"].InsecureSkipTLSVerify)
+	})
+
+	t.Run("should replace CA on all clusters in multi-cluster kubeconfig", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["prod"] = &clientcmdapi.Cluster{
+			Server:                   "https://api.prod.example.com:6443",
+			CertificateAuthorityData: originalClusterCA,
+		}
+		cfg.Clusters["staging"] = &clientcmdapi.Cluster{
+			Server:                   "https://api.staging.example.com:6443",
+			CertificateAuthorityData: []byte("other-ca-data"),
+		}
+		cfg.AuthInfos["admin"] = &clientcmdapi.AuthInfo{Token: "my-token"}
+		cfg.Contexts["prod-ctx"] = &clientcmdapi.Context{Cluster: "prod", AuthInfo: "admin"}
+		cfg.Contexts["staging-ctx"] = &clientcmdapi.Context{Cluster: "staging", AuthInfo: "admin"}
+		cfg.CurrentContext = "prod-ctx"
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		sanitized, err := sanitizeKubeconfig(data, testProxyCAPEM)
+		require.NoError(t, err)
+
+		result, err := clientcmd.Load(sanitized)
+		require.NoError(t, err)
+
+		for name, cluster := range result.Clusters {
+			assert.Equal(t, testProxyCAPEM, cluster.CertificateAuthorityData, "cluster %s should have proxy CA", name)
+			assert.False(t, cluster.InsecureSkipTLSVerify, "cluster %s should not skip TLS verify", name)
+		}
+		assert.NotContains(t, string(sanitized), string(originalClusterCA))
+		assert.NotContains(t, string(sanitized), "other-ca-data")
+	})
+
+	t.Run("should clear InsecureSkipTLSVerify when proxy CA is set", func(t *testing.T) {
+		cfg := clientcmdapi.NewConfig()
+		cfg.Clusters["prod"] = &clientcmdapi.Cluster{
+			Server:                "https://api.example.com:6443",
+			InsecureSkipTLSVerify: true,
+		}
+		cfg.AuthInfos["admin"] = &clientcmdapi.AuthInfo{Token: "my-token"}
+		cfg.Contexts["ctx"] = &clientcmdapi.Context{Cluster: "prod", AuthInfo: "admin"}
+		cfg.CurrentContext = "ctx"
+		data, err := clientcmd.Write(*cfg)
+		require.NoError(t, err)
+
+		sanitized, err := sanitizeKubeconfig(data, testProxyCAPEM)
+		require.NoError(t, err)
+
+		result, err := clientcmd.Load(sanitized)
+		require.NoError(t, err)
+
+		assert.False(t, result.Clusters["prod"].InsecureSkipTLSVerify)
+		assert.Equal(t, testProxyCAPEM, result.Clusters["prod"].CertificateAuthorityData)
 	})
 }
 
@@ -562,6 +641,24 @@ func TestKubernetesCredentialReconciliation(t *testing.T) {
 		assert.NotContains(t, sanitizedConfig, "real-secret-token", "real token should be stripped")
 		assert.Contains(t, sanitizedConfig, "proxy-managed-token", "sanitized placeholder should be present")
 		assert.Contains(t, sanitizedConfig, "api.prod.example.com", "cluster info should be preserved")
+
+		// Verify the proxy CA replaced the cluster CA
+		caSecret := &corev1.Secret{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getProxyCAConfigMapName(testInstanceName),
+			Namespace: namespace,
+		}, caSecret))
+		proxyCACert := caSecret.Data["ca.crt"]
+		require.NotEmpty(t, proxyCACert, "proxy CA cert should exist")
+
+		cfg, err := clientcmd.Load([]byte(sanitizedConfig))
+		require.NoError(t, err)
+		for name, cluster := range cfg.Clusters {
+			assert.Equal(t, proxyCACert, cluster.CertificateAuthorityData,
+				"cluster %s should use proxy CA", name)
+			assert.False(t, cluster.InsecureSkipTLSVerify,
+				"cluster %s should not skip TLS", name)
+		}
 	})
 
 	t.Run("should inject KUBERNETES.md with context info", func(t *testing.T) {

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -662,7 +662,7 @@ func (r *ClawResourceReconciler) stampSecretVersionAnnotation(
 
 // applyProxyCA ensures the proxy CA Secret exists with a valid CA certificate and key.
 // If the Secret is missing or lacks valid data, a new P-256 ECDSA CA is generated.
-func (r *ClawResourceReconciler) applyProxyCA(ctx context.Context, instance *clawv1alpha1.Claw) error {
+func (r *ClawResourceReconciler) applyProxyCA(ctx context.Context, instance *clawv1alpha1.Claw) ([]byte, error) {
 	logger := log.FromContext(ctx)
 	secretName := getProxyCAConfigMapName(instance.Name)
 
@@ -671,15 +671,15 @@ func (r *ClawResourceReconciler) applyProxyCA(ctx context.Context, instance *cla
 	if err == nil {
 		if len(existing.Data["ca.crt"]) > 0 && len(existing.Data["ca.key"]) > 0 {
 			logger.Info("Proxy CA secret already exists, skipping generation")
-			return nil
+			return existing.Data["ca.crt"], nil
 		}
 	} else if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to check for existing proxy CA secret: %w", err)
+		return nil, fmt.Errorf("failed to check for existing proxy CA secret: %w", err)
 	}
 
 	certPEM, keyPEM, err := generateCACertificate()
 	if err != nil {
-		return fmt.Errorf("failed to generate proxy CA: %w", err)
+		return nil, fmt.Errorf("failed to generate proxy CA: %w", err)
 	}
 
 	secret := &corev1.Secret{}
@@ -693,18 +693,18 @@ func (r *ClawResourceReconciler) applyProxyCA(ctx context.Context, instance *cla
 	}
 
 	if err := controllerutil.SetControllerReference(instance, secret, r.Scheme); err != nil {
-		return fmt.Errorf("failed to set controller reference on proxy CA secret: %w", err)
+		return nil, fmt.Errorf("failed to set controller reference on proxy CA secret: %w", err)
 	}
 
 	if err := r.Patch(ctx, secret, client.Apply, &client.PatchOptions{
 		FieldManager: "claw-operator",
 		Force:        ptr.To(true),
 	}); err != nil {
-		return fmt.Errorf("failed to apply proxy CA secret: %w", err)
+		return nil, fmt.Errorf("failed to apply proxy CA secret: %w", err)
 	}
 
 	logger.Info("Generated and applied proxy CA secret")
-	return nil
+	return certPEM, nil
 }
 
 // generateCACertificate creates a self-signed CA certificate and private key.

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -690,13 +690,13 @@ func (r *ClawResourceReconciler) resolveAndApplyCredentials(ctx context.Context,
 	}
 	setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionTrue, clawv1alpha1.ConditionReasonResolved, "All credential Secrets are valid")
 
-	if err := r.applySanitizedKubeconfig(ctx, instance, resolvedCreds); err != nil {
-		logger.Error(err, "Failed to apply sanitized kubeconfig")
+	if err := r.applyProxyCA(ctx, instance); err != nil {
+		logger.Error(err, "Failed to apply proxy CA")
 		return nil, err
 	}
 
-	if err := r.applyProxyCA(ctx, instance); err != nil {
-		logger.Error(err, "Failed to apply proxy CA")
+	if err := r.applySanitizedKubeconfig(ctx, instance, resolvedCreds); err != nil {
+		logger.Error(err, "Failed to apply sanitized kubeconfig")
 		return nil, err
 	}
 

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -690,12 +690,13 @@ func (r *ClawResourceReconciler) resolveAndApplyCredentials(ctx context.Context,
 	}
 	setCondition(instance, clawv1alpha1.ConditionTypeCredentialsResolved, metav1.ConditionTrue, clawv1alpha1.ConditionReasonResolved, "All credential Secrets are valid")
 
-	if err := r.applyProxyCA(ctx, instance); err != nil {
+	proxyCACert, err := r.applyProxyCA(ctx, instance)
+	if err != nil {
 		logger.Error(err, "Failed to apply proxy CA")
 		return nil, err
 	}
 
-	if err := r.applySanitizedKubeconfig(ctx, instance, resolvedCreds); err != nil {
+	if err := r.applySanitizedKubeconfig(ctx, instance, resolvedCreds, proxyCACert); err != nil {
 		logger.Error(err, "Failed to apply sanitized kubeconfig")
 		return nil, err
 	}


### PR DESCRIPTION
- Swap applyProxyCA before applySanitizedKubeconfig so the CA secret exists when the kubeconfig is sanitized
- Add proxyCACert parameter to sanitizeKubeconfig and replace certificate-authority-data on all cluster entries with the proxy CA
- Read the proxy CA secret in applySanitizedKubeconfig and thread it through to sanitizeKubeconfig
- Clear InsecureSkipTLSVerify so oc/kubectl validates against the proxy CA instead of skipping TLS entirely
- Add unit tests for CA replacement (single/multi-cluster, insecure flag reset) and integration test asserting the reconciled ConfigMap contains the proxy CA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubeconfig sanitization now integrates proxy CA management: cluster CAs are replaced with the proxy CA and TLS verification is enforced (no more skip-verify); sanitization fails if no proxy CA is provided.

* **Tests**
  * Expanded tests cover proxy CA handling across single- and multi-cluster kubeconfigs and verify enforcement of CA replacement and TLS settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->