### PR TITLE
fix: drop `clawhub:` prefix from plugin install commands

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -543,7 +543,7 @@ type ClawSpec struct {
 
 	// Plugins lists OpenClaw plugins to install via an init container before
 	// the gateway starts. Each entry is a package name (e.g. "@openclaw/matrix").
-	// The operator runs `openclaw plugins install clawhub:<pkg>` for each entry.
+	// The operator runs `openclaw plugins install <pkg>` for each entry.
 	// +optional
 	Plugins []string `json:"plugins,omitempty"`
 

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -748,7 +748,7 @@ spec:
                 description: |-
                   Plugins lists OpenClaw plugins to install via an init container before
                   the gateway starts. Each entry is a package name (e.g. "@openclaw/matrix").
-                  The operator runs `openclaw plugins install clawhub:<pkg>` for each entry.
+                  The operator runs `openclaw plugins install <pkg>` for each entry.
                 items:
                   type: string
                 type: array

--- a/internal/controller/claw_plugins.go
+++ b/internal/controller/claw_plugins.go
@@ -116,7 +116,7 @@ ls "$EXT" 2>/dev/null | sort > /tmp/before-plugins.txt
 `)
 	for _, pkg := range plugins {
 		escaped := "'" + strings.ReplaceAll(pkg, "'", "'\\''") + "'"
-		fmt.Fprintf(&b, "openclaw plugins install clawhub:%s\n", escaped)
+		fmt.Fprintf(&b, "openclaw plugins install %s\n", escaped)
 	}
 	b.WriteString(`ls "$EXT" | sort | comm -13 /tmp/before-plugins.txt - > "$MANIFEST"
 `)

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -116,18 +116,18 @@ func TestGeneratePluginInstallScript(t *testing.T) {
 
 	t.Run("should generate install command for single plugin", func(t *testing.T) {
 		script := generatePluginInstallScript([]string{"@openclaw/matrix"})
-		assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/matrix'")
+		assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix'")
 	})
 
 	t.Run("should generate install commands for multiple plugins", func(t *testing.T) {
 		script := generatePluginInstallScript([]string{"@openclaw/matrix", "@openclaw/diagnostics-otel"})
-		assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/matrix'")
-		assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/diagnostics-otel'")
+		assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix'")
+		assert.Contains(t, script, "openclaw plugins install '@openclaw/diagnostics-otel'")
 	})
 
 	t.Run("should escape single quotes in plugin names", func(t *testing.T) {
 		script := generatePluginInstallScript([]string{"foo'bar"})
-		assert.Contains(t, script, "openclaw plugins install clawhub:'foo'\\''bar'")
+		assert.Contains(t, script, "openclaw plugins install 'foo'\\''bar'")
 	})
 
 	t.Run("should escape shell metacharacters", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestConfigurePluginsInitContainer(t *testing.T) {
 		command := pluginInit["command"].([]any)
 		assert.Equal(t, "sh", command[0])
 		assert.Equal(t, "-c", command[1])
-		assert.Contains(t, command[2], "openclaw plugins install clawhub:'@openclaw/matrix'")
+		assert.Contains(t, command[2], "openclaw plugins install '@openclaw/matrix'")
 	})
 
 	t.Run("should set proxy environment variables", func(t *testing.T) {
@@ -338,8 +338,8 @@ func TestConfigurePluginsInitContainer(t *testing.T) {
 		command := pluginInit["command"].([]any)
 		script := command[2].(string)
 		assert.Contains(t, script, "set -e")
-		assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/matrix'")
-		assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/diagnostics-otel'")
+		assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix'")
+		assert.Contains(t, script, "openclaw plugins install '@openclaw/diagnostics-otel'")
 	})
 
 	t.Run("should include manifest-tracked cleanup in init container script", func(t *testing.T) {
@@ -625,7 +625,7 @@ func TestPluginsIntegration(t *testing.T) {
 		for _, ic := range deployment.Spec.Template.Spec.InitContainers {
 			if ic.Name == PluginsInitContainerName {
 				found = true
-				assert.Contains(t, ic.Command[2], "openclaw plugins install clawhub:'@openclaw/matrix'")
+				assert.Contains(t, ic.Command[2], "openclaw plugins install '@openclaw/matrix'")
 
 				envMap := make(map[string]string)
 				for _, e := range ic.Env {
@@ -696,8 +696,8 @@ func TestPluginsIntegration(t *testing.T) {
 		for _, ic := range deployment.Spec.Template.Spec.InitContainers {
 			if ic.Name == PluginsInitContainerName {
 				script := ic.Command[2]
-				assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/matrix'")
-				assert.Contains(t, script, "openclaw plugins install clawhub:'@openclaw/diagnostics-otel'")
+				assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix'")
+				assert.Contains(t, script, "openclaw plugins install '@openclaw/diagnostics-otel'")
 				return
 			}
 		}


### PR DESCRIPTION
The `openclaw plugins install` has issues with the `clawhub:`
registry prefix, it seems to ignore the version suffix and always
uses the latest version instead of the one specified in the plugin spec.

```
Resolving clawhub:@openclaw/anthropic-vertex-provider@2026.6.9…
Plugin "@openclaw/anthropic-vertex-provider" requires plugin API >=2026.6.10, butthis OpenClaw runtime exposes 2026.6.9.
command terminated with exit code 1
```

Remove it from the generated init container script,
update the API doc comment and CRD description, and adjust all related
tests accordingly.

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plugin installation behavior to use the plugin spec directly, improving how configured plugins are installed during startup.
  * Fixed quoting and escaping for plugin names, including names with special characters.
* **Documentation**
  * Aligned plugin installation examples and schema text with the current command format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->