### PR TITLE
fix: combine proxy CA with system CAs in git-sync init container

### DIFF
--- a/internal/controller/claw_workspace.go
+++ b/internal/controller/claw_workspace.go
@@ -417,6 +417,12 @@ func isCommitSHA(ref string) bool {
 func generateGitSyncScript(gitSources []clawv1alpha1.GitSource) string {
 	var sb strings.Builder
 	sb.WriteString("set -e\n")
+	// Combine the proxy CA with the system CA bundle so git trusts both
+	// MITM'd connections (proxy CA) and direct CONNECT tunnels (upstream CAs).
+	sb.WriteString("cat /etc/proxy-ca/ca.crt /etc/ssl/certs/ca-certificates.crt " +
+		"> /tmp/combined-ca.crt 2>/dev/null " +
+		"|| cp /etc/proxy-ca/ca.crt /tmp/combined-ca.crt\n")
+	sb.WriteString("export GIT_SSL_CAINFO=/tmp/combined-ca.crt\n")
 	for i, gs := range gitSources {
 		dest := fmt.Sprintf("%s%d", gitSourceMountFn, i)
 		quotedDest := shellQuote(dest)
@@ -494,11 +500,6 @@ func injectGitSyncInitContainer(
 			"mountPath": "/etc/proxy-ca",
 			"readOnly":  true,
 		})
-
-		// Git SSL env var for CA cert
-		envVars = append(envVars,
-			map[string]any{"name": "GIT_SSL_CAINFO", "value": "/etc/proxy-ca/ca.crt"},
-		)
 
 		for i, gs := range gitSources {
 			volName := gitSourceVolumeName(i)

--- a/internal/controller/claw_workspace_test.go
+++ b/internal/controller/claw_workspace_test.go
@@ -1158,6 +1158,8 @@ func TestGenerateGitSyncScript(t *testing.T) {
 			},
 		})
 		assert.Contains(t, script, "set -e")
+		assert.Contains(t, script, "combined-ca.crt")
+		assert.Contains(t, script, "export GIT_SSL_CAINFO=/tmp/combined-ca.crt")
 		assert.Contains(t, script, "CLONE_URL='https://github.com/team/config.git'")
 		assert.Contains(t, script, "git clone --depth 1 --branch 'main'")
 		assert.Contains(t, script, "/git-sources/0")
@@ -1375,7 +1377,6 @@ func TestInjectGitSyncInitContainer(t *testing.T) {
 		}
 		assert.Equal(t, "http://test-proxy:8080", envMap["HTTP_PROXY"])
 		assert.Equal(t, "http://test-proxy:8080", envMap["HTTPS_PROXY"])
-		assert.Equal(t, "/etc/proxy-ca/ca.crt", envMap["GIT_SSL_CAINFO"])
 
 		vMounts, _, _ := unstructured.NestedSlice(gitSync, "volumeMounts")
 		mountNames := map[string]bool{}


### PR DESCRIPTION
## Summary

- The `init-git-sync` container set `GIT_SSL_CAINFO` to only the proxy CA cert. When the proxy uses a direct CONNECT tunnel (no MITM) for domains like `github.com` (`injector: "none"`), git sees the upstream's real TLS certificate signed by a public CA — which isn't in the proxy CA file. This caused git clone failures with `unable to get local issuer certificate`.
- Fix: concatenate the proxy CA with the system CA bundle (`/etc/ssl/certs/ca-certificates.crt`) in the clone script so git trusts both MITM'd and direct-tunnel connections. Falls back to proxy-only CA if the system bundle doesn't exist.
- Remove the now-redundant `GIT_SSL_CAINFO` env var from the container spec since the script sets it after combining.

## Test plan

- [x] Deployed operator with this fix on a fresh OpenShift cluster
- [x] Applied a Claw CR with `gitSources` pointing to a public repo (`github.com/redhat-et/claw-collections`)
- [x] Verified `init-git-sync` clones successfully (previously failed with SSL error)
- [x] Verified `init-seed` seeds all 6 files with `mode=overwrite`
- [x] Verified workspace files in the running pod match the Git repo content
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git sync certificate handling so it now trusts both the proxy certificate and the system certificate bundle.
  * This helps Git operations succeed in environments that use a MITM proxy without breaking access to upstream servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->