### PR TITLE
fix: use podman login -u/-p for quay.io auth in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,8 @@ jobs:
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
           set -euo pipefail
+          : "${QUAY_USERNAME:?QUAY_USERNAME secret is required}"
+          : "${QUAY_TOKEN:?QUAY_TOKEN secret is required}"
           REGISTRY_AUTH_FILE="${RUNNER_TEMP}/containers-auth.json"
           export REGISTRY_AUTH_FILE
           echo "REGISTRY_AUTH_FILE=${REGISTRY_AUTH_FILE}" >> "${GITHUB_ENV}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,13 +31,16 @@ jobs:
           make container-build-proxy PROXY_IMG=quay.io/codeready-toolchain/claw-proxy:${SHA}
 
       - name: Login to Quay.io
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
           set -euo pipefail
           REGISTRY_AUTH_FILE="${RUNNER_TEMP}/containers-auth.json"
           export REGISTRY_AUTH_FILE
           echo "REGISTRY_AUTH_FILE=${REGISTRY_AUTH_FILE}" >> "${GITHUB_ENV}"
-          printf '%s' '{"auths":{"quay.io":{"auth":"${{ secrets.QUAY_TOKEN }}"}}}' > "${REGISTRY_AUTH_FILE}"
-          podman login --authfile "${REGISTRY_AUTH_FILE}" --get-login quay.io
+          podman login --authfile "${REGISTRY_AUTH_FILE}" \
+            -u "${QUAY_USERNAME}" --password-stdin quay.io <<< "${QUAY_TOKEN}"
 
       - name: Push operator image
         run: |


### PR DESCRIPTION
- Replace manual base64 "auth" JSON construction with podman login -u/--password-stdin, which builds the credential file itself
- A malformed base64(username:token) blob in QUAY_TOKEN was causing "missing semicolon" parse errors and failed logins
- Requires a new QUAY_USERNAME secret plus QUAY_TOKEN as the plain robot-account token (no more manual encoding needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow’s container registry login step to use a more secure authentication approach.
  * Improved runtime validation for required registry credentials during release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->