### PR TITLE
tests: add missing openrouter test coverage

### DIFF
--- a/internal/controller/claw_configmap_test.go
+++ b/internal/controller/claw_configmap_test.go
@@ -470,6 +470,30 @@ func TestInjectModelCatalog(t *testing.T) {
 		assert.Equal(t, "google/gemini-3.5-flash", model["primary"])
 	})
 
+	t.Run("openrouter emits three-segment model keys", func(t *testing.T) {
+		config := map[string]any{"models": map[string]any{"providers": map[string]any{}}}
+		credentials := []clawv1alpha1.CredentialSpec{
+			{Name: "or", Type: clawv1alpha1.CredentialTypeBearer, Provider: "openrouter", Domain: "openrouter.ai"},
+		}
+
+		injectModelCatalog(config, testClawWithCredentials(credentials))
+
+		models := config["agents"].(map[string]any)["defaults"].(map[string]any)["models"].(map[string]any)
+		assert.Len(t, models, len(providerModelCatalog("openrouter")))
+		assert.Contains(t, models, "openrouter/openai/gpt-5.5")
+		assert.Contains(t, models, "openrouter/anthropic/claude-sonnet-4-6")
+		assert.Contains(t, models, "openrouter/google/gemini-3.5-flash")
+		entry := models["openrouter/openai/gpt-5.5"].(map[string]any)
+		assert.Equal(t, "GPT-5.5", entry["alias"])
+
+		model := config["agents"].(map[string]any)["defaults"].(map[string]any)["model"].(map[string]any)
+		assert.Equal(t, "openrouter/openai/gpt-5.5", model["primary"])
+		fallbacks := model["fallbacks"].([]any)
+		require.Len(t, fallbacks, 2)
+		assert.Equal(t, "openrouter/anthropic/claude-sonnet-4-6", fallbacks[0])
+		assert.Equal(t, "openrouter/google/gemini-3.5-flash", fallbacks[1])
+	})
+
 	t.Run("primary set from first provider with catalog", func(t *testing.T) {
 		config := map[string]any{"models": map[string]any{"providers": map[string]any{}}}
 		credentials := []clawv1alpha1.CredentialSpec{

--- a/internal/controller/claw_credentials_test.go
+++ b/internal/controller/claw_credentials_test.go
@@ -242,7 +242,7 @@ func TestOpenClawCredentialValidation(t *testing.T) {
 	})
 
 	t.Run("should accept creation via CEL when known provider is set without type", func(t *testing.T) {
-		knownProviders := []string{"google", "anthropic", "openai", "xai"}
+		knownProviders := []string{"google", "anthropic", "openai", "xai", "openrouter"}
 		for _, provider := range knownProviders {
 			t.Run(provider, func(t *testing.T) {
 				t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })

--- a/internal/controller/claw_providers_test.go
+++ b/internal/controller/claw_providers_test.go
@@ -145,6 +145,7 @@ func TestBuildProviderEntry(t *testing.T) {
 		{name: "openai-codex uses Codex responses API", provider: "openai-codex", wantAPI: "openai-codex-responses"},
 		{name: "openai uses OpenClaw default wire format", provider: "openai", wantAPI: ""},
 		{name: "xai uses OpenAI Responses API", provider: "xai", wantAPI: "openai-responses"},
+		{name: "openrouter uses OpenClaw default wire format", provider: "openrouter", wantAPI: ""},
 		{name: "unknown provider uses OpenClaw default", provider: "custom-llm", wantAPI: ""},
 	}
 


### PR DESCRIPTION
- Include openrouter in CEL acceptance test for known providers
- Add buildProviderEntry case verifying default wire format
- Test three-segment model catalog keys (openrouter/openai/gpt-5.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for openrouter provider model catalog functionality
  * Extended credential validation tests to include openrouter provider
  * Verified openrouter provider compatibility with default wire format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->