### PR TITLE
Fix scoping when using gcp vertex providers

### DIFF
--- a/internal/controller/claw_providers.go
+++ b/internal/controller/claw_providers.go
@@ -164,6 +164,13 @@ func vertexAIBaseURL(location string) string {
 	return "https://" + location + "-aiplatform.googleapis.com"
 }
 
+// gcpAIPlatformDomain returns the bare hostname for the Vertex AI API
+// in the given location, derived from vertexAIBaseURL as the single
+// source of truth.
+func gcpAIPlatformDomain(location string) string {
+	return strings.TrimPrefix(vertexAIBaseURL(location), "https://")
+}
+
 // buildProviderEntry constructs an OpenClaw provider config entry with the
 // correct wire format API baked in. This avoids the "build map then mutate"
 // pattern that led to the missing api field bug.
@@ -211,8 +218,8 @@ func resolveProviderDefaults(cred *clawv1alpha1.CredentialSpec) error {
 		}
 
 	case clawv1alpha1.CredentialTypeGCP:
-		if cred.Domain == "" {
-			cred.Domain = ".googleapis.com"
+		if cred.Domain == "" && cred.GCP != nil {
+			cred.Domain = gcpAIPlatformDomain(cred.GCP.Location)
 		}
 
 	case clawv1alpha1.CredentialTypeKubernetes:

--- a/internal/controller/claw_providers_test.go
+++ b/internal/controller/claw_providers_test.go
@@ -225,6 +225,30 @@ func TestVertexAIBaseURL(t *testing.T) {
 	}
 }
 
+func TestGCPAIPlatformDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     string
+	}{
+		{
+			name:     "global uses plain hostname",
+			location: "global",
+			want:     "aiplatform.googleapis.com",
+		},
+		{
+			name:     "regional location uses prefix",
+			location: "us-east5",
+			want:     "us-east5-aiplatform.googleapis.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, gcpAIPlatformDomain(tt.location))
+		})
+	}
+}
+
 // --- Vertex SDK helper tests ---
 
 func TestUsesVertexSDK(t *testing.T) {
@@ -537,24 +561,53 @@ func TestResolveProviderDefaults(t *testing.T) {
 			wantHeader: "x-api-key",
 		},
 		{
-			name: "google gcp fills domain",
+			name: "google gcp fills domain with region-specific aiplatform host",
 			cred: clawv1alpha1.CredentialSpec{
 				Name:     "gemini",
 				Type:     clawv1alpha1.CredentialTypeGCP,
 				Provider: "google",
 				GCP:      &clawv1alpha1.GCPConfig{Project: "p", Location: "us-central1"},
 			},
-			wantDomain: ".googleapis.com",
+			wantDomain: "us-central1-aiplatform.googleapis.com",
 		},
 		{
-			name: "anthropic gcp fills domain",
+			name: "anthropic gcp fills domain with region-specific aiplatform host",
 			cred: clawv1alpha1.CredentialSpec{
 				Name:     "anthropic-vertex",
 				Type:     clawv1alpha1.CredentialTypeGCP,
 				Provider: "anthropic",
 				GCP:      &clawv1alpha1.GCPConfig{Project: "p", Location: "us-east5"},
 			},
+			wantDomain: "us-east5-aiplatform.googleapis.com",
+		},
+		{
+			name: "gcp global location uses plain aiplatform hostname",
+			cred: clawv1alpha1.CredentialSpec{
+				Name:     "gemini-global",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "google",
+				GCP:      &clawv1alpha1.GCPConfig{Project: "p", Location: "global"},
+			},
+			wantDomain: "aiplatform.googleapis.com",
+		},
+		{
+			name: "gcp explicit domain preserved",
+			cred: clawv1alpha1.CredentialSpec{
+				Name:     "vertex-broad",
+				Type:     clawv1alpha1.CredentialTypeGCP,
+				Provider: "google",
+				Domain:   ".googleapis.com",
+				GCP:      &clawv1alpha1.GCPConfig{Project: "p", Location: "us-central1"},
+			},
 			wantDomain: ".googleapis.com",
+		},
+		{
+			name: "gcp without gcp config leaves domain empty",
+			cred: clawv1alpha1.CredentialSpec{
+				Name: "no-gcp-config",
+				Type: clawv1alpha1.CredentialTypeGCP,
+			},
+			wantErr: "domain is required",
 		},
 		{
 			name: "explicit domain preserved",

--- a/internal/controller/claw_proxy.go
+++ b/internal/controller/claw_proxy.go
@@ -56,6 +56,10 @@ const (
 	injectorKubernetes = "kubernetes"
 )
 
+// gcpOAuth2Domain is the GCP OAuth2 token endpoint domain. GCP credentials
+// need this for the proxy's token vending mechanism (isTokenVendingRequest).
+const gcpOAuth2Domain = "oauth2.googleapis.com"
+
 // proxyRoute is a single route entry in the proxy config JSON.
 type proxyRoute struct {
 	Domain         string            `json:"domain"`
@@ -150,7 +154,7 @@ func generateProxyConfig(
 
 	exact = append(exact, mcpPassthroughRoutes(mcpServers, coveredDomains)...)
 
-	credExact, credSuffix := credentialRoutes(credentials)
+	credExact, credSuffix := credentialRoutes(credentials, coveredDomains)
 	exact = append(exact, credExact...)
 	suffix := make([]proxyRoute, 0, len(credSuffix))
 	suffix = append(suffix, credSuffix...)
@@ -196,9 +200,23 @@ func multiSecretRoles(cred clawv1alpha1.CredentialSpec) []channelSecretRole {
 
 // credentialRoutes builds proxy routes from resolved credentials, returning
 // exact-match and suffix-match routes separately for deterministic ordering.
-func credentialRoutes(credentials []resolvedCredential) (exact, suffix []proxyRoute) {
+// coveredDomains is used to deduplicate companion routes (e.g. oauth2.googleapis.com
+// for GCP credentials) and is updated in-place.
+func credentialRoutes(credentials []resolvedCredential, coveredDomains map[string]bool) (exact, suffix []proxyRoute) {
 	for _, rc := range credentials {
 		cred := rc.CredentialSpec
+
+		// GCP credentials need oauth2.googleapis.com for the proxy's token
+		// vending mechanism (isTokenVendingRequest intercepts POST /token).
+		// The GCP injector type is needed to trigger MITM.
+		if cred.Type == clawv1alpha1.CredentialTypeGCP && !coveredDomains[gcpOAuth2Domain] {
+			coveredDomains[gcpOAuth2Domain] = true
+			exact = append(exact, proxyRoute{
+				Domain:     gcpOAuth2Domain,
+				Injector:   injectorGCP,
+				SAFilePath: "/etc/proxy/credentials/" + cred.Name + "/sa-key.json",
+			})
+		}
 
 		if cred.Type == clawv1alpha1.CredentialTypeKubernetes {
 			if rc.KubeConfig == nil {

--- a/internal/controller/claw_proxy_test.go
+++ b/internal/controller/claw_proxy_test.go
@@ -252,7 +252,7 @@ func TestGenerateProxyConfig(t *testing.T) {
 					Name: "gcp-secret",
 					Key:  "sa.json",
 				}},
-				Domain: ".googleapis.com",
+				Domain: "us-central1-aiplatform.googleapis.com",
 				GCP: &clawv1alpha1.GCPConfig{
 					Project:  "my-project",
 					Location: "us-central1",
@@ -265,12 +265,15 @@ func TestGenerateProxyConfig(t *testing.T) {
 
 		var cfg proxyConfig
 		require.NoError(t, json.Unmarshal(data, &cfg))
-		route := findRouteByDomain(t, cfg.Routes, ".googleapis.com")
+		route := findRouteByDomain(t, cfg.Routes, "us-central1-aiplatform.googleapis.com")
 		assert.Equal(t, "gcp", route.Injector)
 		assert.Equal(t, "/etc/proxy/credentials/vertex/sa-key.json", route.SAFilePath)
 		assert.Equal(t, "my-project", route.GCPProject)
 		assert.Equal(t, "/vertex", route.PathPrefix)
 		assert.Equal(t, "https://us-central1-aiplatform.googleapis.com", route.Upstream)
+
+		oauth2Route := findRouteByDomain(t, cfg.Routes, "oauth2.googleapis.com")
+		assert.Equal(t, "gcp", oauth2Route.Injector)
 	})
 
 	t.Run("should order exact matches before suffix matches", func(t *testing.T) {
@@ -909,7 +912,7 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 					Name: "vertex-sa",
 					Key:  "sa.json",
 				}},
-				Domain: ".googleapis.com",
+				Domain: "us-east5-aiplatform.googleapis.com",
 				GCP: &clawv1alpha1.GCPConfig{
 					Project:  "my-project",
 					Location: "us-east5",
@@ -922,10 +925,13 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 
 		var cfg proxyConfig
 		require.NoError(t, json.Unmarshal(data, &cfg))
-		route := findRouteByDomain(t, cfg.Routes, ".googleapis.com")
+		route := findRouteByDomain(t, cfg.Routes, "us-east5-aiplatform.googleapis.com")
 		assert.Equal(t, "gcp", route.Injector)
 		assert.Empty(t, route.PathPrefix, "Vertex SDK provider should not have gateway path prefix")
 		assert.Empty(t, route.Upstream, "Vertex SDK provider should not have gateway upstream")
+
+		oauth2Route := findRouteByDomain(t, cfg.Routes, "oauth2.googleapis.com")
+		assert.Equal(t, "gcp", oauth2Route.Injector)
 	})
 
 	t.Run("should create gateway route for GCP google but not GCP anthropic", func(t *testing.T) {
@@ -938,7 +944,7 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 					Name: "gcp-secret",
 					Key:  "sa.json",
 				}},
-				Domain: ".googleapis.com",
+				Domain: "us-central1-aiplatform.googleapis.com",
 				GCP: &clawv1alpha1.GCPConfig{
 					Project:  "my-project",
 					Location: "us-central1",
@@ -952,7 +958,7 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 					Name: "vertex-sa",
 					Key:  "sa.json",
 				}},
-				Domain: ".googleapis.com",
+				Domain: "us-east5-aiplatform.googleapis.com",
 				GCP: &clawv1alpha1.GCPConfig{
 					Project:  "my-project",
 					Location: "us-east5",
@@ -982,6 +988,128 @@ func TestGenerateProxyConfigVertexSDK(t *testing.T) {
 		require.NotNil(t, anthropicRoute, "anthropic GCP route should exist")
 		assert.Empty(t, anthropicRoute.PathPrefix, "anthropic GCP should not have gateway prefix")
 		assert.Empty(t, anthropicRoute.Upstream, "anthropic GCP should not have gateway upstream")
+
+		oauth2Route := findRouteByDomain(t, cfg.Routes, "oauth2.googleapis.com")
+		assert.Equal(t, "gcp", oauth2Route.Injector, "should have exactly one oauth2 route")
+	})
+}
+
+// --- GCP domain restriction tests ---
+
+func TestGCPDomainRestriction(t *testing.T) {
+	t.Run("should emit only one oauth2 route for multiple GCP credentials", func(t *testing.T) {
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "vertex-google",
+				Type:      clawv1alpha1.CredentialTypeGCP,
+				Provider:  "google",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "sa1", Key: "sa.json"}},
+				Domain:    "us-central1-aiplatform.googleapis.com",
+				GCP:       &clawv1alpha1.GCPConfig{Project: "p1", Location: "us-central1"},
+			},
+			{
+				Name:      "vertex-anthropic",
+				Type:      clawv1alpha1.CredentialTypeGCP,
+				Provider:  "anthropic",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "sa2", Key: "sa.json"}},
+				Domain:    "us-east5-aiplatform.googleapis.com",
+				GCP:       &clawv1alpha1.GCPConfig{Project: "p2", Location: "us-east5"},
+			},
+		}
+
+		data, err := generateProxyConfig(toResolved(credentials), nil, nil)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		oauth2Count := 0
+		for _, r := range cfg.Routes {
+			if r.Domain == "oauth2.googleapis.com" {
+				oauth2Count++
+				assert.Equal(t, "gcp", r.Injector)
+			}
+		}
+		assert.Equal(t, 1, oauth2Count, "should have exactly one oauth2.googleapis.com route")
+	})
+
+	t.Run("should emit separate aiplatform routes per region", func(t *testing.T) {
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "vertex-google",
+				Type:      clawv1alpha1.CredentialTypeGCP,
+				Provider:  "google",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "sa1", Key: "sa.json"}},
+				Domain:    "us-central1-aiplatform.googleapis.com",
+				GCP:       &clawv1alpha1.GCPConfig{Project: "p1", Location: "us-central1"},
+			},
+			{
+				Name:      "vertex-anthropic",
+				Type:      clawv1alpha1.CredentialTypeGCP,
+				Provider:  "anthropic",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "sa2", Key: "sa.json"}},
+				Domain:    "us-east5-aiplatform.googleapis.com",
+				GCP:       &clawv1alpha1.GCPConfig{Project: "p2", Location: "us-east5"},
+			},
+		}
+
+		data, err := generateProxyConfig(toResolved(credentials), nil, nil)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		googleRoute := findRouteByDomain(t, cfg.Routes, "us-central1-aiplatform.googleapis.com")
+		assert.Equal(t, "gcp", googleRoute.Injector)
+		assert.Equal(t, "/etc/proxy/credentials/vertex-google/sa-key.json", googleRoute.SAFilePath)
+
+		anthropicRoute := findRouteByDomain(t, cfg.Routes, "us-east5-aiplatform.googleapis.com")
+		assert.Equal(t, "gcp", anthropicRoute.Injector)
+		assert.Equal(t, "/etc/proxy/credentials/vertex-anthropic/sa-key.json", anthropicRoute.SAFilePath)
+	})
+
+	t.Run("should allow explicit domain override for GCP", func(t *testing.T) {
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "vertex-broad",
+				Type:      clawv1alpha1.CredentialTypeGCP,
+				Provider:  "google",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "sa", Key: "sa.json"}},
+				Domain:    ".googleapis.com",
+				GCP:       &clawv1alpha1.GCPConfig{Project: "p", Location: "us-central1"},
+			},
+		}
+
+		data, err := generateProxyConfig(toResolved(credentials), nil, nil)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		route := findRouteByDomain(t, cfg.Routes, ".googleapis.com")
+		assert.Equal(t, "gcp", route.Injector, "explicit suffix domain should be respected")
+	})
+
+	t.Run("should not emit oauth2 route for non-GCP credentials", func(t *testing.T) {
+		credentials := []clawv1alpha1.CredentialSpec{
+			{
+				Name:      "gemini",
+				Type:      clawv1alpha1.CredentialTypeAPIKey,
+				Provider:  "google",
+				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "s", Key: "k"}},
+				Domain:    "generativelanguage.googleapis.com",
+				APIKey:    &clawv1alpha1.APIKeyConfig{Header: "x-goog-api-key"},
+			},
+		}
+
+		data, err := generateProxyConfig(toResolved(credentials), nil, nil)
+		require.NoError(t, err)
+
+		var cfg proxyConfig
+		require.NoError(t, json.Unmarshal(data, &cfg))
+
+		assert.Nil(t, findRoute(cfg.Routes, "oauth2.googleapis.com"),
+			"oauth2 route should not be emitted for apiKey credentials")
 	})
 }
 
@@ -1032,7 +1160,7 @@ func TestConfigureProxyForCredentials(t *testing.T) {
 				Name:      "vertex",
 				Type:      clawv1alpha1.CredentialTypeGCP,
 				SecretRef: []clawv1alpha1.SecretRefEntry{{Name: "gcp-sa", Key: "sa.json"}},
-				Domain:    ".googleapis.com",
+				Domain:    "us-central1-aiplatform.googleapis.com",
 				GCP:       &clawv1alpha1.GCPConfig{Project: "p", Location: "us-central1"},
 			},
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GCP-backed credentials now use the correct Vertex AI domain for each location, including regional and global variants.
  * Proxy routing now avoids duplicating the `oauth2.googleapis.com` route across multiple GCP credentials.
  * Explicit domain overrides continue to be respected, and missing GCP configuration now returns a clear error.
* **Tests**
  * Expanded coverage for GCP/Vertex AI routing and domain handling across regional, global, and override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->