### PR TITLE
feat: upgrade OpenClaw to 2026.6.11

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -494,10 +494,10 @@ type CustomProviderSpec struct {
 // ClawSpec defines the desired state of Claw
 type ClawSpec struct {
 	// Image is the full container image reference for the OpenClaw gateway
-	// (e.g. "ghcr.io/openclaw/openclaw:2026.6.10"). Used for init-volume,
+	// (e.g. "ghcr.io/openclaw/openclaw:2026.6.11"). Used for init-volume,
 	// init-config, and gateway containers.
 	// +optional
-	// +kubebuilder:default="ghcr.io/openclaw/openclaw:2026.6.10"
+	// +kubebuilder:default="ghcr.io/openclaw/openclaw:2026.6.11"
 	Image string `json:"image,omitempty"`
 
 	// Config provides user-supplied OpenClaw configuration and merge behavior.

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -409,10 +409,10 @@ spec:
                   Deployments to zero replicas. Set to false (or omit) to run normally.
                 type: boolean
               image:
-                default: ghcr.io/openclaw/openclaw:2026.6.10
+                default: ghcr.io/openclaw/openclaw:2026.6.11
                 description: |-
                   Image is the full container image reference for the OpenClaw gateway
-                  (e.g. "ghcr.io/openclaw/openclaw:2026.6.10"). Used for init-volume,
+                  (e.g. "ghcr.io/openclaw/openclaw:2026.6.11"). Used for init-volume,
                   init-config, and gateway containers.
                 type: string
               mcpServers:

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -422,7 +422,7 @@ func TestRequiredProviderPlugins(t *testing.T) {
 		plugins, err := requiredProviderPlugins(instance)
 		require.NoError(t, err)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.10", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.11", plugins[0])
 	})
 
 	t.Run("returns empty for google GCP credential", func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestRequiredProviderPlugins(t *testing.T) {
 		plugins, err := requiredProviderPlugins(instance)
 		require.NoError(t, err)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.10", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.11", plugins[0])
 	})
 
 	t.Run("extracts version from slim-variant tag for vertex plugin", func(t *testing.T) {
@@ -509,7 +509,7 @@ func TestRequiredProviderPlugins(t *testing.T) {
 		plugins, err := requiredProviderPlugins(instance)
 		require.NoError(t, err)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.10", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.11", plugins[0])
 	})
 }
 
@@ -526,7 +526,7 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins, err := effectivePlugins(instance)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"@openclaw/matrix@2026.6.10"}, plugins)
+		assert.Equal(t, []string{"@openclaw/matrix@2026.6.11"}, plugins)
 	})
 
 	t.Run("merges implicit vertex plugin with spec plugins", func(t *testing.T) {
@@ -542,8 +542,8 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins, err := effectivePlugins(instance)
 		require.NoError(t, err)
-		assert.Contains(t, plugins, "@openclaw/matrix@2026.6.10") // same version as the image is set for this plugin
-		assert.Contains(t, plugins, "@openclaw/anthropic-vertex-provider@2026.6.10")
+		assert.Contains(t, plugins, "@openclaw/matrix@2026.6.11") // same version as the image is set for this plugin
+		assert.Contains(t, plugins, "@openclaw/anthropic-vertex-provider@2026.6.11")
 		assert.Len(t, plugins, 2)
 	})
 
@@ -551,7 +551,7 @@ func TestEffectivePlugins(t *testing.T) {
 		instance := &clawv1alpha1.Claw{
 			Spec: clawv1alpha1.ClawSpec{
 				Image:   DefaultOpenClawImage,
-				Plugins: []string{"@openclaw/anthropic-vertex-provider@2026.6.10"},
+				Plugins: []string{"@openclaw/anthropic-vertex-provider@2026.6.11"},
 				Credentials: []clawv1alpha1.CredentialSpec{
 					{Name: "vertex", Type: clawv1alpha1.CredentialTypeGCP, Provider: "anthropic",
 						GCP: &clawv1alpha1.GCPConfig{Project: "p", Location: "us-east5"}},
@@ -560,7 +560,7 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins, err := effectivePlugins(instance)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"@openclaw/anthropic-vertex-provider@2026.6.10"}, plugins)
+		assert.Equal(t, []string{"@openclaw/anthropic-vertex-provider@2026.6.11"}, plugins)
 	})
 
 	t.Run("includes version if spec already declares the plugin with missing version", func(t *testing.T) {
@@ -576,7 +576,7 @@ func TestEffectivePlugins(t *testing.T) {
 		}
 		plugins, err := effectivePlugins(instance)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"@openclaw/anthropic-vertex-provider@2026.6.10"}, plugins)
+		assert.Equal(t, []string{"@openclaw/anthropic-vertex-provider@2026.6.11"}, plugins)
 	})
 
 	t.Run("returns implicit plugins when spec.plugins is empty", func(t *testing.T) {
@@ -592,7 +592,7 @@ func TestEffectivePlugins(t *testing.T) {
 		plugins, err := effectivePlugins(instance)
 		require.NoError(t, err)
 		require.Len(t, plugins, 1)
-		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.10", plugins[0])
+		assert.Equal(t, "@openclaw/anthropic-vertex-provider@2026.6.11", plugins[0])
 	})
 }
 
@@ -691,7 +691,7 @@ func TestPluginsIntegration(t *testing.T) {
 		for _, ic := range deployment.Spec.Template.Spec.InitContainers {
 			if ic.Name == PluginsInitContainerName {
 				found = true
-				assert.Contains(t, ic.Command[2], "openclaw plugins install '@openclaw/matrix@2026.6.10'")
+				assert.Contains(t, ic.Command[2], "openclaw plugins install '@openclaw/matrix@2026.6.11'")
 
 				envMap := make(map[string]string)
 				for _, e := range ic.Env {
@@ -762,8 +762,8 @@ func TestPluginsIntegration(t *testing.T) {
 		for _, ic := range deployment.Spec.Template.Spec.InitContainers {
 			if ic.Name == PluginsInitContainerName {
 				script := ic.Command[2]
-				assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix@2026.6.10'")
-				assert.Contains(t, script, "openclaw plugins install '@openclaw/diagnostics-otel@2026.6.10'")
+				assert.Contains(t, script, "openclaw plugins install '@openclaw/matrix@2026.6.11'")
+				assert.Contains(t, script, "openclaw plugins install '@openclaw/diagnostics-otel@2026.6.11'")
 				return
 			}
 		}

--- a/internal/controller/claw_providers.go
+++ b/internal/controller/claw_providers.go
@@ -152,11 +152,11 @@ var knownProviders = map[string]providerDefaults{
 // imagePluginVersion extracts the OpenClaw release version from a container
 // image tag for use as an npm package version suffix.
 //
-//	"ghcr.io/openclaw/openclaw:2026.6.10"             → "2026.6.10"
-//	"ghcr.io/openclaw/openclaw:2026.6.10-slim-arm64"  → "2026.6.10"
+//	"ghcr.io/openclaw/openclaw:2026.6.11"             → "2026.6.11"
+//	"ghcr.io/openclaw/openclaw:2026.6.11-slim-arm64"  → "2026.6.11"
 //	"ghcr.io/openclaw/openclaw:slim"                  → ""  (latest)
 //	"ghcr.io/openclaw/openclaw:latest"                → ""  (latest)
-//	"ghcr.io/openclaw/openclaw"                       → "2026.6.10"  (or whatever is derived from default image)
+//	"ghcr.io/openclaw/openclaw"                       → "2026.6.11"  (or whatever is derived from default image)
 //	"ghcr.io/openclaw/openclaw@sha256:abc"            → "sha256:abc" (must be a valid digest)
 //	"ghcr.io/openclaw/openclaw@sha256:invalid"        → error
 func imagePluginVersion(image string) (string, error) {

--- a/internal/controller/claw_providers_test.go
+++ b/internal/controller/claw_providers_test.go
@@ -793,15 +793,15 @@ func TestImagePluginVersion(t *testing.T) {
 		expectedErr bool
 	}{
 		{"untagged image", "ghcr.io/openclaw/openclaw", "", false},
-		{"tagged image", "ghcr.io/openclaw/openclaw:2026.6.10", "2026.6.10", false},
+		{"tagged image", "ghcr.io/openclaw/openclaw:2026.6.11", "2026.6.11", false},
 		{"slim tag", "ghcr.io/openclaw/openclaw:slim", "", false},
 		{"latest tag", "ghcr.io/openclaw/openclaw:latest", "", false},
-		{"slim variant with arch", "openclaw:2026.6.10-slim-arm64", "2026.6.10", false},
-		{"slim variant without arch", "openclaw:2026.6.10-slim", "2026.6.10", false},
+		{"slim variant with arch", "openclaw:2026.6.11-slim-arm64", "2026.6.11", false},
+		{"slim variant without arch", "openclaw:2026.6.11-slim", "2026.6.11", false},
 		{"custom registry", "my-registry.io/custom/openclaw:v1.2.3", "v1.2.3", false},
 		{"valid digest", "ghcr.io/openclaw/openclaw@sha256:94a00394bc5a8ef503fb59db0a7d0ae9e1110866e8aee8ba40cd864cea69ea1a", "sha256:94a00394bc5a8ef503fb59db0a7d0ae9e1110866e8aee8ba40cd864cea69ea1a", false},
 		{"invalid digest", "ghcr.io/openclaw/openclaw@sha256:invalid", "", true},
-		{"empty string", "", "2026.6.10", false}, // default image version
+		{"empty string", "", "2026.6.11", false}, // default image version
 		{"port in registry no tag", "localhost:5000/openclaw", "", false},
 		{"port in registry with tag", "localhost:5000/openclaw:v1", "v1", false},
 	}

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -64,7 +64,7 @@ const (
 	ClawInitConfigContainerName = "init-config"
 	ClawConfigModeEnvVar        = "CLAW_CONFIG_MODE"
 	DefaultKubectlImage         = "quay.io/openshift/origin-cli:4.21"
-	DefaultOpenClawImage        = "ghcr.io/openclaw/openclaw:2026.6.10"
+	DefaultOpenClawImage        = "ghcr.io/openclaw/openclaw:2026.6.11"
 	// OpenClaw JSON config keys shared across enrichment functions
 	configKeyGateway   = "gateway"
 	configKeyControlUI = "controlUi"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -45,8 +45,9 @@ var (
 
 	// gatewayImage is the upstream OpenClaw image used by the claw deployment.
 	// Pre-loaded into Kind so e2e tests can verify init container patching.
-	// Set via GATEWAY_IMAGE env var (derived from kustomization.yaml by the Makefile).
-	gatewayImage = envOrDefault("GATEWAY_IMAGE", "ghcr.io/openclaw/openclaw:2026.6.10")
+	// Set via GATEWAY_IMAGE env var (defaults to the Makefile's GATEWAY_IMAGE, which
+	// should track DefaultOpenClawImage in internal/controller/claw_resource_controller.go).
+	gatewayImage = envOrDefault("GATEWAY_IMAGE", "ghcr.io/openclaw/openclaw:2026.6.11")
 )
 
 // TestMain runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,


### PR DESCRIPTION
- Bump default image and CRD default from 2026.6.10 to 2026.6.11
- Anthropic Vertex/matrix/diagnostics-otel plugin versions derive automatically from the image tag, no separate pin needed
- Verified against upstream diff: no config schema, wire-format API, or workspace-seeding changes require operator updates this release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default OpenClaw container image to a newer release across the app and CRD defaults.
  * Aligned controller behavior and end-to-end test defaults with the latest image tag.
  * Refreshed plugin-related test expectations to match the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->