### PR TITLE
chore: lower gateway and proxy default resource requests

### DIFF
--- a/internal/assets/manifests/claw-proxy/proxy-deployment.yaml
+++ b/internal/assets/manifests/claw-proxy/proxy-deployment.yaml
@@ -34,8 +34,8 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: 64Mi
-              cpu: 50m
+              memory: 32Mi
+              cpu: 20m
             limits:
               memory: 256Mi
               cpu: 500m

--- a/internal/assets/manifests/claw/deployment.yaml
+++ b/internal/assets/manifests/claw/deployment.yaml
@@ -213,8 +213,8 @@ spec:
               value: "git@github.com:"
           resources:
             requests:
-              memory: 1Gi
-              cpu: 250m
+              memory: 768Mi
+              cpu: 100m
             limits:
               memory: 4Gi
               cpu: "2"


### PR DESCRIPTION
- gateway: memory request 1Gi -> 768Mi, cpu request 250m -> 100m
- proxy: memory request 64Mi -> 32Mi, cpu request 50m -> 20m
- limits unchanged for both containers

Based on observed idle usage (~640Mi gateway, ~19Mi proxy), with headroom kept above baseline. Lower requests improve pod density across large multi-tenant clusters running many Claw instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized application resource allocation to improve infrastructure efficiency.
  * Reduced baseline memory and CPU requirements for core services while preserving existing functionality and operational settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->