### PR TITLE
feat: upgrade OpenClaw to 2026.6.9

### DIFF
--- a/internal/assets/manifests/claw/kustomization.yaml
+++ b/internal/assets/manifests/claw/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: ghcr.io/openclaw/openclaw
     newName: ghcr.io/openclaw/openclaw
-    newTag: 2026.6.8
+    newTag: 2026.6.9

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -31,7 +31,7 @@ import (
 	clawv1alpha1 "github.com/codeready-toolchain/claw-operator/api/v1alpha1"
 )
 
-const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.6.8"
+const testGatewayImage = "ghcr.io/openclaw/openclaw:2026.6.9"
 
 func makeTestDeploymentForPlugins() []*unstructured.Unstructured {
 	dep := &unstructured.Unstructured{}
@@ -421,7 +421,7 @@ func TestRequiredProviderPlugins(t *testing.T) {
 		}
 		plugins := requiredProviderPlugins(instance)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.8", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.9", plugins[0])
 	})
 
 	t.Run("returns empty for google GCP credential", func(t *testing.T) {
@@ -497,7 +497,7 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins := effectivePlugins(instance)
 		assert.Contains(t, plugins, "@openclaw/matrix")
-		assert.Contains(t, plugins, "@openclaw/anthropic-vertex-provider@2026.6.8")
+		assert.Contains(t, plugins, "@openclaw/anthropic-vertex-provider@2026.6.9")
 		assert.Len(t, plugins, 2)
 	})
 
@@ -526,7 +526,7 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins := effectivePlugins(instance)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.8", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.9", plugins[0])
 	})
 }
 

--- a/internal/controller/claw_providers.go
+++ b/internal/controller/claw_providers.go
@@ -102,7 +102,7 @@ var knownProviders = map[string]providerDefaults{
 		Header:       "x-api-key",
 		API:          "anthropic-messages",
 		VertexAPI:    "anthropic-messages",
-		VertexPlugin: "@openclaw/anthropic-vertex-provider@2026.6.8",
+		VertexPlugin: "@openclaw/anthropic-vertex-provider@2026.6.9",
 		Models: []modelEntry{
 			{Name: "claude-sonnet-4-6", Alias: "Claude Sonnet 4.6"},
 			{Name: "claude-opus-4-8", Alias: "Claude Opus 4.8"},


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the OpenClaw image and Anthropic Vertex provider plugin to version **2026.6.9**.
  * Refreshed related tests to match the **2026.6.9** version expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->