### PR TITLE
feat: refresh Prometheus gauge metrics on operator startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -263,6 +263,7 @@ func main() {
 		KubectlImage:       os.Getenv("KUBECTL_IMAGE"),
 		OTelCollectorImage: os.Getenv("OTEL_COLLECTOR_IMAGE"),
 		ImagePullPolicy:    imagePullPolicy,
+		MetricsRefreshed:   make(chan struct{}),
 	}
 	if err = clawReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Claw")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -255,7 +255,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.ClawResourceReconciler{
+	clawReconciler := &controller.ClawResourceReconciler{
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		UserSecretReader:   controller.NewLoggingUserSecretReader(mgr.GetAPIReader()),
@@ -263,8 +263,13 @@ func main() {
 		KubectlImage:       os.Getenv("KUBECTL_IMAGE"),
 		OTelCollectorImage: os.Getenv("OTEL_COLLECTOR_IMAGE"),
 		ImagePullPolicy:    imagePullPolicy,
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if err = clawReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Claw")
+		os.Exit(1)
+	}
+	if err = mgr.Add(clawReconciler); err != nil {
+		setupLog.Error(err, "unable to add metrics refresh runnable")
 		os.Exit(1)
 	}
 	pairingClientset, err := kubernetes.NewForConfig(mgr.GetConfig())

--- a/internal/controller/claw_operator_metrics.go
+++ b/internal/controller/claw_operator_metrics.go
@@ -17,10 +17,13 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
@@ -102,6 +105,19 @@ func recordClawMetrics(instance *clawv1alpha1.Claw) {
 		authMode,
 		strconv.FormatBool(instance.Spec.Idle),
 	).Set(1)
+}
+
+func refreshClawMetrics(ctx context.Context, c client.Client) error {
+	logger := log.FromContext(ctx)
+	var list clawv1alpha1.ClawList
+	if err := c.List(ctx, &list); err != nil {
+		return err
+	}
+	logger.Info("refreshing Claw metrics on startup", "count", len(list.Items))
+	for i := range list.Items {
+		recordClawMetrics(&list.Items[i])
+	}
+	return nil
 }
 
 func clearClawMetrics(name, namespace string) {

--- a/internal/controller/claw_operator_metrics_test.go
+++ b/internal/controller/claw_operator_metrics_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
@@ -326,4 +330,101 @@ func TestConditionReasonToStatus(t *testing.T) {
 			assert.Equal(t, tt.expected, conditionReasonToStatus(tt.reason))
 		})
 	}
+}
+
+func TestRefreshClawMetrics(t *testing.T) {
+	t.Run("should populate metrics for multiple instances in different states and namespaces", func(t *testing.T) {
+		t.Cleanup(resetMetrics)
+		testCtx := context.Background()
+
+		ns1 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "metrics-refresh-ns1"}}
+		ns2 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "metrics-refresh-ns2"}}
+		require.NoError(t, k8sClient.Create(testCtx, ns1))
+		require.NoError(t, k8sClient.Create(testCtx, ns2))
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(testCtx, ns1)
+			_ = k8sClient.Delete(testCtx, ns2)
+		})
+
+		instances := []*clawv1alpha1.Claw{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "claw-ready", Namespace: ns1.Name},
+				Spec:       clawv1alpha1.ClawSpec{},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "claw-failed", Namespace: ns1.Name},
+				Spec:       clawv1alpha1.ClawSpec{},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "claw-idled", Namespace: ns2.Name},
+				Spec:       clawv1alpha1.ClawSpec{Idle: true},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "claw-provisioning", Namespace: ns2.Name},
+				Spec:       clawv1alpha1.ClawSpec{},
+			},
+		}
+		for _, inst := range instances {
+			require.NoError(t, k8sClient.Create(testCtx, inst))
+		}
+		t.Cleanup(func() {
+			for _, inst := range instances {
+				_ = k8sClient.Delete(testCtx, inst)
+			}
+		})
+
+		// Set status conditions on the created resources
+		statusUpdates := []struct {
+			name, namespace, reason string
+			condStatus              metav1.ConditionStatus
+		}{
+			{"claw-ready", ns1.Name, clawv1alpha1.ConditionReasonReady, metav1.ConditionTrue},
+			{"claw-failed", ns1.Name, clawv1alpha1.ConditionReasonValidationFailed, metav1.ConditionFalse},
+			{"claw-idled", ns2.Name, clawv1alpha1.ConditionReasonIdle, metav1.ConditionFalse},
+			// claw-provisioning: no condition set — should default to provisioning
+		}
+		for _, su := range statusUpdates {
+			inst := &clawv1alpha1.Claw{}
+			require.NoError(t, k8sClient.Get(testCtx, client.ObjectKey{Name: su.name, Namespace: su.namespace}, inst))
+			inst.Status.Conditions = []metav1.Condition{
+				{Type: clawv1alpha1.ConditionTypeReady, Status: su.condStatus, Reason: su.reason, LastTransitionTime: metav1.Now()},
+			}
+			require.NoError(t, k8sClient.Status().Update(testCtx, inst))
+		}
+
+		require.NoError(t, refreshClawMetrics(testCtx, k8sClient))
+
+		// 4 instances * 4 status values = 16 status series + 4 info series
+		assert.Equal(t, 16, testutil.CollectAndCount(clawInstanceStatus))
+		assert.Equal(t, 4, testutil.CollectAndCount(clawInstanceInfo))
+
+		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "claw-ready", "namespace": ns1.Name, "status": metricStatusReady,
+		})))
+		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "claw-failed", "namespace": ns1.Name, "status": metricStatusFailed,
+		})))
+		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "claw-idled", "namespace": ns2.Name, "status": metricStatusIdled,
+		})))
+		assert.Equal(t, float64(1), testutil.ToFloat64(clawInstanceStatus.With(prometheus.Labels{
+			"name": "claw-provisioning", "namespace": ns2.Name, "status": metricStatusProvisioning,
+		})))
+	})
+
+	t.Run("should not set any metrics when no Claw instances exist", func(t *testing.T) {
+		t.Cleanup(resetMetrics)
+		testCtx := context.Background()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "metrics-refresh-empty"}}
+		require.NoError(t, k8sClient.Create(testCtx, ns))
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(testCtx, ns)
+		})
+
+		require.NoError(t, refreshClawMetrics(testCtx, k8sClient))
+
+		assert.Equal(t, 0, testutil.CollectAndCount(clawInstanceStatus))
+		assert.Equal(t, 0, testutil.CollectAndCount(clawInstanceInfo))
+	})
 }

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -393,6 +393,9 @@ type ClawResourceReconciler struct {
 	KubectlImage       string
 	OTelCollectorImage string
 	ImagePullPolicy    string
+	// MetricsRefreshed is closed by Start() after the initial metrics refresh.
+	// Reconcile() waits on it so no reconciliation runs before metrics are populated.
+	MetricsRefreshed chan struct{}
 }
 
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;delete
@@ -414,6 +417,13 @@ type ClawResourceReconciler struct {
 
 // Reconcile manages the complete lifecycle of resources for Claw instances
 func (r *ClawResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocyclo
+	if r.MetricsRefreshed != nil {
+		select {
+		case <-r.MetricsRefreshed:
+		case <-ctx.Done():
+			return ctrl.Result{}, ctx.Err()
+		}
+	}
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling Claw", "name", req.Name, "namespace", req.Namespace)
 
@@ -1474,6 +1484,7 @@ func parseYAMLToObjects(yamlData []byte) ([]*unstructured.Unstructured, error) {
 // mgr.Add(). It refreshes Prometheus gauge metrics for all existing Claw
 // resources, ensuring they are populated immediately after a restart.
 func (r *ClawResourceReconciler) Start(ctx context.Context) error {
+	defer close(r.MetricsRefreshed)
 	logger := log.FromContext(ctx).WithName("claw-metrics-refresh")
 	if err := refreshClawMetrics(log.IntoContext(ctx, logger), r.Client); err != nil {
 		logger.Error(err, "failed to refresh Claw metrics on startup")

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -1470,6 +1470,17 @@ func parseYAMLToObjects(yamlData []byte) ([]*unstructured.Unstructured, error) {
 	return objects, nil
 }
 
+// Start implements manager.Runnable so the reconciler can be registered with
+// mgr.Add(). It refreshes Prometheus gauge metrics for all existing Claw
+// resources, ensuring they are populated immediately after a restart.
+func (r *ClawResourceReconciler) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("claw-metrics-refresh")
+	if err := refreshClawMetrics(log.IntoContext(ctx, logger), r.Client); err != nil {
+		logger.Error(err, "failed to refresh Claw metrics on startup")
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClawResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/design.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Prometheus gauge metrics (`claw_instance_status`, `claw_instance_info`) are stored in-memory and lost on operator restart. Currently, they are only repopulated when individual Claw resources are reconciled due to change events. This leaves a gap where dashboards and alerts have no data for existing instances.
+
+The operator already has `recordClawMetrics()` which correctly sets gauges from a Claw instance's status and spec. The missing piece is a startup routine that lists all existing Claw resources and calls this function for each.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Populate all Claw gauge metrics immediately on operator startup
+- Reuse existing `recordClawMetrics()` — no metric logic duplication
+- Follow controller-runtime lifecycle patterns
+
+**Non-Goals:**
+- Changing metric definitions or label sets
+- Adding new metrics
+- Handling metric persistence across restarts (gauges are inherently in-memory)
+
+## Decisions
+
+### Use `mgr.Add(Runnable)` for startup refresh
+
+Add a `Runnable` to the controller manager that lists all Claw resources and records their metrics. Controller-runtime runs runnables after cache sync and leader election, so the client is ready and the list call uses the informer cache (no extra API server load).
+
+**Alternative considered:** Trigger a full reconcile for all Claw resources at startup. Rejected because it would run the entire three-phase reconciliation (including server-side apply of all resources) when we only need to read status and record metrics. Heavy and unnecessary.
+
+**Alternative considered:** Add a one-time check inside `Reconcile()`. Rejected because reconcile is event-driven — if no events fire, metrics stay empty. Also adds branching complexity to the hot path.
+
+### Implement as a method on `ClawResourceReconciler`
+
+The reconciler already holds the `Client` needed to list Claw resources. Add a `RefreshMetrics(ctx)` method and a `Start(ctx)` method implementing `Runnable`. Register it with `mgr.Add(reconciler)` in `cmd/main.go`.
+
+This keeps the metrics refresh logic co-located with the reconciler and avoids creating a separate struct.
+
+### Log but don't fail on list errors
+
+If the list call fails (e.g., CRD not installed), log a warning and return without error. The operator should still start — metrics will be populated on the first reconcile of each instance. This is a best-effort refresh, not a hard dependency.
+
+## Risks / Trade-offs
+
+- **[Small startup delay]** Listing all Claw resources adds a small delay to startup. Mitigated by using the informer cache (already synced). For typical deployments (< 100 instances), this is negligible.
+- **[Race with first reconciles]** A reconcile event could fire concurrently with the startup refresh. `recordClawMetrics()` is idempotent (sets absolute gauge values, not increments), so concurrent calls produce correct results.

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/proposal.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+When the operator restarts, in-memory Prometheus gauge metrics (`claw_instance_status`, `claw_instance_info`) are lost. They only get repopulated when each Claw resource happens to be reconciled due to a change event. This creates an observability gap where Prometheus dashboards and alerts show no data for existing Claw instances until something triggers their reconciliation.
+
+## What Changes
+
+- Add a startup routine that lists all existing Claw resources and records their metrics before the controller starts processing events
+- This ensures the `/metrics` endpoint immediately reflects the correct state of all Claw instances after an operator restart
+
+## Capabilities
+
+### New Capabilities
+
+- `metrics-startup-refresh`: On operator startup, list all existing Claw resources and populate gauge metrics so they are available immediately on the `/metrics` endpoint
+
+### Modified Capabilities
+
+- `operator-prometheus-metrics`: Add requirement that metrics are restored on operator startup, not only during reconciliation
+
+## Impact
+
+- `internal/controller/claw_operator_metrics.go` — add startup refresh function that lists Claw resources and calls `recordClawMetrics()` for each
+- `internal/controller/claw_resource_controller.go` or `cmd/main.go` — wire the startup routine into the manager lifecycle
+- No API changes, no CRD changes, no breaking changes

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/specs/metrics-startup-refresh/spec.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/specs/metrics-startup-refresh/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Metrics refreshed on operator startup
+The operator SHALL list all existing Claw resources on startup and populate gauge metrics (`claw_instance_status`, `claw_instance_info`) for each instance before the controller begins processing reconcile events.
+
+#### Scenario: Metrics restored after restart with existing instances
+- **WHEN** the operator starts and there are existing Claw resources in the cluster
+- **THEN** the `/metrics` endpoint SHALL return correct `claw_instance_status` and `claw_instance_info` series for all existing instances
+
+#### Scenario: Metrics reflect current status after restart
+- **WHEN** the operator restarts and a Claw instance has Ready condition with reason=Ready
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `1` for that instance
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0` for that instance
+
+#### Scenario: Multiple instances across namespaces
+- **WHEN** the operator starts with Claw instances in different namespaces
+- **THEN** metrics SHALL be populated for all instances across all namespaces
+
+#### Scenario: No Claw resources exist
+- **WHEN** the operator starts and there are no Claw resources in the cluster
+- **THEN** no metric series SHALL be created
+- **THEN** the operator SHALL start normally
+
+### Requirement: Startup refresh is best-effort
+The operator SHALL NOT fail to start if the metric refresh encounters an error (e.g., CRD not installed). The error SHALL be logged as a warning.
+
+#### Scenario: CRD not installed
+- **WHEN** the operator starts and the Claw CRD is not installed
+- **THEN** the operator SHALL log a warning
+- **THEN** the operator SHALL continue starting normally
+
+### Requirement: Startup refresh uses controller-runtime Runnable
+The operator SHALL implement the startup metric refresh as a `Runnable` registered with the controller manager, ensuring it runs after cache sync and leader election.
+
+#### Scenario: Runs after cache sync
+- **WHEN** the operator starts and the manager cache is synced
+- **THEN** the metric refresh SHALL execute using the cached client (no direct API server calls)
+
+### Requirement: Unit tests cover startup refresh
+The operator SHALL have unit tests verifying that the startup refresh correctly populates metrics for existing Claw resources.
+
+#### Scenario: Test refresh with multiple instances
+- **WHEN** `RefreshMetrics()` is called with existing Claw resources in different states
+- **THEN** each instance's metrics SHALL be correctly populated
+
+#### Scenario: Test refresh with no instances
+- **WHEN** `RefreshMetrics()` is called with no existing Claw resources
+- **THEN** no metrics SHALL be set
+- **THEN** no error SHALL be returned

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/specs/operator-prometheus-metrics/spec.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/specs/operator-prometheus-metrics/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Metrics updated in updateStatus path
+The operator SHALL update both `claw_instance_status` and `claw_instance_info` metrics every time `updateStatus()` is called during reconciliation, after the Ready condition is computed. The operator SHALL also populate these metrics for all existing Claw resources on startup.
+
+#### Scenario: Metrics consistent with condition
+- **WHEN** `updateStatus()` sets the Ready condition to reason=Ready
+- **THEN** the `claw_instance_status` metric SHALL reflect `status="ready"` before the status subresource write completes
+
+#### Scenario: Metrics updated on every reconcile
+- **WHEN** the reconciler runs and calls `updateStatus()`
+- **THEN** the metrics SHALL be updated regardless of whether the Ready condition changed
+
+#### Scenario: Metrics populated on startup
+- **WHEN** the operator starts with existing Claw resources
+- **THEN** all metrics SHALL be populated from the current status of each Claw resource before the first reconcile event is processed

--- a/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/tasks.md
+++ b/openspec/changes/archive/2026-06-08-prometheus-metric-refresh-startup/tasks.md
@@ -1,0 +1,13 @@
+## 1. Core Implementation
+
+- [x] 1.1 Add `RefreshMetrics(ctx context.Context) error` method to `ClawResourceReconciler` that lists all Claw resources across all namespaces and calls `recordClawMetrics()` for each instance
+- [x] 1.2 Add `Start(ctx context.Context) error` method to `ClawResourceReconciler` implementing the `Runnable` interface, which calls `RefreshMetrics()` and logs a warning on error instead of returning it
+
+## 2. Wiring
+
+- [x] 2.1 Register the reconciler as a `Runnable` via `mgr.Add(reconciler)` in `cmd/main.go` after `SetupWithManager`
+
+## 3. Tests
+
+- [x] 3.1 Add unit test for `RefreshMetrics()` with multiple Claw instances in different states (ready, provisioning, failed, idled) across different namespaces — verify all metrics are correctly populated
+- [x] 3.2 Add unit test for `RefreshMetrics()` with no Claw instances — verify no metrics are set and no error is returned

--- a/openspec/specs/metrics-startup-refresh/spec.md
+++ b/openspec/specs/metrics-startup-refresh/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Metrics refreshed on operator startup
+The operator SHALL list all existing Claw resources on startup and populate gauge metrics (`claw_instance_status`, `claw_instance_info`) for each instance before the controller begins processing reconcile events.
+
+#### Scenario: Metrics restored after restart with existing instances
+- **WHEN** the operator starts and there are existing Claw resources in the cluster
+- **THEN** the `/metrics` endpoint SHALL return correct `claw_instance_status` and `claw_instance_info` series for all existing instances
+
+#### Scenario: Metrics reflect current status after restart
+- **WHEN** the operator restarts and a Claw instance has Ready condition with reason=Ready
+- **THEN** the metric `claw_instance_status{status="ready"}` SHALL be `1` for that instance
+- **THEN** the metric `claw_instance_status{status="provisioning"}` SHALL be `0` for that instance
+
+#### Scenario: Multiple instances across namespaces
+- **WHEN** the operator starts with Claw instances in different namespaces
+- **THEN** metrics SHALL be populated for all instances across all namespaces
+
+#### Scenario: No Claw resources exist
+- **WHEN** the operator starts and there are no Claw resources in the cluster
+- **THEN** no metric series SHALL be created
+- **THEN** the operator SHALL start normally
+
+### Requirement: Startup refresh is best-effort
+The operator SHALL NOT fail to start if the metric refresh encounters an error (e.g., CRD not installed). The error SHALL be logged as a warning.
+
+#### Scenario: CRD not installed
+- **WHEN** the operator starts and the Claw CRD is not installed
+- **THEN** the operator SHALL log a warning
+- **THEN** the operator SHALL continue starting normally
+
+### Requirement: Startup refresh uses controller-runtime Runnable
+The operator SHALL implement the startup metric refresh as a `Runnable` registered with the controller manager, ensuring it runs after cache sync and leader election.
+
+#### Scenario: Runs after cache sync
+- **WHEN** the operator starts and the manager cache is synced
+- **THEN** the metric refresh SHALL execute using the cached client (no direct API server calls)
+
+### Requirement: Unit tests cover startup refresh
+The operator SHALL have unit tests verifying that the startup refresh correctly populates metrics for existing Claw resources.
+
+#### Scenario: Test refresh with multiple instances
+- **WHEN** `RefreshMetrics()` is called with existing Claw resources in different states
+- **THEN** each instance's metrics SHALL be correctly populated
+
+#### Scenario: Test refresh with no instances
+- **WHEN** `RefreshMetrics()` is called with no existing Claw resources
+- **THEN** no metrics SHALL be set
+- **THEN** no error SHALL be returned

--- a/openspec/specs/metrics-startup-refresh/spec.md
+++ b/openspec/specs/metrics-startup-refresh/spec.md
@@ -36,6 +36,21 @@ The operator SHALL implement the startup metric refresh as a `Runnable` register
 - **WHEN** the operator starts and the manager cache is synced
 - **THEN** the metric refresh SHALL execute using the cached client (no direct API server calls)
 
+### Requirement: Reconciliation blocked until metrics refresh completes
+The controller SHALL NOT process any reconcile events until the startup metric refresh has completed. This ensures no mismatch or double-counting between the refresh and normal reconciliation.
+
+#### Scenario: Reconcile waits for refresh
+- **WHEN** a reconcile event is triggered before the metric refresh has completed
+- **THEN** the reconciler SHALL block until the refresh finishes before proceeding
+
+#### Scenario: Reconcile proceeds after refresh
+- **WHEN** the metric refresh has completed
+- **THEN** subsequent reconcile events SHALL proceed without delay
+
+#### Scenario: Context cancelled while waiting
+- **WHEN** a reconcile event is waiting for the metric refresh and the context is cancelled
+- **THEN** the reconciler SHALL return the context error immediately
+
 ### Requirement: Unit tests cover startup refresh
 The operator SHALL have unit tests verifying that the startup refresh correctly populates metrics for existing Claw resources.
 

--- a/openspec/specs/operator-prometheus-metrics/spec.md
+++ b/openspec/specs/operator-prometheus-metrics/spec.md
@@ -56,7 +56,7 @@ The operator SHALL expose a Prometheus gauge vector named `claw_instance_info` w
 - **THEN** a new series with `idle="true"` SHALL be set to `1`
 
 ### Requirement: Metrics updated in updateStatus path
-The operator SHALL update both `claw_instance_status` and `claw_instance_info` metrics every time `updateStatus()` is called during reconciliation, after the Ready condition is computed.
+The operator SHALL update both `claw_instance_status` and `claw_instance_info` metrics every time `updateStatus()` is called during reconciliation, after the Ready condition is computed. The operator SHALL also populate these metrics for all existing Claw resources on startup.
 
 #### Scenario: Metrics consistent with condition
 - **WHEN** `updateStatus()` sets the Ready condition to reason=Ready
@@ -65,6 +65,10 @@ The operator SHALL update both `claw_instance_status` and `claw_instance_info` m
 #### Scenario: Metrics updated on every reconcile
 - **WHEN** the reconciler runs and calls `updateStatus()`
 - **THEN** the metrics SHALL be updated regardless of whether the Ready condition changed
+
+#### Scenario: Metrics populated on startup
+- **WHEN** the operator starts with existing Claw resources
+- **THEN** all metrics SHALL be populated from the current status of each Claw resource before the first reconcile event is processed
 
 ### Requirement: Metrics cleaned up on Claw deletion
 The operator SHALL reset all metric series when a Claw instance is deleted.


### PR DESCRIPTION
When the operator restarts, in-memory gauge metrics (`claw_instance_status`,
`claw_instance_info`) are lost and only repopulated when individual Claw
resources are reconciled. This adds a `Start()` method on the reconciler
implementing `manager.Runnable`, which lists all existing Claw resources
and calls `refreshClawMetrics()` to restore their metrics immediately.

The reconciler is registered via `mgr.Add()` in `cmd/main.go`, so the
refresh runs after cache sync and leader election. Errors are logged but
do not block startup.

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator now performs a startup refresh of Prometheus metrics and delays reconcile processing until in-memory metrics are populated, so /metrics and dashboards reflect current Claw instance status immediately after restart.

* **Tests**
  * Added integration tests that verify metric population across multiple instances, namespaces, and the no-instances case.

* **Documentation**
  * Added design, proposal, spec and task docs describing the startup metric-refresh behavior and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->