### PR TITLE
fix: raise init-plugins memory limit to 1Gi

### DIFF
--- a/internal/controller/claw_plugins.go
+++ b/internal/controller/claw_plugins.go
@@ -302,7 +302,7 @@ func configurePluginsInitContainer(
 			},
 			"resources": map[string]any{
 				"requests": map[string]any{"memory": "128Mi", "cpu": "100m"},
-				"limits":   map[string]any{"memory": "512Mi", "cpu": "500m"},
+				"limits":   map[string]any{"memory": "1Gi", "cpu": "500m"},
 			},
 			"securityContext": map[string]any{
 				"allowPrivilegeEscalation": false,

--- a/internal/controller/claw_plugins_test.go
+++ b/internal/controller/claw_plugins_test.go
@@ -302,7 +302,7 @@ func TestConfigurePluginsInitContainer(t *testing.T) {
 		assert.Equal(t, "100m", requests["cpu"])
 
 		limits := resources["limits"].(map[string]any)
-		assert.Equal(t, "512Mi", limits["memory"])
+		assert.Equal(t, "1Gi", limits["memory"])
 		assert.Equal(t, "500m", limits["cpu"])
 	})
 


### PR DESCRIPTION
## Summary

The `init-plugins` container runs with a 512Mi memory limit, which is no longer enough. Installing the codex plugin OOMKills the init container, so the pod never reaches the gateway and an upgrade looks like a hang with no error to point at.

This raises the limit to 1Gi. Requests stay at 128Mi, so the container still schedules cheaply and only bursts during the install itself.

Observed on a live instance: `init-plugins` crash-looping with exit 137 after an image upgrade, cleared by the bump.

## Notes for reviewers

#244 lowered the gateway and proxy default *requests*, which is a scheduling-density change. This moves an init container's *limit*, which only bounds a short-lived burst — it doesn't reserve anything and doesn't affect scheduling density, so the two changes point in the same direction rather than against each other.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [ ] Deploy a Claw CR whose credentials pull in a provider plugin — verify `init-plugins` completes instead of exiting 137