### PR TITLE
Set UID for init-kubectl container

### DIFF
--- a/internal/controller/claw_deployment.go
+++ b/internal/controller/claw_deployment.go
@@ -309,6 +309,7 @@ func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, 
 			"command":         []any{"sh", "-c", "cp /usr/bin/oc /usr/bin/kubectl /tools/"},
 			"securityContext": map[string]any{
 				"runAsNonRoot":             true,
+				"runAsUser":                int64(65532),
 				"allowPrivilegeEscalation": false,
 				"readOnlyRootFilesystem":   true,
 				"capabilities":             map[string]any{"drop": []any{"ALL"}},


### PR DESCRIPTION
The new daily-e2e jobs I introduced were failing (eg. https://github.com/codeready-toolchain/claw-operator/actions/runs/27402421765/job/80983363837) and it seems to be an issue with the securityContext.

It could be related to the daily-e2e job pinning the kind version to v0.32.0 while the test-e2e job uses the latest kind version. Maybe there's a difference in behaviour between the two. Either way, this change should hopefully avoid issues in more environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security settings for internal deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->