### PR TITLE
feat: add `idled` status value to `claw_instance_status` Prometheus metric

### DIFF
--- a/internal/controller/claw_operator_metrics.go
+++ b/internal/controller/claw_operator_metrics.go
@@ -30,9 +30,10 @@ const (
 	metricStatusReady        = "ready"
 	metricStatusProvisioning = "provisioning"
 	metricStatusFailed       = "failed"
+	metricStatusIdled        = "idled"
 )
 
-var allStatusValues = []string{metricStatusReady, metricStatusProvisioning, metricStatusFailed}
+var allStatusValues = []string{metricStatusReady, metricStatusProvisioning, metricStatusFailed, metricStatusIdled}
 
 var clawInstanceStatus = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
@@ -60,6 +61,8 @@ func conditionReasonToStatus(reason string) string {
 		return metricStatusReady
 	case clawv1alpha1.ConditionReasonValidationFailed:
 		return metricStatusFailed
+	case clawv1alpha1.ConditionReasonIdle:
+		return metricStatusIdled
 	default:
 		return metricStatusProvisioning
 	}

--- a/internal/controller/claw_operator_metrics_test.go
+++ b/internal/controller/claw_operator_metrics_test.go
@@ -55,6 +55,9 @@ func TestRecordClawMetrics(t *testing.T) {
 		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "my-claw", "namespace": "test-ns", "status": metricStatusFailed,
 		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusIdled,
+		})))
 	})
 
 	t.Run("should set provisioning=1 when condition reason is Provisioning", func(t *testing.T) {
@@ -78,6 +81,9 @@ func TestRecordClawMetrics(t *testing.T) {
 		})))
 		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "my-claw", "namespace": "test-ns", "status": metricStatusFailed,
+		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusIdled,
 		})))
 	})
 
@@ -103,6 +109,9 @@ func TestRecordClawMetrics(t *testing.T) {
 		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "my-claw", "namespace": "test-ns", "status": metricStatusFailed,
 		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusIdled,
+		})))
 	})
 
 	t.Run("should default to provisioning when no Ready condition exists", func(t *testing.T) {
@@ -122,9 +131,12 @@ func TestRecordClawMetrics(t *testing.T) {
 		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "my-claw", "namespace": "test-ns", "status": metricStatusFailed,
 		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusIdled,
+		})))
 	})
 
-	t.Run("should default to provisioning for unknown reason (e.g. Idle)", func(t *testing.T) {
+	t.Run("should set idled=1 when condition reason is Idle", func(t *testing.T) {
 		t.Cleanup(resetMetrics)
 		instance := &clawv1alpha1.Claw{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-claw", Namespace: "test-ns"},
@@ -137,8 +149,17 @@ func TestRecordClawMetrics(t *testing.T) {
 
 		recordClawMetrics(instance)
 
-		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusReady,
+		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "my-claw", "namespace": "test-ns", "status": metricStatusProvisioning,
+		})))
+		assert.Equal(t, float64(0), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusFailed,
+		})))
+		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "my-claw", "namespace": "test-ns", "status": metricStatusIdled,
 		})))
 	})
 }
@@ -156,7 +177,7 @@ func TestClearClawMetrics(t *testing.T) {
 		}
 		recordClawMetrics(instance)
 
-		assert.Equal(t, 3, testutil.CollectAndCount(clawInstanceStatus))
+		assert.Equal(t, 4, testutil.CollectAndCount(clawInstanceStatus))
 		assert.Equal(t, 1, testutil.CollectAndCount(clawInstanceInfo))
 
 		clearClawMetrics("my-claw", "test-ns")
@@ -186,12 +207,12 @@ func TestClearClawMetrics(t *testing.T) {
 		recordClawMetrics(instance1)
 		recordClawMetrics(instance2)
 
-		assert.Equal(t, 6, testutil.CollectAndCount(clawInstanceStatus))
+		assert.Equal(t, 8, testutil.CollectAndCount(clawInstanceStatus))
 		assert.Equal(t, 2, testutil.CollectAndCount(clawInstanceInfo))
 
 		clearClawMetrics("claw-1", "ns-1")
 
-		assert.Equal(t, 3, testutil.CollectAndCount(clawInstanceStatus))
+		assert.Equal(t, 4, testutil.CollectAndCount(clawInstanceStatus))
 		assert.Equal(t, 1, testutil.CollectAndCount(clawInstanceInfo))
 		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
 			"name": "claw-2", "namespace": "ns-2", "status": metricStatusProvisioning,
@@ -295,7 +316,7 @@ func TestConditionReasonToStatus(t *testing.T) {
 		{clawv1alpha1.ConditionReasonReady, metricStatusReady},
 		{clawv1alpha1.ConditionReasonProvisioning, metricStatusProvisioning},
 		{clawv1alpha1.ConditionReasonValidationFailed, metricStatusFailed},
-		{clawv1alpha1.ConditionReasonIdle, metricStatusProvisioning},
+		{clawv1alpha1.ConditionReasonIdle, metricStatusIdled},
 		{"UnknownReason", metricStatusProvisioning},
 		{"", metricStatusProvisioning},
 	}

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/design.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The `claw_instance_status` Prometheus gauge currently maps condition reasons to three status values: `ready`, `provisioning`, `failed`. When an instance is idled (`spec.idle=true`), the Ready condition reason is set to `Idle`, which falls through the default case in `conditionReasonToStatus()` and reports as `provisioning`. This misrepresents the instance state.
+
+The idle code path already calls `recordClawMetrics()` after setting conditions, so the metric update pipeline is in place -- only the mapping function needs to change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accurately represent idled instances in the `claw_instance_status` metric with a distinct `status="idled"` value.
+- Maintain backward compatibility for the three existing status values.
+
+**Non-Goals:**
+- Changing the `claw_instance_info` metric (it already tracks idle state via the `idle` label).
+- Adding new metrics or new label dimensions.
+- Changing the idle/unidle reconciliation logic.
+
+## Decisions
+
+**Use `"idled"` as the status value (not `"idle"`).**
+The existing status values use adjective/past-participle forms describing a state the instance is *in*: `ready`, `failed`. `"idled"` follows this convention -- the instance *has been idled*. This also avoids collision with the `idle` label on `claw_instance_info`.
+
+**Add an explicit case to `conditionReasonToStatus()` rather than changing the default.**
+The default → `provisioning` fallback is a safe catch-all for genuinely unknown reasons. Adding an explicit `ConditionReasonIdle` case keeps the default as a safety net.
+
+## Risks / Trade-offs
+
+**Existing dashboards/alerts may not expect a fourth status value.** → This is a minor observability concern. The `"idled"` value only appears when instances are explicitly idled, which is an operator-initiated action. Document the new value in the PR description.

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/proposal.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When a Claw instance is idled (`spec.idle=true`), the `claw_instance_status` metric currently reports `status="provisioning"` because the `ConditionReasonIdle` falls through to the default case in `conditionReasonToStatus()`. This is misleading -- an idled instance is not provisioning. Adding a dedicated `"idled"` value to the `status` label lets operators distinguish idle instances from genuinely provisioning ones in dashboards and alerts.
+
+## What Changes
+
+- Add `"idled"` as a fourth possible value for the `status` label on the `claw_instance_status` gauge.
+- Map `ConditionReasonIdle` to `status="idled"` in the `conditionReasonToStatus()` function instead of falling through to the default `"provisioning"`.
+- Update unit tests and e2e tests to verify the new status value.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `operator-prometheus-metrics`: The `status` label on `claw_instance_status` gains a fourth value `"idled"` when the instance is idle. The existing three values are unchanged.
+
+## Impact
+
+- **Code**: `internal/controller/claw_operator_metrics.go` (new constant, updated switch), `internal/controller/claw_operator_metrics_test.go` (updated tests), `test/e2e/e2e_test.go` (idle metric assertion).
+- **Observability**: Existing Prometheus queries or alerts that assume exactly three status values may need updating (e.g., `sum by (status)` will now include `"idled"`).
+- **APIs/Dependencies**: No API or dependency changes.

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/specs/operator-prometheus-metrics/spec.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/specs/operator-prometheus-metrics/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Operator exposes claw_instance_status gauge
+The operator SHALL expose a Prometheus gauge vector named `claw_instance_status` with label `status`. The `status` label SHALL have exactly four possible values: `ready`, `provisioning`, `failed`, `idled`.
+
+#### Scenario: Instance is ready
+- **WHEN** a Claw instance has Ready condition with reason=Ready
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `1`
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
+
+#### Scenario: Instance is provisioning
+- **WHEN** a Claw instance has Ready condition with reason=Provisioning
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `1`
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
+
+#### Scenario: Instance has failed
+- **WHEN** a Claw instance has Ready condition with reason=ValidationFailed
+- **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `1`
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
+
+#### Scenario: Instance has no Ready condition yet
+- **WHEN** a Claw instance has no Ready condition set (e.g. first reconcile)
+- **THEN** the metric SHALL default to `status="provisioning"` with value `1`
+
+#### Scenario: Instance is idled
+- **WHEN** a Claw instance has Ready condition with reason=Idle
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `1`
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
+
+### Requirement: Unit tests cover metric logic
+The operator SHALL have unit tests for the metric update and cleanup functions.
+
+#### Scenario: Test status metric for each reason
+- **WHEN** `recordClawMetrics()` is called with a Claw instance whose Ready condition reason is Ready, Provisioning, ValidationFailed, or Idle
+- **THEN** the corresponding status gauge SHALL be `1` and the others SHALL be `0`
+
+#### Scenario: Test conditionReasonToStatus maps Idle to idled
+- **WHEN** `conditionReasonToStatus()` is called with `ConditionReasonIdle`
+- **THEN** it SHALL return `"idled"`
+
+#### Scenario: Test cleanup removes series
+- **WHEN** `clearClawMetrics()` is called
+- **THEN** all series SHALL be removed from both gauge vectors
+
+#### Scenario: Test info metric label values
+- **WHEN** `recordClawMetrics()` is called with a Claw instance
+- **THEN** the info gauge labels SHALL match the instance's spec values

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/tasks.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-idled-status/tasks.md
@@ -1,0 +1,15 @@
+## 1. Metric mapping
+
+- [x] 1.1 Add `metricStatusIdled = "idled"` constant in `internal/controller/claw_operator_metrics.go`
+- [x] 1.2 Add `case clawv1alpha1.ConditionReasonIdle: return metricStatusIdled` to `conditionReasonToStatus()`
+- [x] 1.3 Add the `metricStatusIdled` gauge set/reset in `recordClawMetrics()` alongside the existing three statuses
+
+## 2. Unit tests
+
+- [x] 2.1 Update `TestConditionReasonToStatus` table to expect `"idled"` for `ConditionReasonIdle` (instead of `"provisioning"`)
+- [x] 2.2 Add a `TestRecordClawMetrics` subtest for idled instances: Ready condition with reason=Idle should produce `status="idled"` = 1 and all others = 0
+- [x] 2.3 Run `make test` and verify all tests pass
+
+## 3. E2E tests
+
+- [x] 3.1 Add metric assertions in the idle e2e test: after idling, verify `claw_instance_status{status="idled"}` = 1 and `status="ready"` = 0

--- a/openspec/specs/operator-prometheus-metrics/spec.md
+++ b/openspec/specs/operator-prometheus-metrics/spec.md
@@ -1,29 +1,39 @@
 ## ADDED Requirements
 
 ### Requirement: Operator exposes claw_instance_status gauge
-The operator SHALL expose a Prometheus gauge vector named `claw_instance_status` with label `status`. The `status` label SHALL have exactly three possible values: `ready`, `provisioning`, `failed`.
+The operator SHALL expose a Prometheus gauge vector named `claw_instance_status` with label `status`. The `status` label SHALL have exactly four possible values: `ready`, `provisioning`, `failed`, `idled`.
 
 #### Scenario: Instance is ready
 - **WHEN** a Claw instance has Ready condition with reason=Ready
 - **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `1`
 - **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
 - **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
 
 #### Scenario: Instance is provisioning
 - **WHEN** a Claw instance has Ready condition with reason=Provisioning
 - **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `1`
 - **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
 - **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
 
 #### Scenario: Instance has failed
 - **WHEN** a Claw instance has Ready condition with reason=ValidationFailed
 - **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `1`
 - **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
 - **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `0`
 
 #### Scenario: Instance has no Ready condition yet
 - **WHEN** a Claw instance has no Ready condition set (e.g. first reconcile)
 - **THEN** the metric SHALL default to `status="provisioning"` with value `1`
+
+#### Scenario: Instance is idled
+- **WHEN** a Claw instance has Ready condition with reason=Idle
+- **THEN** the metric `claw_instance_status{status="idled"}` SHALL be `1`
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0`
+- **THEN** the metric `claw_instance_status{status="failed"}` SHALL be `0`
 
 ### Requirement: Operator exposes claw_instance_info gauge
 The operator SHALL expose a Prometheus gauge vector named `claw_instance_info` with labels `auth_mode` and `idle`. The value SHALL always be `1` for each reconciled instance.
@@ -87,8 +97,12 @@ The operator SHALL register both gauge vectors on the controller-runtime metrics
 The operator SHALL have unit tests for the metric update and cleanup functions.
 
 #### Scenario: Test status metric for each reason
-- **WHEN** `recordClawMetrics()` is called with a Claw instance whose Ready condition reason is Ready, Provisioning, or ValidationFailed
+- **WHEN** `recordClawMetrics()` is called with a Claw instance whose Ready condition reason is Ready, Provisioning, ValidationFailed, or Idle
 - **THEN** the corresponding status gauge SHALL be `1` and the others SHALL be `0`
+
+#### Scenario: Test conditionReasonToStatus maps Idle to idled
+- **WHEN** `conditionReasonToStatus()` is called with `ConditionReasonIdle`
+- **THEN** it SHALL return `"idled"`
 
 #### Scenario: Test cleanup removes series
 - **WHEN** `clearClawMetrics()` is called

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -360,6 +360,7 @@ func TestManager(t *testing.T) { //nolint:gocyclo
 			assert.Contains(t, metricsOutput, `claw_instance_status{name="instance",namespace="default",status="ready"} 1`)
 			assert.Contains(t, metricsOutput, `claw_instance_status{name="instance",namespace="default",status="provisioning"} 0`)
 			assert.Contains(t, metricsOutput, `claw_instance_status{name="instance",namespace="default",status="failed"} 0`)
+			assert.Contains(t, metricsOutput, `claw_instance_status{name="instance",namespace="default",status="idled"} 0`)
 
 			t.Log("verifying claw_instance_info metric")
 			assert.Contains(t, metricsOutput, `claw_instance_info{auth_mode="token",idle="false",name="instance",namespace="default"} 1`)
@@ -1098,6 +1099,13 @@ spec:
 					return err == nil && (output == "[]" || output == ""), nil
 				})
 			require.NoError(t, err, "Pods should be terminated after idling")
+
+			t.Log("verifying claw_instance_status metric for idled instance")
+			idleMetrics := fetchFreshMetrics(t, "curl-metrics-idle")
+			assert.Contains(t, idleMetrics, `claw_instance_status{name="instance",namespace="default",status="idled"} 1`)
+			assert.Contains(t, idleMetrics, `claw_instance_status{name="instance",namespace="default",status="ready"} 0`)
+			assert.Contains(t, idleMetrics, `claw_instance_status{name="instance",namespace="default",status="provisioning"} 0`)
+			assert.Contains(t, idleMetrics, `claw_instance_status{name="instance",namespace="default",status="failed"} 0`)
 
 			t.Log("unidling the instance")
 			cmd = exec.Command("kubectl", "patch", "claw", "instance",


### PR DESCRIPTION
Map `ConditionReasonIdle` to a dedicated `status="idled"` label value in
`conditionReasonToStatus()` instead of falling through to `"provisioning"`.
This lets operators distinguish idle instances from genuinely provisioning
ones in dashboards and alerts.

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "idled" status value to Prometheus instance status metrics to enable better visibility and distinction between idle and provisioning instance states

* **Bug Fixes**
  * Corrected instance status metric reporting to properly reflect idle instances with the new "idled" status value instead of incorrectly defaulting to "provisioning"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->