### PR TITLE
feat: add `readOnly` field on workspace sources for immutable file mounts

### DIFF
--- a/api/v1alpha1/claw_types.go
+++ b/api/v1alpha1/claw_types.go
@@ -408,8 +408,15 @@ type InlineSource struct {
 	Content string `json:"content"`
 
 	// Mode controls seeding behavior. Default: overwrite.
+	// Ignored when ReadOnly is true.
 	// +optional
 	Mode SeedMode `json:"mode,omitempty"`
+
+	// ReadOnly mounts this file directly into the workspace via a
+	// read-only Kubernetes volume mount instead of seeding it onto the PVC.
+	// The OpenClaw process cannot modify or delete the file at runtime.
+	// +optional
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 // ConfigMapRef references a ConfigMap in the same namespace.
@@ -450,8 +457,15 @@ type ConfigMapSource struct {
 
 	// Mode controls seeding behavior for all items in this source.
 	// Individual items can override this. Default: overwrite.
+	// Ignored when ReadOnly is true.
 	// +optional
 	Mode SeedMode `json:"mode,omitempty"`
+
+	// ReadOnly mounts all items directly into the workspace via
+	// read-only Kubernetes volume mounts instead of seeding them onto the PVC.
+	// The OpenClaw process cannot modify or delete these files at runtime.
+	// +optional
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 // GitItem maps a file in a Git repository to a workspace path.
@@ -496,8 +510,15 @@ type GitSource struct {
 
 	// Mode controls seeding behavior for all items in this source.
 	// Individual items can override this. Default: overwrite.
+	// Ignored when ReadOnly is true.
 	// +optional
 	Mode SeedMode `json:"mode,omitempty"`
+
+	// ReadOnly mounts all items directly into the workspace via
+	// read-only Kubernetes volume mounts instead of seeding them onto the PVC.
+	// The OpenClaw process cannot modify or delete these files at runtime.
+	// +optional
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 // WorkspaceSpec configures workspace file seeding.

--- a/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
+++ b/config/crd/bases/claw.sandbox.redhat.com_claws.yaml
@@ -901,10 +901,17 @@ spec:
                           description: |-
                             Mode controls seeding behavior for all items in this source.
                             Individual items can override this. Default: overwrite.
+                            Ignored when ReadOnly is true.
                           enum:
                           - overwrite
                           - seedIfMissing
                           type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly mounts all items directly into the workspace via
+                            read-only Kubernetes volume mounts instead of seeding them onto the PVC.
+                            The OpenClaw process cannot modify or delete these files at runtime.
+                          type: boolean
                       required:
                       - configMapRef
                       - items
@@ -957,10 +964,17 @@ spec:
                           description: |-
                             Mode controls seeding behavior for all items in this source.
                             Individual items can override this. Default: overwrite.
+                            Ignored when ReadOnly is true.
                           enum:
                           - overwrite
                           - seedIfMissing
                           type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly mounts all items directly into the workspace via
+                            read-only Kubernetes volume mounts instead of seeding them onto the PVC.
+                            The OpenClaw process cannot modify or delete these files at runtime.
+                          type: boolean
                         ref:
                           description: |-
                             Ref is the Git reference to check out: branch name, tag, or commit SHA.
@@ -1009,7 +1023,9 @@ spec:
                           description: Content is the inline file content.
                           type: string
                         mode:
-                          description: 'Mode controls seeding behavior. Default: overwrite.'
+                          description: |-
+                            Mode controls seeding behavior. Default: overwrite.
+                            Ignored when ReadOnly is true.
                           enum:
                           - overwrite
                           - seedIfMissing
@@ -1019,6 +1035,12 @@ spec:
                             "SOUL.md", "docs/guide.md").
                           minLength: 1
                           type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly mounts this file directly into the workspace via a
+                            read-only Kubernetes volume mount instead of seeding it onto the PVC.
+                            The OpenClaw process cannot modify or delete the file at runtime.
+                          type: boolean
                       required:
                       - content
                       - path

--- a/internal/controller/claw_resource_controller.go
+++ b/internal/controller/claw_resource_controller.go
@@ -886,6 +886,9 @@ func (r *ClawResourceReconciler) enrichWorkspaceSources(
 	if err := injectSeedInitContainer(objects, instance, gatewayImage); err != nil {
 		return fmt.Errorf("failed to inject seed init container: %w", err)
 	}
+	if err := injectReadOnlyWorkspaceMounts(objects, instance); err != nil {
+		return fmt.Errorf("failed to inject read-only workspace mounts: %w", err)
+	}
 	return nil
 }
 

--- a/internal/controller/claw_workspace.go
+++ b/internal/controller/claw_workspace.go
@@ -42,6 +42,7 @@ const (
 	gitSourceMountFn       = "/git-sources/"
 	commitSHALength        = 40
 	configMountPath        = "/config/"
+	workspaceMountPath     = "/home/node/.openclaw/workspace/"
 )
 
 // seedManifestEntry describes a single file to seed into the workspace.
@@ -226,6 +227,9 @@ func generateSeedManifest(ws *clawv1alpha1.WorkspaceSpec) []seedManifestEntry {
 	}
 
 	for _, src := range ws.InlineSources {
+		if src.ReadOnly {
+			continue
+		}
 		entries = append(entries, seedManifestEntry{
 			Source: configMountPath + workspaceKeyPrefix + encodeWorkspacePath(src.Path),
 			Target: src.Path,
@@ -234,6 +238,9 @@ func generateSeedManifest(ws *clawv1alpha1.WorkspaceSpec) []seedManifestEntry {
 	}
 
 	for _, cms := range ws.ConfigMapSources {
+		if cms.ReadOnly {
+			continue
+		}
 		volName := configMapSourceVolumeName(cms.ConfigMapRef.Name)
 		for _, item := range cms.Items {
 			entries = append(entries, seedManifestEntry{
@@ -245,6 +252,9 @@ func generateSeedManifest(ws *clawv1alpha1.WorkspaceSpec) []seedManifestEntry {
 	}
 
 	for i, gs := range ws.GitSources {
+		if gs.ReadOnly {
+			continue
+		}
 		for _, item := range gs.Items {
 			entries = append(entries, seedManifestEntry{
 				Source: fmt.Sprintf("%s%d/%s", gitSourceMountFn, i, item.RepoPath),
@@ -707,6 +717,100 @@ func injectSeedInitContainer(
 		return nil
 	}
 	return fmt.Errorf("claw deployment not found in manifests")
+}
+
+// injectReadOnlyWorkspaceMounts adds per-item read-only volumeMounts to the
+// gateway container for all workspace sources that have ReadOnly set to true.
+// Instead of seeding these files onto the PVC, they are mounted directly from
+// the source volume (config, ws-cm-*, ws-git-*), giving OS-level EROFS
+// enforcement that the OpenClaw process cannot circumvent.
+func injectReadOnlyWorkspaceMounts(objects []*unstructured.Unstructured, instance *clawv1alpha1.Claw) error {
+	ws := instance.Spec.Workspace
+	if ws == nil {
+		return nil
+	}
+
+	var mounts []any
+
+	for _, src := range ws.InlineSources {
+		if !src.ReadOnly {
+			continue
+		}
+		mounts = append(mounts, map[string]any{
+			"name":      "config",
+			"mountPath": workspaceMountPath + src.Path,
+			"subPath":   workspaceKeyPrefix + encodeWorkspacePath(src.Path),
+			"readOnly":  true,
+		})
+	}
+
+	for _, cms := range ws.ConfigMapSources {
+		if !cms.ReadOnly {
+			continue
+		}
+		volName := configMapSourceVolumeName(cms.ConfigMapRef.Name)
+		for _, item := range cms.Items {
+			mounts = append(mounts, map[string]any{
+				"name":      volName,
+				"mountPath": workspaceMountPath + item.Path,
+				"subPath":   item.Key,
+				"readOnly":  true,
+			})
+		}
+	}
+
+	for i, gs := range ws.GitSources {
+		if !gs.ReadOnly {
+			continue
+		}
+		volName := gitSourceVolumeName(i)
+		for _, item := range gs.Items {
+			mounts = append(mounts, map[string]any{
+				"name":      volName,
+				"mountPath": workspaceMountPath + item.Path,
+				"subPath":   item.RepoPath,
+				"readOnly":  true,
+			})
+		}
+	}
+
+	if len(mounts) == 0 {
+		return nil
+	}
+
+	gatewayName := getClawDeploymentName(instance.Name)
+	for _, obj := range objects {
+		if obj.GetKind() != DeploymentKind || obj.GetName() != gatewayName {
+			continue
+		}
+
+		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		if err != nil {
+			return fmt.Errorf("failed to get containers from gateway deployment: %w", err)
+		}
+		if !found {
+			return fmt.Errorf("containers field not found in gateway deployment")
+		}
+
+		for i, c := range containers {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(cm, "name"); name != ClawGatewayContainerName {
+				continue
+			}
+			volumeMounts, _, _ := unstructured.NestedSlice(cm, "volumeMounts")
+			volumeMounts = append(volumeMounts, mounts...)
+			if err := unstructured.SetNestedSlice(cm, volumeMounts, "volumeMounts"); err != nil {
+				return fmt.Errorf("failed to set volumeMounts on gateway container: %w", err)
+			}
+			containers[i] = cm
+			return unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers")
+		}
+		return fmt.Errorf("container %q not found in gateway deployment", ClawGatewayContainerName)
+	}
+	return fmt.Errorf("gateway deployment %s not found in manifests", gatewayName)
 }
 
 // injectSkillFiles validates skill names and writes _skill_ prefixed keys

--- a/internal/controller/claw_workspace_test.go
+++ b/internal/controller/claw_workspace_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -588,6 +589,95 @@ func TestGenerateSeedManifest(t *testing.T) {
 		assert.True(t, targets["custom-soul.md"])
 		assert.True(t, targets["TOOLS.md"])
 		assert.True(t, targets["AGENTS.md"], "builtin AGENTS.md should be present")
+	})
+
+	t.Run("should skip read-only inline sources", func(t *testing.T) {
+		entries := generateSeedManifest(&clawv1alpha1.WorkspaceSpec{
+			InlineSources: []clawv1alpha1.InlineSource{
+				{Path: "writable.md", Content: "w"},
+				{Path: "readonly.md", Content: "r", ReadOnly: true},
+			},
+		})
+		targets := map[string]bool{}
+		for _, e := range entries {
+			targets[e.Target] = true
+		}
+		assert.True(t, targets["writable.md"], "writable inline source should be in manifest")
+		assert.False(t, targets["readonly.md"], "read-only inline source should be excluded")
+	})
+
+	t.Run("should skip read-only configMap sources", func(t *testing.T) {
+		entries := generateSeedManifest(&clawv1alpha1.WorkspaceSpec{
+			ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+				{
+					ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "writable-cm"},
+					Items:        []clawv1alpha1.ConfigMapItem{{Key: "a", Path: "a.md"}},
+				},
+				{
+					ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "readonly-cm"},
+					ReadOnly:     true,
+					Items:        []clawv1alpha1.ConfigMapItem{{Key: "b", Path: "b.md"}},
+				},
+			},
+		})
+		targets := map[string]bool{}
+		for _, e := range entries {
+			targets[e.Target] = true
+		}
+		assert.True(t, targets["a.md"], "writable configMap item should be in manifest")
+		assert.False(t, targets["b.md"], "read-only configMap item should be excluded")
+	})
+
+	t.Run("should skip read-only git sources", func(t *testing.T) {
+		entries := generateSeedManifest(&clawv1alpha1.WorkspaceSpec{
+			GitSources: []clawv1alpha1.GitSource{
+				{
+					URL:   "https://example.com/writable.git",
+					Items: []clawv1alpha1.GitItem{{RepoPath: "a.md", Path: "a.md"}},
+				},
+				{
+					URL:      "https://example.com/readonly.git",
+					ReadOnly: true,
+					Items:    []clawv1alpha1.GitItem{{RepoPath: "b.md", Path: "b.md"}},
+				},
+			},
+		})
+		targets := map[string]bool{}
+		for _, e := range entries {
+			targets[e.Target] = true
+		}
+		assert.True(t, targets["a.md"], "writable git item should be in manifest")
+		assert.False(t, targets["b.md"], "read-only git item should be excluded")
+	})
+
+	t.Run("should skip all read-only sources in mixed spec", func(t *testing.T) {
+		entries := generateSeedManifest(&clawv1alpha1.WorkspaceSpec{
+			InlineSources: []clawv1alpha1.InlineSource{
+				{Path: "inline-rw.md", Content: "w"},
+				{Path: "inline-ro.md", Content: "r", ReadOnly: true},
+			},
+			ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+				{
+					ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "cm-ro"},
+					ReadOnly:     true,
+					Items:        []clawv1alpha1.ConfigMapItem{{Key: "k", Path: "cm-ro.md"}},
+				},
+			},
+			GitSources: []clawv1alpha1.GitSource{
+				{
+					URL:   "https://example.com/rw.git",
+					Items: []clawv1alpha1.GitItem{{RepoPath: "g.md", Path: "git-rw.md"}},
+				},
+			},
+		})
+		targets := map[string]bool{}
+		for _, e := range entries {
+			targets[e.Target] = true
+		}
+		assert.True(t, targets["inline-rw.md"])
+		assert.False(t, targets["inline-ro.md"])
+		assert.False(t, targets["cm-ro.md"])
+		assert.True(t, targets["git-rw.md"])
 	})
 
 	t.Run("should use correct git source index for multiple git sources", func(t *testing.T) {
@@ -1578,6 +1668,213 @@ func TestInjectSeedInitContainer(t *testing.T) {
 	})
 }
 
+// --- injectReadOnlyWorkspaceMounts tests ---
+
+func TestInjectReadOnlyWorkspaceMounts(t *testing.T) {
+	t.Run("should be no-op when workspace is nil", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec:       clawv1alpha1.ClawSpec{},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+	})
+
+	t.Run("should be no-op when no sources are read-only", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					InlineSources: []clawv1alpha1.InlineSource{
+						{Path: "SOUL.md", Content: "soul"},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		assert.Empty(t, mounts, "no mounts should be added when nothing is read-only")
+	})
+
+	t.Run("should mount read-only inline source from config volume", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					InlineSources: []clawv1alpha1.InlineSource{
+						{Path: "docs/POLICY.md", Content: "policy", ReadOnly: true},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		require.Len(t, mounts, 1)
+
+		m := mounts[0].(map[string]any)
+		assert.Equal(t, "config", m["name"])
+		assert.Equal(t, "/home/node/.openclaw/workspace/docs/POLICY.md", m["mountPath"])
+		assert.Equal(t, "_ws_docs--POLICY.md", m["subPath"])
+		assert.Equal(t, true, m["readOnly"])
+	})
+
+	t.Run("should mount read-only configMap source items", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+						{
+							ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "compliance-docs"},
+							ReadOnly:     true,
+							Items: []clawv1alpha1.ConfigMapItem{
+								{Key: "rules.md", Path: "docs/rules.md"},
+								{Key: "policy.md", Path: "docs/policy.md"},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		require.Len(t, mounts, 2)
+
+		m0 := mounts[0].(map[string]any)
+		assert.Equal(t, "ws-cm-compliance-docs", m0["name"])
+		assert.Equal(t, "/home/node/.openclaw/workspace/docs/rules.md", m0["mountPath"])
+		assert.Equal(t, "rules.md", m0["subPath"])
+		assert.Equal(t, true, m0["readOnly"])
+
+		m1 := mounts[1].(map[string]any)
+		assert.Equal(t, "ws-cm-compliance-docs", m1["name"])
+		assert.Equal(t, "/home/node/.openclaw/workspace/docs/policy.md", m1["mountPath"])
+		assert.Equal(t, "policy.md", m1["subPath"])
+		assert.Equal(t, true, m1["readOnly"])
+	})
+
+	t.Run("should mount read-only git source items", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					GitSources: []clawv1alpha1.GitSource{
+						{
+							URL:      "https://example.com/repo.git",
+							ReadOnly: true,
+							Items: []clawv1alpha1.GitItem{
+								{RepoPath: "policies/guide.md", Path: "guide.md"},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		require.Len(t, mounts, 1)
+
+		m := mounts[0].(map[string]any)
+		assert.Equal(t, "ws-git-0", m["name"])
+		assert.Equal(t, "/home/node/.openclaw/workspace/guide.md", m["mountPath"])
+		assert.Equal(t, "policies/guide.md", m["subPath"])
+		assert.Equal(t, true, m["readOnly"])
+	})
+
+	t.Run("should use correct git source index with mixed read-only", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					GitSources: []clawv1alpha1.GitSource{
+						{
+							URL:   "https://example.com/writable.git",
+							Items: []clawv1alpha1.GitItem{{RepoPath: "a.md", Path: "a.md"}},
+						},
+						{
+							URL:      "https://example.com/readonly.git",
+							ReadOnly: true,
+							Items:    []clawv1alpha1.GitItem{{RepoPath: "b.md", Path: "b.md"}},
+						},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		require.Len(t, mounts, 1)
+
+		m := mounts[0].(map[string]any)
+		assert.Equal(t, "ws-git-1", m["name"], "should use index 1, not 0")
+	})
+
+	t.Run("should handle mixed read-only and writable sources", func(t *testing.T) {
+		dep := makeTestDeployment()
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName},
+			Spec: clawv1alpha1.ClawSpec{
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					InlineSources: []clawv1alpha1.InlineSource{
+						{Path: "writable.md", Content: "w"},
+						{Path: "readonly.md", Content: "r", ReadOnly: true},
+					},
+					ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+						{
+							ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "rw-cm"},
+							Items:        []clawv1alpha1.ConfigMapItem{{Key: "k", Path: "rw.md"}},
+						},
+						{
+							ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "ro-cm"},
+							ReadOnly:     true,
+							Items:        []clawv1alpha1.ConfigMapItem{{Key: "k", Path: "ro.md"}},
+						},
+					},
+				},
+			},
+		}
+		err := injectReadOnlyWorkspaceMounts([]*unstructured.Unstructured{dep}, instance)
+		require.NoError(t, err)
+
+		containers, _, _ := unstructured.NestedSlice(dep.Object, "spec", "template", "spec", "containers")
+		gateway := containers[0].(map[string]any)
+		mounts, _, _ := unstructured.NestedSlice(gateway, "volumeMounts")
+		require.Len(t, mounts, 2, "should only mount read-only sources")
+
+		mountPaths := make([]string, len(mounts))
+		for i, m := range mounts {
+			mountPaths[i] = m.(map[string]any)["mountPath"].(string)
+		}
+		assert.Contains(t, mountPaths, "/home/node/.openclaw/workspace/readonly.md")
+		assert.Contains(t, mountPaths, "/home/node/.openclaw/workspace/ro.md")
+	})
+}
+
 // --- Integration tests ---
 
 func TestWorkspaceIntegration(t *testing.T) {
@@ -1972,5 +2269,331 @@ func TestWorkspaceIntegration(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "SOUL.md")
 		assert.Contains(t, err.Error(), "inline source")
+	})
+
+	t.Run("read-only inline source should mount directly on gateway and be excluded from seed manifest", func(t *testing.T) {
+		ctx := context.Background()
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
+			Spec: clawv1alpha1.ClawSpec{
+				Credentials: testCredentials(),
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					InlineSources: []clawv1alpha1.InlineSource{
+						{Path: "POLICY.md", Content: "# Do not modify", ReadOnly: true},
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify seed manifest excludes the read-only entry
+		var cm corev1.ConfigMap
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getConfigMapName(testInstanceName),
+			Namespace: namespace,
+		}, &cm))
+
+		var manifest []seedManifestEntry
+		require.NoError(t, json.Unmarshal([]byte(cm.Data[seedManifestKey]), &manifest))
+		for _, e := range manifest {
+			assert.NotEqual(t, "POLICY.md", e.Target, "read-only file should not appear in seed manifest")
+		}
+
+		// Verify the _ws_ key is still in the ConfigMap (needed for the volume mount)
+		assert.Equal(t, "# Do not modify", cm.Data["_ws_POLICY.md"],
+			"inline content should still be injected into ConfigMap for the volume mount")
+
+		// Verify gateway deployment has a read-only volumeMount
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(testInstanceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "Deployment should be created")
+
+		var gatewayContainer *corev1.Container
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == ClawGatewayContainerName {
+				gatewayContainer = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, gatewayContainer, "gateway container should exist")
+
+		var roMount *corev1.VolumeMount
+		for i := range gatewayContainer.VolumeMounts {
+			if gatewayContainer.VolumeMounts[i].MountPath == "/home/node/.openclaw/workspace/POLICY.md" {
+				roMount = &gatewayContainer.VolumeMounts[i]
+				break
+			}
+		}
+		require.NotNil(t, roMount, "read-only volumeMount for POLICY.md should exist on gateway")
+		assert.Equal(t, "config", roMount.Name, "should mount from config volume")
+		assert.Equal(t, "_ws_POLICY.md", roMount.SubPath, "subPath should be the encoded key")
+		assert.True(t, roMount.ReadOnly, "mount must be read-only")
+	})
+
+	t.Run("read-only configMap source should mount directly on gateway and be excluded from seed manifest", func(t *testing.T) {
+		ctx := context.Background()
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		wsCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "ro-compliance", Namespace: namespace},
+			Data:       map[string]string{"rules.md": "# Compliance Rules"},
+		}
+		require.NoError(t, k8sClient.Create(ctx, wsCM))
+
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
+			Spec: clawv1alpha1.ClawSpec{
+				Credentials: testCredentials(),
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+						{
+							ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "ro-compliance"},
+							ReadOnly:     true,
+							Items: []clawv1alpha1.ConfigMapItem{
+								{Key: "rules.md", Path: "docs/rules.md"},
+							},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(ctx, wsCM)
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify seed manifest excludes the read-only entry
+		var cm corev1.ConfigMap
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getConfigMapName(testInstanceName),
+			Namespace: namespace,
+		}, &cm))
+
+		var manifest []seedManifestEntry
+		require.NoError(t, json.Unmarshal([]byte(cm.Data[seedManifestKey]), &manifest))
+		for _, e := range manifest {
+			assert.NotEqual(t, "docs/rules.md", e.Target, "read-only file should not appear in seed manifest")
+		}
+
+		// Verify gateway deployment has a read-only volumeMount
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(testInstanceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "Deployment should be created")
+
+		var gatewayContainer *corev1.Container
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == ClawGatewayContainerName {
+				gatewayContainer = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, gatewayContainer, "gateway container should exist")
+
+		var roMount *corev1.VolumeMount
+		for i := range gatewayContainer.VolumeMounts {
+			if gatewayContainer.VolumeMounts[i].MountPath == "/home/node/.openclaw/workspace/docs/rules.md" {
+				roMount = &gatewayContainer.VolumeMounts[i]
+				break
+			}
+		}
+		require.NotNil(t, roMount, "read-only volumeMount for docs/rules.md should exist on gateway")
+		assert.Equal(t, "ws-cm-ro-compliance", roMount.Name, "should mount from the ConfigMap volume")
+		assert.Equal(t, "rules.md", roMount.SubPath, "subPath should be the ConfigMap key")
+		assert.True(t, roMount.ReadOnly, "mount must be read-only")
+	})
+
+	t.Run("read-only git source should mount directly on gateway and be excluded from seed manifest", func(t *testing.T) {
+		ctx := context.Background()
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
+			Spec: clawv1alpha1.ClawSpec{
+				Credentials: testCredentials(),
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					GitSources: []clawv1alpha1.GitSource{
+						{
+							URL:      "https://git.example.com/team/policies.git",
+							Ref:      "main",
+							ReadOnly: true,
+							Items: []clawv1alpha1.GitItem{
+								{RepoPath: "policies/guide.md", Path: "guide.md"},
+							},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+		t.Cleanup(func() { deleteAndWaitAllResources(t, namespace) })
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify seed manifest excludes the read-only entry
+		var cm corev1.ConfigMap
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getConfigMapName(testInstanceName),
+			Namespace: namespace,
+		}, &cm))
+
+		var manifest []seedManifestEntry
+		require.NoError(t, json.Unmarshal([]byte(cm.Data[seedManifestKey]), &manifest))
+		for _, e := range manifest {
+			assert.NotEqual(t, "guide.md", e.Target, "read-only file should not appear in seed manifest")
+		}
+
+		// Verify gateway deployment has a read-only volumeMount
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(testInstanceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "Deployment should be created")
+
+		var gatewayContainer *corev1.Container
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == ClawGatewayContainerName {
+				gatewayContainer = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, gatewayContainer, "gateway container should exist")
+
+		var roMount *corev1.VolumeMount
+		for i := range gatewayContainer.VolumeMounts {
+			if gatewayContainer.VolumeMounts[i].MountPath == "/home/node/.openclaw/workspace/guide.md" {
+				roMount = &gatewayContainer.VolumeMounts[i]
+				break
+			}
+		}
+		require.NotNil(t, roMount, "read-only volumeMount for guide.md should exist on gateway")
+		assert.Equal(t, "ws-git-0", roMount.Name, "should mount from git emptyDir volume")
+		assert.Equal(t, "policies/guide.md", roMount.SubPath, "subPath should be the repo path")
+		assert.True(t, roMount.ReadOnly, "mount must be read-only")
+	})
+
+	t.Run("mixed read-only and writable sources should only mount read-only files on gateway", func(t *testing.T) {
+		ctx := context.Background()
+
+		secret := createTestAPIKeySecret(aiModelSecret, namespace, aiModelSecretKey, aiModelSecretValue)
+		require.NoError(t, k8sClient.Create(ctx, secret))
+
+		wsCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "mixed-cm", Namespace: namespace},
+			Data:       map[string]string{"policy.md": "# Policy"},
+		}
+		require.NoError(t, k8sClient.Create(ctx, wsCM))
+
+		instance := &clawv1alpha1.Claw{
+			ObjectMeta: metav1.ObjectMeta{Name: testInstanceName, Namespace: namespace},
+			Spec: clawv1alpha1.ClawSpec{
+				Credentials: testCredentials(),
+				Workspace: &clawv1alpha1.WorkspaceSpec{
+					InlineSources: []clawv1alpha1.InlineSource{
+						{Path: "SOUL.md", Content: "# Soul (writable)"},
+						{Path: "RULES.md", Content: "# Rules (read-only)", ReadOnly: true},
+					},
+					ConfigMapSources: []clawv1alpha1.ConfigMapSource{
+						{
+							ConfigMapRef: clawv1alpha1.ConfigMapRef{Name: "mixed-cm"},
+							ReadOnly:     true,
+							Items: []clawv1alpha1.ConfigMapItem{
+								{Key: "policy.md", Path: "docs/policy.md"},
+							},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, instance))
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(ctx, wsCM)
+			deleteAndWaitAllResources(t, namespace)
+		})
+
+		reconciler := createClawReconciler()
+		reconcileClaw(t, ctx, reconciler, testInstanceName, namespace)
+
+		// Verify seed manifest contains writable but not read-only entries
+		var cm corev1.ConfigMap
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{
+			Name:      getConfigMapName(testInstanceName),
+			Namespace: namespace,
+		}, &cm))
+
+		var manifest []seedManifestEntry
+		require.NoError(t, json.Unmarshal([]byte(cm.Data[seedManifestKey]), &manifest))
+		manifestTargets := map[string]bool{}
+		for _, e := range manifest {
+			manifestTargets[e.Target] = true
+		}
+		assert.True(t, manifestTargets["SOUL.md"], "writable inline source should be in seed manifest")
+		assert.False(t, manifestTargets["RULES.md"], "read-only inline source should NOT be in seed manifest")
+		assert.False(t, manifestTargets["docs/policy.md"], "read-only configMap item should NOT be in seed manifest")
+
+		// Verify gateway deployment has read-only mounts only for read-only sources
+		deployment := &appsv1.Deployment{}
+		waitFor(t, timeout, interval, func() bool {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Name:      getClawDeploymentName(testInstanceName),
+				Namespace: namespace,
+			}, deployment) == nil
+		}, "Deployment should be created")
+
+		var gatewayContainer *corev1.Container
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == ClawGatewayContainerName {
+				gatewayContainer = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, gatewayContainer, "gateway container should exist")
+
+		mountsByPath := map[string]corev1.VolumeMount{}
+		for _, vm := range gatewayContainer.VolumeMounts {
+			mountsByPath[vm.MountPath] = vm
+		}
+
+		// Read-only inline source should have a read-only mount
+		rulesMount, ok := mountsByPath["/home/node/.openclaw/workspace/RULES.md"]
+		require.True(t, ok, "read-only RULES.md should have a volumeMount")
+		assert.True(t, rulesMount.ReadOnly, "RULES.md mount must be read-only")
+		assert.Equal(t, "config", rulesMount.Name)
+
+		// Read-only configMap source should have a read-only mount
+		policyMount, ok := mountsByPath["/home/node/.openclaw/workspace/docs/policy.md"]
+		require.True(t, ok, "read-only docs/policy.md should have a volumeMount")
+		assert.True(t, policyMount.ReadOnly, "docs/policy.md mount must be read-only")
+		assert.Equal(t, "ws-cm-mixed-cm", policyMount.Name)
+
+		// Writable inline source should NOT have a direct workspace mount
+		_, hasSoulMount := mountsByPath["/home/node/.openclaw/workspace/SOUL.md"]
+		assert.False(t, hasSoulMount, "writable SOUL.md should NOT have a direct workspace volumeMount (it's seeded via PVC)")
 	})
 }

--- a/openspec/changes/archive/2026-07-15-read-only-workspace-sources/design.md
+++ b/openspec/changes/archive/2026-07-15-read-only-workspace-sources/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Workspace sources (introduced in commit 9e9fb364) seed files from inline content, ConfigMaps, and Git repos into the OpenClaw workspace on the PVC. The seeding flow is: source volumes are mounted on init containers, the `init-seed` container reads a manifest and copies files to the PVC, and the gateway container reads/writes the PVC at runtime.
+
+All three source types already have pod-level volumes defined:
+- **Inline**: content baked into the gateway ConfigMap (`config` volume) as `_ws_<encoded-path>` keys
+- **ConfigMap**: dedicated `ws-cm-<name>` volumes
+- **Git**: `ws-git-<index>` emptyDir volumes populated by `init-git-sync`
+
+The `mode` field (overwrite/seedIfMissing) controls re-seeding behavior on restart, but nothing prevents the OpenClaw process from modifying seeded files during runtime.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent the OpenClaw process from modifying operator-managed workspace files at runtime
+- Use OS-level enforcement (not just file permissions) so protection cannot be circumvented
+- Support read-only mode for all three source types (inline, ConfigMap, Git)
+- Keep the API simple: one `readOnly` bool per source, all items inherit it
+
+**Non-Goals:**
+- Per-item read-only control (can be added later if needed)
+- Read-only directories beyond what individual file mounts provide
+- Protecting files that live on the PVC (read-only requires bypassing the PVC)
+
+## Decisions
+
+### 1. Read-only via direct volume mounts, not PVC seeding
+
+When `readOnly: true`, skip the PVC seed manifest entry entirely and instead mount the source volume directly into the gateway container at the workspace target path with `readOnly: true`.
+
+**Rationale:** Kubernetes read-only volume mounts return `EROFS` on any write attempt. This is OS-level enforcement that cannot be circumvented by the process regardless of UID or capabilities. File permission approaches (`chmod 444`) would be bypassable since the same UID owns the files.
+
+**Trade-off:** Files are volume mounts, not PVC copies. They cannot be modified by the user or agent under any circumstances. This is the desired behavior.
+
+### 2. Reuse existing volumes
+
+Each source type already has a pod-level volume. Read-only mounts add volumeMounts to the gateway container from these existing volumes using `subPath` to target individual files.
+
+| Source Type    | Volume           | Gateway volumeMount subPath  |
+|----------------|------------------|------------------------------|
+| InlineSource   | `config`         | `_ws_<encoded-path>`         |
+| ConfigMapSource| `ws-cm-<name>`   | `<item.Key>`                 |
+| GitSource      | `ws-git-<index>` | `<item.RepoPath>`            |
+
+All mounts target `mountPath: /home/node/.openclaw/workspace/<target-path>`.
+
+**Rationale:** No new volumes, volume types, or pod-level changes needed. The volumes exist because the init containers already use them for seeding.
+
+### 3. `readOnly` field at source level only
+
+A single `ReadOnly bool` on each source type. All items in that source inherit it. No per-item override.
+
+```go
+type InlineSource struct {
+    Path     string   `json:"path"`
+    Content  string   `json:"content"`
+    Mode     SeedMode `json:"mode,omitempty"`
+    ReadOnly bool     `json:"readOnly,omitempty"`
+}
+
+type ConfigMapSource struct {
+    ConfigMapRef ConfigMapRef    `json:"configMapRef"`
+    Items        []ConfigMapItem `json:"items"`
+    Mode         SeedMode        `json:"mode,omitempty"`
+    ReadOnly     bool            `json:"readOnly,omitempty"`
+}
+
+type GitSource struct {
+    URL       string         `json:"url"`
+    Ref       string         `json:"ref,omitempty"`
+    SecretRef *SecretRefEntry `json:"secretRef,omitempty"`
+    Items     []GitItem      `json:"items"`
+    Mode      SeedMode        `json:"mode,omitempty"`
+    ReadOnly  bool            `json:"readOnly,omitempty"`
+}
+```
+
+**Rationale:** Simpler API, covers the primary use case (a whole source is managed reference content). If per-item control is ever needed, the same ConfigMap can be split into two `ConfigMapSource` entries — one read-only, one writable.
+
+### 4. `mode` is silently ignored when `readOnly: true`
+
+The `mode` field (overwrite/seedIfMissing) controls PVC seeding behavior. When `readOnly: true`, there is no PVC seeding — the file is always the current source version via a direct mount. Rather than rejecting the combination with a validation error, `mode` is simply ignored.
+
+**Rationale:** Reduces friction. Users setting source-level defaults for `mode` shouldn't have to remove them when enabling `readOnly`. The behavior is unambiguous regardless.
+
+### 5. `subPath` mounts (no live ConfigMap update propagation)
+
+Kubernetes only propagates ConfigMap updates to full-volume mounts, not `subPath` mounts. Read-only files from inline and ConfigMap sources will require a pod restart to pick up changes. This is consistent with the existing config-hash rollout mechanism that triggers restarts when the gateway ConfigMap changes.
+
+**Rationale:** Using `subPath` is necessary to mount individual files into specific workspace paths without shadowing the entire directory. The restart-on-change behavior is already handled by `stampGatewayConfigHash`.
+
+## Risks / Trade-offs
+
+**[Risk] Volume mount count grows with read-only files** — Each read-only file adds one volumeMount to the gateway container. Kubernetes handles many mounts well, but very large numbers (100+) could affect pod startup time. Mitigation: this is unlikely in practice; typical use cases involve a handful of managed files.
+
+**[Risk] Parent directory creation for deeply nested paths** — A read-only file at `docs/policies/guide.md` requires intermediate directories. The kubelet creates mount-point parent directories automatically, so this should work. Worth validating in e2e tests.
+
+**[Risk] Path conflicts between read-only mounts and PVC** — A read-only mount overlays the PVC at that specific path. If a previous (non-read-only) run seeded the file to the PVC, the old PVC copy becomes invisible (shadowed by the mount) but still consumes disk. Not harmful, but the stale copy remains on the PVC.

--- a/openspec/changes/archive/2026-07-15-read-only-workspace-sources/proposal.md
+++ b/openspec/changes/archive/2026-07-15-read-only-workspace-sources/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Workspace sources (inline, ConfigMap, Git) currently seed files onto the PVC, where the OpenClaw process can freely modify or delete them at runtime. For managed reference files (company policies, compliance docs, skill definitions, curated configs), the operator needs a way to guarantee the files remain untouched — preventing both accidental and intentional edits by the agent.
+
+The existing `mode: overwrite` re-seeds on restart but does not protect files during runtime.
+
+## What Changes
+
+- Add a `readOnly` boolean field to `InlineSource`, `ConfigMapSource`, and `GitSource`
+- When `readOnly: true`, bypass PVC seeding entirely and mount source files directly into the gateway container's workspace path using Kubernetes read-only volume mounts (OS-level enforcement via `EROFS`)
+- Reuse existing pod volumes — no new volume types needed
+
+## Capabilities
+
+### Modified Capabilities
+
+- `workspace-sources`: Adds `readOnly` field at the source level for all three source types. When set, items are mounted directly into the workspace via read-only Kubernetes volume mounts instead of being seeded onto the PVC.
+
+## Impact
+
+- **API**: New `ReadOnly bool` field on `InlineSource`, `ConfigMapSource`, `GitSource` in `api/v1alpha1/claw_types.go`
+- **CRD**: Regenerated CRD YAML (`make manifests`, `make generate`)
+- **Controller**: New `injectReadOnlyWorkspaceMounts()` function adds per-item volumeMounts to the gateway container; `generateSeedManifest()` skips read-only entries
+- **Reconciler**: Call new injection function in phase 3 (alongside existing `inject*` calls)
+- **Spec**: Updated `workspace-sources` spec with new read-only requirements and scenarios
+- **Tests**: New test cases in `claw_workspace_test.go` covering all three source types, mixed read-only/writable sources, and volume mount verification

--- a/openspec/changes/archive/2026-07-15-read-only-workspace-sources/specs/workspace-sources/spec.md
+++ b/openspec/changes/archive/2026-07-15-read-only-workspace-sources/specs/workspace-sources/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Source-level read-only mode
+The system SHALL support a `readOnly` boolean field on `InlineSource`, `ConfigMapSource`, and `GitSource`. When `readOnly: true`, all items in that source SHALL be mounted directly into the gateway container's workspace path via Kubernetes read-only volume mounts, bypassing PVC seeding entirely.
+
+#### Scenario: Read-only inline source is mounted directly
+- **GIVEN** a Claw CR with an inline source `{path: "POLICY.md", content: "Do not delete", readOnly: true}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `config` volume at `/home/node/.openclaw/workspace/POLICY.md` with `subPath: _ws_POLICY--md` (or equivalent encoded path) and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `POLICY.md`
+
+#### Scenario: Read-only ConfigMap source is mounted directly
+- **GIVEN** a ConfigMap `compliance-docs` with key `rules.md` containing "Compliance rules"
+- **AND** a Claw CR with a ConfigMap source referencing `compliance-docs` with `readOnly: true` and item `{key: rules.md, path: docs/rules.md}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `ws-cm-compliance-docs` volume at `/home/node/.openclaw/workspace/docs/rules.md` with `subPath: rules.md` and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `docs/rules.md`
+
+#### Scenario: Read-only Git source is mounted directly
+- **GIVEN** a Claw CR with a git source at index 0 with `readOnly: true` and item `{repoPath: "policies/guide.md", path: "guide.md"}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `ws-git-0` volume at `/home/node/.openclaw/workspace/guide.md` with `subPath: policies/guide.md` and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `guide.md`
+
+#### Scenario: Read-only files cannot be written by the OpenClaw process
+- **GIVEN** a read-only workspace source is mounted
+- **WHEN** the OpenClaw process attempts to write to the file
+- **THEN** the write SHALL fail with a read-only filesystem error (EROFS)
+
+#### Scenario: Mode field is ignored when readOnly is true
+- **GIVEN** a ConfigMap source with `readOnly: true` and `mode: seedIfMissing`
+- **WHEN** the controller reconciles
+- **THEN** the file SHALL be mounted read-only (mode has no effect since PVC seeding is bypassed)
+
+#### Scenario: Mixed read-only and writable sources
+- **GIVEN** a Claw CR with a read-only ConfigMap source targeting `POLICY.md` and a writable inline source targeting `SOUL.md`
+- **WHEN** the controller reconciles
+- **THEN** `POLICY.md` SHALL be a read-only volume mount on the gateway container
+- **AND** `SOUL.md` SHALL be seeded onto the PVC via the seed manifest (writable)
+
+#### Scenario: Read-only source with multiple items
+- **GIVEN** a ConfigMap source with `readOnly: true` and items `[{key: a.md, path: a.md}, {key: b.md, path: b.md}]`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have read-only volumeMounts for both `a.md` and `b.md`
+
+#### Scenario: Path conflict between read-only and writable sources
+- **GIVEN** a read-only inline source with `path: "SOUL.md"` and a writable ConfigMap source item with `path: "SOUL.md"`
+- **WHEN** the controller reconciles
+- **THEN** the Ready condition SHALL be False with a message indicating the path conflict

--- a/openspec/changes/archive/2026-07-15-read-only-workspace-sources/tasks.md
+++ b/openspec/changes/archive/2026-07-15-read-only-workspace-sources/tasks.md
@@ -1,0 +1,34 @@
+## 1. Update API Types
+
+- [x] 1.1 Add `ReadOnly bool` field with `json:"readOnly,omitempty"` tag to `InlineSource` in `api/v1alpha1/claw_types.go`
+- [x] 1.2 Add `ReadOnly bool` field with `json:"readOnly,omitempty"` tag to `ConfigMapSource` in `api/v1alpha1/claw_types.go`
+- [x] 1.3 Add `ReadOnly bool` field with `json:"readOnly,omitempty"` tag to `GitSource` in `api/v1alpha1/claw_types.go`
+- [x] 1.4 Run `make generate` to regenerate DeepCopy methods
+- [x] 1.5 Run `make manifests` to regenerate CRD YAML
+
+## 2. Skip Read-Only Entries in Seed Manifest
+
+- [x] 2.1 Update `generateSeedManifest()` in `claw_workspace.go` to skip inline sources where `ReadOnly == true`
+- [x] 2.2 Update `generateSeedManifest()` to skip ConfigMap source items where the parent ConfigMapSource has `ReadOnly == true`
+- [x] 2.3 Update `generateSeedManifest()` to skip Git source items where the parent GitSource has `ReadOnly == true`
+- [x] 2.4 Add unit tests verifying read-only entries are excluded from the manifest while writable entries remain
+
+## 3. Inject Read-Only Volume Mounts on Gateway Container
+
+- [x] 3.1 Implement `injectReadOnlyWorkspaceMounts()` in `claw_workspace.go` that adds per-item volumeMounts to the gateway container for all read-only sources
+- [x] 3.2 For read-only inline sources: mount from `config` volume with `subPath: _ws_<encoded-path>`, `readOnly: true`
+- [x] 3.3 For read-only ConfigMap sources: mount from `ws-cm-<name>` volume with `subPath: <item.Key>`, `readOnly: true`
+- [x] 3.4 For read-only Git sources: mount from `ws-git-<index>` volume with `subPath: <item.RepoPath>`, `readOnly: true`
+- [x] 3.5 All mounts target `mountPath: /home/node/.openclaw/workspace/<target-path>`
+- [x] 3.6 Add unit tests verifying correct volumeMounts are added for each source type
+- [x] 3.7 Add unit test for mixed read-only and writable sources in the same spec
+
+## 4. Wire Into Reconciler
+
+- [x] 4.1 Call `injectReadOnlyWorkspaceMounts()` in phase 3 of `claw_resource_controller.go` (alongside existing `inject*` calls)
+
+## 5. Verification
+
+- [x] 5.1 Run `make build` to verify compilation
+- [x] 5.2 Run `make lint` to verify linting passes
+- [x] 5.3 Run `make test` to verify all tests pass (existing + new)

--- a/openspec/specs/workspace-sources/spec.md
+++ b/openspec/specs/workspace-sources/spec.md
@@ -149,3 +149,51 @@ The operator SHALL read a `GIT_SYNC_IMAGE` environment variable to configure the
 - **GIVEN** the operator is deployed with `GIT_SYNC_IMAGE=registry.corp.com/alpine/git:2.47`
 - **WHEN** the controller creates an init-git-sync container
 - **THEN** the container image SHALL be `registry.corp.com/alpine/git:2.47`
+
+### Requirement: Source-level read-only mode
+The system SHALL support a `readOnly` boolean field on `InlineSource`, `ConfigMapSource`, and `GitSource`. When `readOnly: true`, all items in that source SHALL be mounted directly into the gateway container's workspace path via Kubernetes read-only volume mounts, bypassing PVC seeding entirely.
+
+#### Scenario: Read-only inline source is mounted directly
+- **GIVEN** a Claw CR with an inline source `{path: "POLICY.md", content: "Do not delete", readOnly: true}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `config` volume at `/home/node/.openclaw/workspace/POLICY.md` with `subPath: _ws_POLICY--md` (or equivalent encoded path) and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `POLICY.md`
+
+#### Scenario: Read-only ConfigMap source is mounted directly
+- **GIVEN** a ConfigMap `compliance-docs` with key `rules.md` containing "Compliance rules"
+- **AND** a Claw CR with a ConfigMap source referencing `compliance-docs` with `readOnly: true` and item `{key: rules.md, path: docs/rules.md}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `ws-cm-compliance-docs` volume at `/home/node/.openclaw/workspace/docs/rules.md` with `subPath: rules.md` and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `docs/rules.md`
+
+#### Scenario: Read-only Git source is mounted directly
+- **GIVEN** a Claw CR with a git source at index 0 with `readOnly: true` and item `{repoPath: "policies/guide.md", path: "guide.md"}`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have a volumeMount from the `ws-git-0` volume at `/home/node/.openclaw/workspace/guide.md` with `subPath: policies/guide.md` and `readOnly: true`
+- **AND** the seed manifest SHALL NOT contain an entry for `guide.md`
+
+#### Scenario: Read-only files cannot be written by the OpenClaw process
+- **GIVEN** a read-only workspace source is mounted
+- **WHEN** the OpenClaw process attempts to write to the file
+- **THEN** the write SHALL fail with a read-only filesystem error (EROFS)
+
+#### Scenario: Mode field is ignored when readOnly is true
+- **GIVEN** a ConfigMap source with `readOnly: true` and `mode: seedIfMissing`
+- **WHEN** the controller reconciles
+- **THEN** the file SHALL be mounted read-only (mode has no effect since PVC seeding is bypassed)
+
+#### Scenario: Mixed read-only and writable sources
+- **GIVEN** a Claw CR with a read-only ConfigMap source targeting `POLICY.md` and a writable inline source targeting `SOUL.md`
+- **WHEN** the controller reconciles
+- **THEN** `POLICY.md` SHALL be a read-only volume mount on the gateway container
+- **AND** `SOUL.md` SHALL be seeded onto the PVC via the seed manifest (writable)
+
+#### Scenario: Read-only source with multiple items
+- **GIVEN** a ConfigMap source with `readOnly: true` and items `[{key: a.md, path: a.md}, {key: b.md, path: b.md}]`
+- **WHEN** the controller reconciles
+- **THEN** the gateway container SHALL have read-only volumeMounts for both `a.md` and `b.md`
+
+#### Scenario: Path conflict between read-only and writable sources
+- **GIVEN** a read-only inline source with `path: "SOUL.md"` and a writable ConfigMap source item with `path: "SOUL.md"`
+- **WHEN** the controller reconciles
+- **THEN** the Ready condition SHALL be False with a message indicating the path conflict

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -108,6 +108,24 @@ func WithConfigMapSources(configMapSources ...v1alpha1.ConfigMapSource) ClawSpec
 	}
 }
 
+func WithInlineSources(inlineSources ...v1alpha1.InlineSource) ClawSpecOption {
+	return func(spec *v1alpha1.ClawSpec) {
+		if spec.Workspace == nil {
+			spec.Workspace = &v1alpha1.WorkspaceSpec{}
+		}
+		spec.Workspace.InlineSources = inlineSources
+	}
+}
+
+func WithSkipBootstrap() ClawSpecOption {
+	return func(spec *v1alpha1.ClawSpec) {
+		if spec.Workspace == nil {
+			spec.Workspace = &v1alpha1.WorkspaceSpec{}
+		}
+		spec.Workspace.SkipBootstrap = true
+	}
+}
+
 func newClawYAML(t *testing.T, opts ...ClawSpecOption) []byte {
 	t.Helper()
 	claw := &v1alpha1.Claw{
@@ -2326,6 +2344,295 @@ spec:
 				"init-git-sync should come after wait-for-proxy")
 			assert.Greater(t, seedIdx, gitSyncIdx,
 				"init-seed should come after init-git-sync")
+		})
+
+		t.Run("should mount read-only inline source as immutable file in workspace", func(t *testing.T) {
+			require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			createLabeledSecret(t, "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value")
+
+			t.Log("applying Claw CR with read-only inline source")
+			crFile := filepath.Join("/tmp", "claw-e2e-ro-inline.yaml")
+			clawYAML := newClawYAML(t,
+				WithGeminiCredentials("gemini-api-key", "api-key"),
+				WithSkipBootstrap(),
+				WithInlineSources(
+					v1alpha1.InlineSource{
+						Path:     "POLICY.md",
+						Content:  "# Immutable Policy\nDo not modify.",
+						ReadOnly: true,
+					},
+					v1alpha1.InlineSource{
+						Path:    "SOUL.md",
+						Content: "# Writable Soul\nFeel free to edit.",
+					},
+				))
+			err := os.WriteFile(crFile, clawYAML, os.FileMode(0o644))
+			require.NoError(t, err)
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True")
+
+			t.Log("waiting for gateway pod Running")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw",
+						"-o", "jsonpath={.items[0].status.phase}", "-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == podPhaseRunning, nil
+				})
+			require.NoError(t, err, "Gateway pod did not reach Running")
+
+			cmd = exec.Command("kubectl", "get", "pods", "-l", "app=claw",
+				"-o", "jsonpath={.items[0].metadata.name}", "-n", userNamespace)
+			podName, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+
+			t.Log("verifying read-only POLICY.md has correct content")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "cat", "/home/node/.openclaw/workspace/POLICY.md")
+			content, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to read POLICY.md")
+			assert.Equal(t, "# Immutable Policy\nDo not modify.", strings.TrimRight(content, "\n"))
+
+			t.Log("verifying POLICY.md is NOT writable (write attempt should fail with read-only filesystem error)")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "sh", "-c",
+				"echo 'tampered' > /home/node/.openclaw/workspace/POLICY.md 2>&1 || echo 'WRITE_FAILED'")
+			writeOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Contains(t, writeOutput, "WRITE_FAILED",
+				"writing to read-only POLICY.md should fail")
+
+			t.Log("verifying writable SOUL.md IS writable")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "sh", "-c",
+				"echo 'modified' > /home/node/.openclaw/workspace/SOUL.md && cat /home/node/.openclaw/workspace/SOUL.md")
+			writableOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Contains(t, writableOutput, "modified",
+				"writable SOUL.md should be modifiable")
+
+			t.Log("verifying seed manifest excludes read-only entry but includes writable entry")
+			cmd = exec.Command("kubectl", "get", "configmap", configMapName,
+				"-o", "jsonpath={.data._seed_manifest\\.json}", "-n", userNamespace)
+			manifestJSON, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.NotContains(t, manifestJSON, `"target":"POLICY.md"`,
+				"read-only file should not appear in seed manifest")
+			assert.Contains(t, manifestJSON, "SOUL.md",
+				"writable file should appear in seed manifest")
+		})
+
+		t.Run("should mount read-only ConfigMap source as immutable file in workspace", func(t *testing.T) {
+			const wsConfigMapName = "e2e-ro-configmap"
+
+			require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "configmap", wsConfigMapName, "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating workspace source ConfigMap")
+			cmd := exec.Command("kubectl", "create", "configmap", wsConfigMapName,
+				"--from-literal=compliance.md=# Compliance Rules\nThese rules are mandatory.",
+				"-n", userNamespace)
+			_, err := utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to create workspace source ConfigMap")
+
+			t.Log("creating the credential Secret")
+			cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			createLabeledSecret(t, "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value")
+
+			t.Log("applying Claw CR with read-only configMapSource")
+			crFile := filepath.Join("/tmp", "claw-e2e-ro-configmap.yaml")
+			clawYAML := newClawYAML(t,
+				WithGeminiCredentials("gemini-api-key", "api-key"),
+				WithSkipBootstrap(),
+				WithConfigMapSources(v1alpha1.ConfigMapSource{
+					ConfigMapRef: v1alpha1.ConfigMapRef{Name: wsConfigMapName},
+					ReadOnly:     true,
+					Items: []v1alpha1.ConfigMapItem{
+						{Key: "compliance.md", Path: "docs/compliance.md"},
+					},
+				}))
+			err = os.WriteFile(crFile, clawYAML, os.FileMode(0o644))
+			require.NoError(t, err)
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw Ready condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, extendedTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw Ready did not become True")
+
+			t.Log("waiting for gateway pod Running")
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "pods", "-l", "app=claw",
+						"-o", "jsonpath={.items[0].status.phase}", "-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == podPhaseRunning, nil
+				})
+			require.NoError(t, err, "Gateway pod did not reach Running")
+
+			cmd = exec.Command("kubectl", "get", "pods", "-l", "app=claw",
+				"-o", "jsonpath={.items[0].metadata.name}", "-n", userNamespace)
+			podName, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+
+			t.Log("verifying read-only docs/compliance.md has correct content")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "cat", "/home/node/.openclaw/workspace/docs/compliance.md")
+			content, err := utils.Run(t, cmd)
+			require.NoError(t, err, "failed to read docs/compliance.md")
+			assert.Equal(t, "# Compliance Rules\nThese rules are mandatory.",
+				strings.TrimRight(content, "\n"))
+
+			t.Log("verifying docs/compliance.md is NOT writable")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "sh", "-c",
+				"echo 'tampered' > /home/node/.openclaw/workspace/docs/compliance.md 2>&1 || echo 'WRITE_FAILED'")
+			writeOutput, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Contains(t, writeOutput, "WRITE_FAILED",
+				"writing to read-only docs/compliance.md should fail")
+
+			t.Log("verifying content is unchanged after write attempt")
+			cmd = exec.Command("kubectl", "exec", podName, "-c", controller.ClawGatewayContainerName,
+				"-n", userNamespace, "--", "cat", "/home/node/.openclaw/workspace/docs/compliance.md")
+			contentAfter, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "# Compliance Rules\nThese rules are mandatory.",
+				strings.TrimRight(contentAfter, "\n"),
+				"content should remain unchanged after failed write attempt")
+		})
+
+		t.Run("should mount read-only git source as immutable file in workspace", func(t *testing.T) {
+			require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+
+			t.Cleanup(func() {
+				collectDebugInfo(t)
+				cmd := exec.Command("kubectl", "delete", "claw", "instance", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "gemini-api-key", "-n", userNamespace)
+				_, _ = utils.Run(t, cmd)
+				require.NoError(t, waitForPVCDeletion(t), "PVC deletion timed out")
+			})
+
+			t.Log("creating the credential Secret")
+			cmd := exec.Command("kubectl", "delete", "secret", "gemini-api-key",
+				"-n", userNamespace, "--ignore-not-found")
+			_, _ = utils.Run(t, cmd)
+			createLabeledSecret(t, "gemini-api-key",
+				"--from-literal=api-key=test-api-key-value")
+
+			t.Log("applying Claw CR with read-only gitSource")
+			crYAML := `apiVersion: claw.sandbox.redhat.com/v1alpha1
+kind: Claw
+metadata:
+  name: instance
+spec:
+  credentials:
+    - name: gemini
+      provider: google
+      secretRef:
+        - name: gemini-api-key
+          key: api-key
+  workspace:
+    skipBootstrap: true
+    gitSources:
+      - url: https://git.example.com/team/policies.git
+        ref: main
+        readOnly: true
+        items:
+          - repoPath: "policies/guide.md"
+            path: "guide.md"
+`
+			crFile := filepath.Join("/tmp", "claw-e2e-ro-git.yaml")
+			err := os.WriteFile(crFile, []byte(crYAML), os.FileMode(0o644))
+			require.NoError(t, err)
+			cmd = exec.Command("kubectl", "apply", "-f", crFile, "-n", userNamespace)
+			_, err = utils.Run(t, cmd)
+			require.NoError(t, err, "Failed to apply Claw CR")
+
+			t.Log("waiting for Claw ProxyConfigured condition")
+			ctx := context.Background()
+			err = wait.PollUntilContextTimeout(ctx, pollInterval, defaultTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					cmd := exec.Command("kubectl", "get", "claw", "instance",
+						"-o", "jsonpath={.status.conditions[?(@.type=='ProxyConfigured')].status}",
+						"-n", userNamespace)
+					output, err := utils.Run(t, cmd)
+					return err == nil && output == conditionTrue, nil
+				})
+			require.NoError(t, err, "Claw ProxyConfigured did not become True")
+
+			t.Log("verifying gateway deployment has read-only volumeMount for guide.md")
+			// Use a JSONPath filter to find the volumeMount targeting the workspace path
+			allMountsJP := fmt.Sprintf(
+				"jsonpath={.spec.template.spec.containers[?(@.name=='%s')].volumeMounts}",
+				controller.ClawGatewayContainerName)
+			cmd = exec.Command("kubectl", "get", "deployment", clawInstanceName,
+				"-o", allMountsJP, "-n", userNamespace)
+			mountsJSON, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.Contains(t, mountsJSON, "/home/node/.openclaw/workspace/guide.md",
+				"gateway should have a volumeMount at the workspace path for guide.md")
+			assert.Contains(t, mountsJSON, "ws-git-0",
+				"the mount should reference the git emptyDir volume")
+
+			t.Log("verifying seed manifest excludes read-only git entry")
+			cmd = exec.Command("kubectl", "get", "configmap", configMapName,
+				"-o", "jsonpath={.data._seed_manifest\\.json}", "-n", userNamespace)
+			manifestJSON, err := utils.Run(t, cmd)
+			require.NoError(t, err)
+			assert.NotContains(t, manifestJSON, `"target":"guide.md"`,
+				"read-only git file should not appear in seed manifest")
 		})
 	})
 }


### PR DESCRIPTION
Add a `readOnly` boolean field to `InlineSource`, `ConfigMapSource`, and
`GitSource`. When set, items bypass PVC seeding and are mounted directly
into the gateway container's workspace path via Kubernetes read-only
volume mounts, enforcing OS-level EROFS protection.

- `generateSeedManifest()` skips entries from read-only sources
- New `injectReadOnlyWorkspaceMounts()` adds per-item `subPath` mounts
  on the gateway container from existing volumes (`config`, `ws-cm-*`,
  `ws-git-*`)
- Unit tests cover all three source types, mixed read-only/writable
  specs, and correct git source indexing
- Integration tests (envtest) verify deployment volumeMounts and seed
  manifest exclusion after full reconciliation
- E2e tests verify runtime immutability via `kubectl exec` write
  attempts returning EROFS

Assisted-by: Claude Opus 4.6 (1M context)
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-level read-only workspace files for inline, ConfigMap, and Git sources.
  * Read-only files are mounted directly into the gateway workspace and are not writable or deletable at runtime.
  * Mixed read-only and writable sources are supported in the same workspace.
* **Documentation**
  * Updated API/CRD and specs to clarify `mode` is ignored when `readOnly: true`.
* **Tests**
  * Added unit and e2e coverage to verify read-only mounting and seed-manifest exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->