### PR TITLE
Revert "Use UID 65532 for init-kubectl container as is used in the ot…

### DIFF
--- a/internal/controller/claw_deployment.go
+++ b/internal/controller/claw_deployment.go
@@ -309,7 +309,6 @@ func configureClawDeploymentForKubernetes(objects []*unstructured.Unstructured, 
 			"command":         []any{"sh", "-c", "cp /usr/bin/oc /usr/bin/kubectl /tools/"},
 			"securityContext": map[string]any{
 				"runAsNonRoot":             true,
-				"runAsUser":                int64(65532),
 				"allowPrivilegeEscalation": false,
 				"readOnlyRootFilesystem":   true,
 				"capabilities":             map[string]any{"drop": []any{"ALL"}},


### PR DESCRIPTION
This reverts commit bfd5c92ddf01c0b39970c0ccad0f9a179c98b597.

It passed with kind in e2e tests but it caused an error with the claw deployment on OpenShift:

```
pods "claw-5c7c66b456-" is forbidden: unable to validate against any security context constraint: [provider "openshift-ai-llminferenceservice-multi-node-scc": Forbidden: not usable by user or serviceaccount, provider "openshift-ai-llminferenceservice-scc": Forbidden: not usable by user or serviceaccount, provider "anyuid": Forbidden: not usable by user or serviceaccount, provider "pipelines-scc": Forbidden: not usable by user or serviceaccount, provider "run-as-ray-user": Forbidden: not usable by user or serviceaccount, provider "container-run": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .initContainers[3].runAsUser: Invalid value: 65532: must be in the ranges: [1015050000, 1015059999], provider restricted-v3: .spec.securityContext.hostUsers: Invalid value: null: Host Users must be set to false, provider "restricted": Forbidden: not usable by user or serviceaccount, provider "container-build": Forbidden: not usable by user or serviceaccount, provider "nested-container": Forbidden: not usable by user or serviceaccount, provider "containerized-data-importer": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "pcap-dedicated-admins": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "logging-scc": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid-v2": Forbidden: not usable by user or serviceaccount, provider "kubevirt-controller": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "bridge-marker": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "nfd-worker": Forbidden: not usable by user or serviceaccount, provider "nfd-topology-updater": Forbidden: not usable by user or serviceaccount, provider "linux-bridge": Forbidden: not usable by user or serviceaccount, provider "passt-binding-cni": Forbidden: not usable by user or serviceaccount, provider "insights-runtime-extractor-scc": Forbidden: not usable by user or serviceaccount, provider "nvidia-driver": Forbidden: not usable by user or serviceaccount, provider "nvidia-gpu-feature-discovery": Forbidden: not usable by user or serviceaccount, provider "nvidia-mig-manager": Forbidden: not usable by user or serviceaccount, provider "nvidia-node-status-exporter": Forbidden: not usable by user or serviceaccount, provider "nvidia-operator-validator": Forbidden: not usable by user or serviceaccount, provider "splunkforwarder": Forbidden: not usable by user or serviceaccount, provider "kubevirt-handler": Forbidden: not usable by user or serviceaccount, provider "nvidia-dcgm-exporter": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "nvidia-dcgm": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes deployment security by enforcing stricter container permissions, disabling privilege escalation, and implementing read-only filesystem access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->