### PR TITLE
Update to 2026.6.5

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.6.1
+    newTag: 2026.6.5

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -31,7 +31,7 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
-const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.6.1"
+const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.6.5"
 
 func makeTestDeploymentForPlugins() []*unstructured.Unstructured {
 	dep := &unstructured.Unstructured{}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCLAW image to version 2026.6.5.

* **Tests**
  * Updated test references for the new image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->