### PR TITLE
Set missing env vars for gcp vertex provider configuration

### DIFF
--- a/internal/controller/claw_deployment.go
+++ b/internal/controller/claw_deployment.go
@@ -125,11 +125,84 @@ func (r *ClawResourceReconciler) applyVertexADCConfigMap(ctx context.Context, in
 	return nil
 }
 
-// configureClawDeploymentForVertex adds Vertex AI environment variables and the stub
+// isGoogleVertexCredential returns true when a credential uses Google's own Vertex AI
+// REST endpoint (provider=google, type=gcp). These credentials route through the
+// proxy for auth injection but the gateway's google-generative-ai SDK still needs
+// GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION to construct internal requests.
+func isGoogleVertexCredential(cred clawv1alpha1.CredentialSpec) bool {
+	return cred.Type == clawv1alpha1.CredentialTypeGCP && cred.Provider == "google" && cred.GCP != nil
+}
+
+// configureClawDeploymentForGCPVertex sets GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION
+// on the gateway container when a Google Vertex AI credential is present. The proxy
+// handles token injection, but the google-generative-ai SDK requires these env vars to
+// construct its internal Vertex AI requests.
+func configureClawDeploymentForGCPVertex(objects []*unstructured.Unstructured, credentials []resolvedCredential, instanceName string) error {
+	var googleCred *clawv1alpha1.CredentialSpec
+	for _, rc := range credentials {
+		if isGoogleVertexCredential(rc.CredentialSpec) {
+			googleCred = &rc.CredentialSpec
+			break
+		}
+	}
+	if googleCred == nil {
+		return nil
+	}
+
+	gatewayName := getClawDeploymentName(instanceName)
+	for _, obj := range objects {
+		if obj.GetKind() != DeploymentKind || obj.GetName() != gatewayName {
+			continue
+		}
+
+		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		if err != nil {
+			return fmt.Errorf("failed to get containers from claw deployment: %w", err)
+		}
+		if !found {
+			return fmt.Errorf("containers field not found in claw deployment")
+		}
+
+		containerIdx := -1
+		var container map[string]any
+		for i, c := range containers {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(cm, "name"); name == ClawGatewayContainerName {
+				containerIdx = i
+				container = cm
+				break
+			}
+		}
+		if containerIdx < 0 {
+			return fmt.Errorf("container %q not found in claw deployment", ClawGatewayContainerName)
+		}
+
+		envVars, _, _ := unstructured.NestedSlice(container, "env")
+		envVars = append(envVars,
+			map[string]any{"name": "GOOGLE_CLOUD_PROJECT", "value": googleCred.GCP.Project},
+			map[string]any{"name": "GOOGLE_CLOUD_LOCATION", "value": googleCred.GCP.Location},
+		)
+
+		if err := unstructured.SetNestedSlice(container, envVars, "env"); err != nil {
+			return fmt.Errorf("failed to set env vars on claw deployment: %w", err)
+		}
+		containers[containerIdx] = container
+		if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+			return fmt.Errorf("failed to set containers on claw deployment: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("claw deployment not found in manifests")
+}
+
+// configureClawDeploymentForAnthropicVertexSDK adds Vertex AI environment variables and the stub
 // ADC volume mount to the claw (gateway) deployment when any credential uses the
 // native Vertex SDK (GCP + non-Google provider). The stub ADC allows google-auth-library
 // to bootstrap token refresh, which the MITM proxy intercepts with real credentials.
-func configureClawDeploymentForVertex(objects []*unstructured.Unstructured, credentials []resolvedCredential, instanceName string) error {
+func configureClawDeploymentForAnthropicVertexSDK(objects []*unstructured.Unstructured, credentials []resolvedCredential, instanceName string) error {
 	var vertexCreds []clawv1alpha1.CredentialSpec
 	for _, rc := range credentials {
 		if usesVertexSDK(rc.CredentialSpec) {

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -227,7 +227,7 @@ func TestConfigureClawDeploymentForAnthropicVertex(t *testing.T) {
 
 // --- GCP Vertex deployment configuration tests ---
 
-func TestconfigureClawDeploymentForGCPVertex(t *testing.T) {
+func TestConfigureClawDeploymentForGCPVertex(t *testing.T) {
 	makeDeployment := func() []*unstructured.Unstructured {
 		dep := &unstructured.Unstructured{}
 		dep.SetKind(DeploymentKind)

--- a/internal/controller/claw_deployment_test.go
+++ b/internal/controller/claw_deployment_test.go
@@ -126,9 +126,9 @@ func TestConfigureImagePullPolicy(t *testing.T) {
 	})
 }
 
-// --- Vertex AI deployment configuration tests ---
+// --- Anthropic Vertex AI deployment configuration tests ---
 
-func TestConfigureClawDeploymentForVertex(t *testing.T) {
+func TestConfigureClawDeploymentForAnthropicVertex(t *testing.T) {
 	makeDeployment := func() []*unstructured.Unstructured {
 		dep := &unstructured.Unstructured{}
 		dep.SetKind(DeploymentKind)
@@ -167,7 +167,7 @@ func TestConfigureClawDeploymentForVertex(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForVertex(objects, toResolved(credentials), testInstanceName))
+		require.NoError(t, configureClawDeploymentForAnthropicVertexSDK(objects, toResolved(credentials), testInstanceName))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)
@@ -216,7 +216,146 @@ func TestConfigureClawDeploymentForVertex(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, configureClawDeploymentForVertex(objects, toResolved(credentials), testInstanceName))
+		require.NoError(t, configureClawDeploymentForAnthropicVertexSDK(objects, toResolved(credentials), testInstanceName))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+		envVars := container["env"].([]any)
+		assert.Len(t, envVars, 1, "should only have original HOME env var")
+	})
+}
+
+// --- GCP Vertex deployment configuration tests ---
+
+func TestconfigureClawDeploymentForGCPVertex(t *testing.T) {
+	makeDeployment := func() []*unstructured.Unstructured {
+		dep := &unstructured.Unstructured{}
+		dep.SetKind(DeploymentKind)
+		dep.SetName(getClawDeploymentName(testInstanceName))
+		dep.Object["spec"] = map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name": ClawGatewayContainerName,
+							"env": []any{
+								map[string]any{"name": "HOME", "value": "/home/node"},
+							},
+						},
+					},
+				},
+			},
+		}
+		return []*unstructured.Unstructured{dep}
+	}
+
+	t.Run("should set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION", func(t *testing.T) {
+		objects := makeDeployment()
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "gemini",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "google",
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-gcp-project",
+					Location: "us-central1",
+				},
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForGCPVertex(objects, toResolved(credentials), testInstanceName))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+		envVars := container["env"].([]any)
+
+		var projectEnv, locationEnv map[string]any
+		for _, e := range envVars {
+			env := e.(map[string]any)
+			switch env["name"] {
+			case "GOOGLE_CLOUD_PROJECT":
+				projectEnv = env
+			case "GOOGLE_CLOUD_LOCATION":
+				locationEnv = env
+			}
+		}
+
+		require.NotNil(t, projectEnv, "GOOGLE_CLOUD_PROJECT should be set")
+		assert.Equal(t, "my-gcp-project", projectEnv["value"])
+
+		require.NotNil(t, locationEnv, "GOOGLE_CLOUD_LOCATION should be set")
+		assert.Equal(t, "us-central1", locationEnv["value"])
+	})
+
+	t.Run("should use global location", func(t *testing.T) {
+		objects := makeDeployment()
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "gemini",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "google",
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-project",
+					Location: "global",
+				},
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForGCPVertex(objects, toResolved(credentials), testInstanceName))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+		envVars := container["env"].([]any)
+
+		var locationEnv map[string]any
+		for _, e := range envVars {
+			env := e.(map[string]any)
+			if env["name"] == "GOOGLE_CLOUD_LOCATION" {
+				locationEnv = env
+			}
+		}
+
+		require.NotNil(t, locationEnv)
+		assert.Equal(t, "global", locationEnv["value"])
+	})
+
+	t.Run("should be no-op for google apiKey credential", func(t *testing.T) {
+		objects := makeDeployment()
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "gemini",
+				Type:     clawv1alpha1.CredentialTypeAPIKey,
+				Provider: "google",
+				Domain:   "generativelanguage.googleapis.com",
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForGCPVertex(objects, toResolved(credentials), testInstanceName))
+
+		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+		container := containers[0].(map[string]any)
+		envVars := container["env"].([]any)
+		assert.Len(t, envVars, 1, "should only have original HOME env var")
+	})
+
+	t.Run("should be no-op for non-google Vertex credential", func(t *testing.T) {
+		objects := makeDeployment()
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:     "anthropic-vertex",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "anthropic",
+				Domain:   ".googleapis.com",
+				GCP: &clawv1alpha1.GCPConfig{
+					Project:  "my-project",
+					Location: "us-east5",
+				},
+			},
+		}
+
+		require.NoError(t, configureClawDeploymentForGCPVertex(objects, toResolved(credentials), testInstanceName))
 
 		containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
 		container := containers[0].(map[string]any)

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -819,8 +819,11 @@ func (r *ClawResourceReconciler) configureDeployments(
 	if err := configureProxyForWebSearch(objects, instance); err != nil {
 		return fmt.Errorf("failed to configure proxy for web search: %w", err)
 	}
-	if err := configureClawDeploymentForVertex(objects, resolvedCreds, instance.Name); err != nil {
-		return fmt.Errorf("failed to configure claw deployment for Vertex AI: %w", err)
+	if err := configureClawDeploymentForGCPVertex(objects, resolvedCreds, instance.Name); err != nil {
+		return fmt.Errorf("failed to configure claw deployment for Google Vertex: %w", err)
+	}
+	if err := configureClawDeploymentForAnthropicVertexSDK(objects, resolvedCreds, instance.Name); err != nil {
+		return fmt.Errorf("failed to configure claw deployment for Anthropic Vertex AI: %w", err)
 	}
 	kubectlImage := r.KubectlImage
 	if kubectlImage == "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Vertex AI credentials by automatically setting the required project and location settings in the gateway deployment.
  * Improved Vertex AI configuration by separating Google-specific handling from other Vertex SDK setups.

* **Bug Fixes**
  * Vertex-related gateway settings are now applied only when the matching Google credential type is detected; otherwise configuration is left unchanged.
  * Added support for the special `global` location value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->